### PR TITLE
Update for Ubuntu

### DIFF
--- a/.github/workflows/build-autoupdate-major.yml
+++ b/.github/workflows/build-autoupdate-major.yml
@@ -10,12 +10,12 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install Prerequisites
         run: ./build/vsts-prerequisites.ps1
-        shell: powershell
+        shell: pwsh
       - name: Validate
         run: ./build/vsts-validate.ps1
-        shell: powershell
+        shell: pwsh
       - name: Build
         run: ./build/vsts-build.ps1 -ApiKey $env:APIKEY -AutoMajorVersion
-        shell: powershell
+        shell: pwsh
         env:
           APIKEY: ${{ secrets.APIKEY }}

--- a/.github/workflows/build-autoupdate-minor.yml
+++ b/.github/workflows/build-autoupdate-minor.yml
@@ -10,12 +10,12 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install Prerequisites
         run: ./build/vsts-prerequisites.ps1
-        shell: powershell
+        shell: pwsh
       - name: Validate
         run: ./build/vsts-validate.ps1
-        shell: powershell
+        shell: pwsh
       - name: Build
         run: ./build/vsts-build.ps1 -ApiKey $env:APIKEY -AutoMinorVersion
-        shell: powershell
+        shell: pwsh
         env:
           APIKEY: ${{ secrets.APIKEY }}


### PR DESCRIPTION
This pull request updates the shell used in the GitHub Actions workflows for both major and minor auto-update build pipelines. The workflows now use `pwsh` (PowerShell Core) instead of the legacy `powershell` shell for running PowerShell scripts, improving compatibility and consistency across environments.

Workflow updates:

* Updated the `build-autoupdate-major.yml` workflow to use `pwsh` for all PowerShell script steps, replacing the previous use of `powershell`.
* Updated the `build-autoupdate-minor.yml` workflow to use `pwsh` for all PowerShell script steps, replacing the previous use of `powershell`.