### PR TITLE
Add Move-XdrAlertToIncident

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Get-XdrTenantContext -Force
 | Invoke-XdrRestMethod                                        | Invoke REST API calls to XDR endpoints                        |
 | Invoke-XdrXspmHuntingQuery                                  | Execute hunting queries against XSPM attack surface API       |
 | Merge-XdrIncident                                           | Merge multiple incidents into a single incident               |
+| Move-XdrAlertToIncident                                     | Move alerts to a specific incident or create a new one        |
 | New-XdrAdvancedHuntingFunction                              | Create new Advanced Hunting functions                         |
 | New-XdrEndpointConfigurationCustomCollectionRule            | Create custom collection rules from YAML files                |
 | New-XdrIdentityConfigurationRemediationActionAccount        | Create new remediation action account configuration           |
@@ -186,6 +187,12 @@ Set-XdrEndpointConfigurationCustomCollectionRule -FilePath "C:\Rules\UpdatedRule
 $rule = Get-XdrEndpointConfigurationCustomCollectionRule | Where-Object { $_.ruleName -eq "My Rule" }
 $rule.isEnabled = $false
 Set-XdrEndpointConfigurationCustomCollectionRule -InputObject $rule
+
+# Move alerts to an existing incident
+Move-XdrAlertToIncident -AlertIds "alert1", "alert2" -TargetIncidentId 12345
+
+# Move alerts to a new incident
+Move-XdrAlertToIncident -AlertIds "alert1"
 
 # Get attack paths from XSPM
 Get-XdrXspmAttackPath -Top 50

--- a/XDRInternals/XDRInternals.psd1
+++ b/XDRInternals/XDRInternals.psd1
@@ -122,6 +122,7 @@
         "Invoke-XdrRestMethod",
         "Invoke-XdrXspmHuntingQuery",
         "Merge-XdrIncident",
+        "Move-XdrAlertToIncident",
         "New-XdrAdvancedHuntingFunction",
         "New-XdrEndpointConfigurationCustomCollectionRule",
         "New-XdrIdentityConfigurationRemediationActionAccount",

--- a/XDRInternals/functions/Move-XdrAlertToIncident.ps1
+++ b/XDRInternals/functions/Move-XdrAlertToIncident.ps1
@@ -1,0 +1,114 @@
+﻿function Move-XdrAlertToIncident {
+    <#
+    .SYNOPSIS
+        Moves alerts to a specific incident or creates a new one.
+
+    .DESCRIPTION
+        Moves one or more alerts to a target incident. If TargetIncidentId is not specified,
+        a new incident is created containing the alerts.
+        Validates that the TargetIncidentId and AlertIds exist before attempting the move.
+
+    .PARAMETER AlertIds
+        A list of alert IDs to move.
+
+    .PARAMETER TargetIncidentId
+        The ID of the incident to move the alerts to. If null or omitted, a new incident is created.
+
+    .PARAMETER Comment
+        Optional comment for the operation. Default is "Moved via XDRInternals".
+    
+    .PARAMETER Confirm
+        Prompts for confirmation before executing the move operation.
+    
+    .PARAMETER WhatIf
+        Shows what would happen if the cmdlet runs.
+
+    .EXAMPLE
+        Move-XdrAlertToIncident -AlertIds "ed638962183442188554_-691007355" -TargetIncidentId 2822
+        Moves the specified alert to incident 2822.
+
+    .EXAMPLE
+        Move-XdrAlertToIncident -AlertIds "ed638962183442188554_-691007355"
+        Moves the specified alert to a new incident.
+    #>
+    [OutputType([PSCustomObject])]
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]$AlertIds,
+
+        [Parameter()]
+        [long]$TargetIncidentId,
+
+        [Parameter()]
+        [string]$Comment = "Moved via XDRInternals"
+    )
+
+    begin {
+        Update-XdrConnectionSettings
+    }
+
+    process {
+        # Validate TargetIncidentId if provided
+        $incidentIdValue = $null
+        if ($PSBoundParameters.ContainsKey('TargetIncidentId') -and $TargetIncidentId -gt 0) {
+            Write-Verbose "Validating TargetIncidentId: $TargetIncidentId"
+            $incidentSearch = Get-XdrIncidentSearch -Term "$TargetIncidentId"
+            
+            # Check if we found an exact match
+            $incidentMatch = $incidentSearch | Where-Object { $_.incidentId -eq $TargetIncidentId }
+            
+            if (-not $incidentMatch) {
+                Write-Error "Target Incident ID '$TargetIncidentId' not found."
+                return
+            }
+            $incidentIdValue = $TargetIncidentId
+        }
+
+        # Validate AlertIds
+        $validAlertIds = @()
+        foreach ($alertId in $AlertIds) {
+            Write-Verbose "Validating AlertId: $alertId"
+            $alertSearch = Get-XdrAlertSearch -SearchTerm $alertId
+            
+            # Check if we found an exact match
+            $alertMatch = $alertSearch | Where-Object { $_.id -eq $alertId }
+
+            if ($alertMatch) {
+                $validAlertIds += $alertId
+            } else {
+                Write-Error "Alert ID '$alertId' not found."
+                return
+            }
+        }
+
+        if ($validAlertIds.Count -eq 0) {
+            return
+        }
+
+        if ($PSCmdlet.ShouldProcess("Alerts: $($validAlertIds -join ', ')", "Move to Incident: $(if ($incidentIdValue) { $incidentIdValue } else { 'New Incident' })")) {
+            
+            $body = @{
+                AlertIds                               = $validAlertIds
+                IncidentId                             = $incidentIdValue
+                Comment                                = $Comment
+                ReturnOkIfAlertAlreadyLinkedToIncident = $true
+                FeedbackContent                        = @{
+                    ClientFalseCorrelationEntities  = @()
+                    ClientFalseCorrelationLinkTypes = @()
+                    ClientNewLinkReasons            = @()
+                }
+            }
+
+            $Uri = "https://security.microsoft.com/apiproxy/mtp/alertsLinks/alerts/incidentLinks?newApi=true"
+            
+            try {
+                $response = Invoke-XdrRestMethod -Uri $Uri -Method POST -Body ($body | ConvertTo-Json -Depth 10) -ErrorAction Stop
+                return $response
+            } catch {
+                Write-Error "Failed to move alerts: $_"
+            }
+        }
+    }
+}

--- a/XDRInternals/internal/functions/Get-XdrAlertSearch.ps1
+++ b/XDRInternals/internal/functions/Get-XdrAlertSearch.ps1
@@ -1,0 +1,50 @@
+﻿function Get-XdrAlertSearch {
+    <#
+    .SYNOPSIS
+        Internal helper function to search for alerts by ID or title.
+
+    .DESCRIPTION
+        Searches for alerts using a search term (ID or title).
+        This is an internal function used for alert validation and lookup.
+
+    .PARAMETER SearchTerm
+        The term to search for (Alert ID or Title).
+
+    .PARAMETER Limit
+        Number of results to return. Default is 10.
+    
+    .EXAMPLE
+        Get-XdrAlertSearch -SearchTerm "ed638962183442188554_-691007355"
+        Searches for alerts matching the specified alert ID.
+
+    .OUTPUTS
+        Object[]
+        Returns an array of alert objects with name and id properties.
+    #>
+    [OutputType([object[]])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SearchTerm,
+
+        [Parameter()]
+        [int]$Limit = 10
+    )
+
+    begin {
+        Update-XdrConnectionSettings
+    }
+
+    process {
+        try {
+            $Uri = "https://security.microsoft.com/apiproxy/mtp/alerts/searchAlertTitlesandId?searchTerm=$([System.Web.HttpUtility]::UrlEncode($SearchTerm))&limit=$Limit"
+
+            $response = Invoke-XdrRestMethod -Uri $Uri -Method GET -ErrorAction Stop
+
+            return $response
+        } catch {
+            Write-Error "Failed to search for alert: $_"
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new capability to move alerts to incidents within the XDRInternals module, along with supporting internal functions and documentation updates. The main focus is on enabling users to associate alerts with existing or new incidents, ensuring proper validation and ease of use.

### New Alert-to-Incident Functionality

* Added the `Move-XdrAlertToIncident` cmdlet, which moves one or more alerts to a specified incident or creates a new incident if no target is provided. The function validates both incident and alert IDs before proceeding, and includes support for confirmation and comments. (`XDRInternals/functions/Move-XdrAlertToIncident.ps1`)

* Introduced the internal helper function `Get-XdrAlertSearch`, used to search and validate alert IDs by querying alert titles or IDs. (`XDRInternals/internal/functions/Get-XdrAlertSearch.ps1`)

### Documentation and Manifest Updates

* Updated the `README.md` to document the new `Move-XdrAlertToIncident` cmdlet, including usage examples for moving alerts to existing or new incidents. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R107) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R191-R196)

* Registered the new cmdlet in the module manifest (`XDRInternals.psd1`) to make it available as part of the public API.