### PR TITLE
Add cmdlets for action center information

### DIFF
--- a/XDRInternals/XDRInternals.psd1
+++ b/XDRInternals/XDRInternals.psd1
@@ -63,6 +63,8 @@
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = @(
         "Connect-XdrByEstsCookie",
+        "Get-XdrActionsCenterHistory",
+        "Get-XdrActionsCenterPending",
         "Get-XdrAdvancedHuntingTableSchema",
         "Get-XdrAdvancedHuntingUserHistory",
         "Get-XdrConfigurationAlertServiceSetting",

--- a/XDRInternals/functions/Get-XdrActionsCenterHistory.ps1
+++ b/XDRInternals/functions/Get-XdrActionsCenterHistory.ps1
@@ -1,0 +1,141 @@
+﻿function Get-XdrActionsCenterHistory {
+    <#
+    .SYNOPSIS
+        Retrieves historical actions from the Microsoft Defender XDR Action Center.
+
+    .DESCRIPTION
+        Gets a list of historical actions from the Microsoft Defender XDR Action Center with options to filter by date range, sort, and paginate the results.
+
+    .PARAMETER SortByField
+        The field to sort actions by. Valid values are: InvestigationId, ApprovalId, ActionType, EntityType, Asset, Decision, DecidedBy, ActionSource, Status, ActionUpdateTime. Defaults to 'ActionUpdateTime'.
+
+    .PARAMETER SortOrder
+        The sort order for results. Valid values are 'Ascending' or 'Descending'. Defaults to 'Descending'.
+
+    .PARAMETER PageIndex
+        The page index for pagination. Defaults to 1.
+
+    .PARAMETER PageSize
+        The number of actions to return per page. Defaults to 100.
+
+    .PARAMETER ToDate
+        The end date for the history query. Defaults to current time.
+
+    .PARAMETER FromDate
+        The start date for the history query. Defaults to 6 months before ToDate.
+
+    .PARAMETER UseMtpApi
+        Whether to use the MTP API. Defaults to $true.
+
+    .PARAMETER Months
+        The number of months to look back from the current date. Cannot be used together with FromDate parameter.
+        Defaults to 6 months if neither FromDate nor Months is specified.
+
+    .EXAMPLE
+        Get-XdrActionsCenterHistory
+        Retrieves the last 6 months of action center history with default settings.
+
+    .EXAMPLE
+        Get-XdrActionsCenterHistory -PageSize 50 -PageIndex 2
+        Retrieves the second page of 50 historical actions.
+
+    .EXAMPLE
+        Get-XdrActionsCenterHistory -Months 3
+        Retrieves the last 3 months of action center history.
+
+    .EXAMPLE
+        Get-XdrActionsCenterHistory -FromDate (Get-Date).AddDays(-30) -ToDate (Get-Date)
+        Retrieves the last 30 days of action center history.
+
+    .EXAMPLE
+        Get-XdrActionsCenterHistory -SortByField "ActionUpdateTime" -SortOrder "Ascending"
+        Retrieves actions sorted by action update time in ascending order.
+
+    .OUTPUTS
+        Object
+        Returns the historical actions from the Action Center.
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Months')]
+    param (
+        [Parameter()]
+        [ValidateSet("InvestigationId", "ApprovalId", "ActionType", "EntityType", "Asset", "Decision", "DecidedBy", "ActionSource", "Status", "ActionUpdateTime")]
+        [string]$SortByField = "ActionUpdateTime",
+
+        [Parameter()]
+        [ValidateSet("Ascending", "Descending")]
+        [string]$SortOrder = "Descending",
+
+        [Parameter()]
+        [int]$PageIndex = 1,
+
+        [Parameter()]
+        [int]$PageSize = 100,
+
+        [Parameter()]
+        [datetime]$ToDate = (Get-Date),
+
+        [Parameter(ParameterSetName = 'FromDate')]
+        [datetime]$FromDate,
+
+        [Parameter(ParameterSetName = 'Months')]
+        [int]$Months = 6,
+
+        [Parameter()]
+        [bool]$UseMtpApi = $true
+    )
+
+    begin {
+        Update-XdrConnectionSettings
+    }
+
+    process {
+        # Translate friendly SortByField names to internal field names
+        $sortFieldMap = @{
+            "InvestigationId"  = "investigationId"
+            "ApprovalId"       = "bulkId"
+            "ActionType"       = "actionType"
+            "EntityType"       = "entityType"
+            "Asset"            = "computerName"
+            "Decision"         = "actionDecision"
+            "DecidedBy"        = "decidedBy"
+            "ActionSource"     = "actionSource"
+            "Status"           = "actionStatus"
+            "ActionUpdateTime" = "eventTime"
+        }
+        $internalSortField = $sortFieldMap[$SortByField]
+
+        # Calculate the actual from date based on parameter set
+        if ($PSCmdlet.ParameterSetName -eq 'Months') {
+            $calculatedFromDate = $ToDate.AddMonths(-$Months)
+        } else {
+            $calculatedFromDate = $FromDate
+        }
+
+        # Convert dates to ISO 8601 format with milliseconds
+        $toDateString = $ToDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+        $fromDateString = $calculatedFromDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+
+        # Build the URI with query parameters
+        $queryParams = @(
+            "sortByField=$([System.Uri]::EscapeDataString($internalSortField))"
+            "sortOrder=$([System.Uri]::EscapeDataString($SortOrder))"
+            "type=history"
+            "pageIndex=$PageIndex"
+            "pageSize=$PageSize"
+            "toDate=$([System.Uri]::EscapeDataString($toDateString))"
+            "fromDate=$([System.Uri]::EscapeDataString($fromDateString))"
+            "useMtpApi=$($UseMtpApi.ToString().ToLower())"
+        )
+
+        $Uri = "https://security.microsoft.com/apiproxy/mtp/actionCenter/actioncenterui/history-actions/?$($queryParams -join '&')"
+
+        Write-Verbose "Retrieving XDR Action Center history (From: $fromDateString, To: $toDateString, Page: $PageIndex, Size: $PageSize)"
+        $result = Invoke-RestMethod -Uri $Uri -Method Get -ContentType "application/json" -WebSession $script:session -Headers $script:headers | Select-Object -ExpandProperty Results
+
+        return $result
+    }
+
+    end {
+
+    }
+}

--- a/XDRInternals/functions/Get-XdrActionsCenterPending.ps1
+++ b/XDRInternals/functions/Get-XdrActionsCenterPending.ps1
@@ -1,0 +1,101 @@
+﻿function Get-XdrActionsCenterPending {
+    <#
+    .SYNOPSIS
+        Retrieves pending actions from the Microsoft Defender XDR Action Center.
+
+    .DESCRIPTION
+        Gets a list of pending actions from the Microsoft Defender XDR Action Center with options to sort and paginate the results.
+
+    .PARAMETER SortByField
+        The field to sort actions by. Valid values are: InvestigationId, ApprovalId, ActionType, EntityType, Asset, Decision, DecidedBy, ActionSource, Status, ActionUpdateTime. Defaults to 'ActionUpdateTime'.
+
+    .PARAMETER SortOrder
+        The sort order for results. Valid values are 'Ascending' or 'Descending'. Defaults to 'Descending'.
+
+    .PARAMETER PageIndex
+        The page index for pagination. Defaults to 1.
+
+    .PARAMETER PageSize
+        The number of actions to return per page. Defaults to 100.
+
+    .PARAMETER UseMtpApi
+        Whether to use the MTP API. Defaults to $true.
+
+    .EXAMPLE
+        Get-XdrActionsCenterPending
+        Retrieves pending actions from the Action Center with default settings.
+
+    .EXAMPLE
+        Get-XdrActionsCenterPending -PageSize 50 -PageIndex 2
+        Retrieves the second page of 50 pending actions.
+
+    .EXAMPLE
+        Get-XdrActionsCenterPending -SortByField "ActionUpdateTime" -SortOrder "Ascending"
+        Retrieves pending actions sorted by action update time in ascending order.
+
+    .OUTPUTS
+        Object
+        Returns the pending actions from the Action Center.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [ValidateSet("InvestigationId", "ApprovalId", "ActionType", "EntityType", "Asset", "Decision", "DecidedBy", "ActionSource", "Status", "ActionUpdateTime")]
+        [string]$SortByField = "ActionUpdateTime",
+
+        [Parameter()]
+        [ValidateSet("Ascending", "Descending")]
+        [string]$SortOrder = "Descending",
+
+        [Parameter()]
+        [int]$PageIndex = 1,
+
+        [Parameter()]
+        [int]$PageSize = 100,
+
+        [Parameter()]
+        [bool]$UseMtpApi = $true
+    )
+
+    begin {
+        Update-XdrConnectionSettings
+    }
+
+    process {
+        # Translate friendly SortByField names to internal field names
+        $sortFieldMap = @{
+            "InvestigationId"  = "investigationId"
+            "ApprovalId"       = "bulkId"
+            "ActionType"       = "actionType"
+            "EntityType"       = "entityType"
+            "Asset"            = "computerName"
+            "Decision"         = "actionDecision"
+            "DecidedBy"        = "decidedBy"
+            "ActionSource"     = "actionSource"
+            "Status"           = "actionStatus"
+            "ActionUpdateTime" = "eventTime"
+        }
+        $internalSortField = $sortFieldMap[$SortByField]
+
+        # Build the URI with query parameters
+        $queryParams = @(
+            "sortByField=$([System.Uri]::EscapeDataString($internalSortField))"
+            "sortOrder=$([System.Uri]::EscapeDataString($SortOrder))"
+            "type=pending"
+            "pageIndex=$PageIndex"
+            "pageSize=$PageSize"
+            "useMtpApi=$($UseMtpApi.ToString().ToLower())"
+        )
+
+        $Uri = "https://security.microsoft.com/apiproxy/mtp/actionCenter/actioncenterui/pending-actions/?$($queryParams -join '&')"
+
+        Write-Verbose "Retrieving XDR Action Center pending actions (Page: $PageIndex, Size: $PageSize, Sort: $SortByField $SortOrder)"
+        $result = Invoke-RestMethod -Uri $Uri -Method Get -ContentType "application/json" -WebSession $script:session -Headers $script:headers | Select-Object -ExpandProperty Results
+
+        return $result
+    }
+
+    end {
+
+    }
+}


### PR DESCRIPTION
This pull request adds two new PowerShell cmdlets to the `XDRInternals` module for retrieving Microsoft Defender XDR Action Center data, and updates the module manifest to export these new functions. The main focus is on enabling users to fetch both historical and pending actions with flexible filtering, sorting, and pagination options.

**New Action Center cmdlets:**

* Added `Get-XdrActionsCenterHistory` to retrieve historical actions from the Action Center, supporting date range filtering, sorting by various fields, and pagination. Users can specify a date range explicitly or by number of months, and sort results as needed. (`Get-XdrActionsCenterHistory.ps1`, `XDRInternals.psd1`) [[1]](diffhunk://#diff-bfd9278af852cbef057862df867c3774c83d159569927f02235abbe8e6f79c76R1-R141) [[2]](diffhunk://#diff-615010fe83977d6a200d732fd9cf876594ae9ea248f74b5f9622479e2b65d476R66-R67)
* Added `Get-XdrActionsCenterPending` to retrieve pending (unresolved) actions, with similar sorting and pagination options as the history cmdlet. (`Get-XdrActionsCenterPending.ps1`, `XDRInternals.psd1`) [[1]](diffhunk://#diff-7602a03be5d6c3e635b5bc7de8c70b5963e8343b31099a5015bb1ff0a3a4fcc2R1-R101) [[2]](diffhunk://#diff-615010fe83977d6a200d732fd9cf876594ae9ea248f74b5f9622479e2b65d476R66-R67)

**Module manifest update:**

* Updated `FunctionsToExport` in `XDRInternals.psd1` to include the new cmdlets, making them available when the module is imported.