### PR TITLE
Add workflow_dispatch trigger to build workflow

### DIFF
--- a/.github/workflows/build-autoupdate-build.yml
+++ b/.github/workflows/build-autoupdate-build.yml
@@ -1,5 +1,7 @@
 ﻿name: Build and Auto-Update Build Version
 on:
+  workflow_dispatch:
+
   push:
     branches:
       - main


### PR DESCRIPTION
This pull request introduces a minor update to the GitHub Actions workflow configuration. The change adds support for manually triggering the `Build and Auto-Update Build Version` workflow using the workflow dispatch event.