### PR TITLE
Fix sync-doc generator correctness for helper-first files

### DIFF
--- a/build/Sync-CmdletDocumentation.ps1
+++ b/build/Sync-CmdletDocumentation.ps1
@@ -105,25 +105,54 @@ function Test-IncompleteUri {
 }
 
 # Helper function to extract API parameter mappings from cmdlet content using PowerShell AST
-function Get-ApiParameterMapping {
-    param([string]$Content)
+function Get-CmdletFunctionAst {
+    param(
+        [string]$Content,
+        [string]$ExpectedFunctionName
+    )
 
-    $parameters = @{}
     $tokens = $null
     $parseErrors = $null
     $scriptAst = [System.Management.Automation.Language.Parser]::ParseInput($Content, [ref]$tokens, [ref]$parseErrors)
 
     if ($parseErrors.Count -gt 0) {
-        return $parameters
+        return $null
     }
 
-    $functionAst = @(
+    $functionAsts = @(
         $scriptAst.FindAll({
                 param($node)
                 $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
-            }, $true) |
-            Select-Object -First 1
-    )[0]
+            }, $true)
+    )
+
+    if ($functionAsts.Count -eq 0) {
+        return $null
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($ExpectedFunctionName)) {
+        $expectedFunctionAst = @(
+            $functionAsts |
+                Where-Object { $_.Name -ceq $ExpectedFunctionName } |
+                Select-Object -First 1
+        )[0]
+
+        if ($expectedFunctionAst) {
+            return $expectedFunctionAst
+        }
+    }
+
+    return @($functionAsts | Select-Object -First 1)[0]
+}
+
+function Get-ApiParameterMapping {
+    param(
+        [string]$Content,
+        [string]$ExpectedFunctionName
+    )
+
+    $parameters = @{}
+    $functionAst = Get-CmdletFunctionAst -Content $Content -ExpectedFunctionName $ExpectedFunctionName
 
     if ($null -eq $functionAst) {
         return $parameters
@@ -428,19 +457,19 @@ foreach ($file in $cmdletFiles) {
     Write-Verbose "Processing: $($file.Name)"
     
     $content = Get-Content -Path $file.FullName -Raw
-    $parameters = Get-ApiParameterMapping -Content $content
-    
-    # Extract function name
-    if ($content -match 'function\s+([\w-]+)\s*{') {
-        $cmdletName = $Matches[1]
-    } else {
+    $functionAst = Get-CmdletFunctionAst -Content $content -ExpectedFunctionName $file.BaseName
+
+    if ($null -eq $functionAst) {
         Write-Warning "Could not extract function name from $($file.Name)"
         continue
     }
+
+    $cmdletName = $functionAst.Name
+    $parameters = Get-ApiParameterMapping -Content $content -ExpectedFunctionName $cmdletName
     
     # Extract synopsis
     $synopsis = ""
-    if ($content -match '\.SYNOPSIS\s*\n\s*(.+?)(?=\n\s*\n|\n\s*\.|\z)') {
+    if ($content -match '\.SYNOPSIS\s*\n\s*(.+?)(?=\n\s*(?:\n|\.|#>)|\z)') {
         $synopsis = $Matches[1].Trim()
     }
     

--- a/tests/build/Sync-CmdletDocumentation.Tests.ps1
+++ b/tests/build/Sync-CmdletDocumentation.Tests.ps1
@@ -1,0 +1,197 @@
+﻿Describe 'Sync-CmdletDocumentation' {
+    It 'uses the public cmdlet matching the file name when helper functions come first' {
+        $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+        $sourceScriptPath = Join-Path $repoRoot 'build\Sync-CmdletDocumentation.ps1'
+        $fixtureRoot = Join-Path $TestDrive 'repo'
+        $fixtureBuildPath = Join-Path $fixtureRoot 'build'
+        $fixtureFunctionsPath = Join-Path $fixtureRoot 'XDRInternals\functions'
+        $fixtureManifestPath = Join-Path $fixtureRoot 'XDRInternals\XDRInternals.psd1'
+        $fixtureReadmePath = Join-Path $fixtureRoot 'README.md'
+        $fixtureJsonPath = Join-Path $fixtureRoot 'XDRay\CmdletApiMapping.json'
+        $fixtureFirefoxJsonPath = Join-Path $fixtureRoot 'XDRay Firefox\CmdletApiMapping.json'
+        $fixtureFunctionPath = Join-Path $fixtureFunctionsPath 'Get-TestWidget.ps1'
+
+        $null = New-Item -Path $fixtureBuildPath -ItemType Directory -Force
+        $null = New-Item -Path $fixtureFunctionsPath -ItemType Directory -Force
+        $null = New-Item -Path (Split-Path -Parent $fixtureJsonPath) -ItemType Directory -Force
+        $null = New-Item -Path (Split-Path -Parent $fixtureFirefoxJsonPath) -ItemType Directory -Force
+
+        Copy-Item -Path $sourceScriptPath -Destination (Join-Path $fixtureBuildPath 'Sync-CmdletDocumentation.ps1')
+
+        Set-Content -Path $fixtureReadmePath -Value @'
+## Available Cmdlets
+
+| Cmdlet | Description |
+|--------|-------------|
+| Placeholder | Placeholder |
+
+## Next Section
+'@ -Encoding utf8
+
+        Set-Content -Path $fixtureManifestPath -Value @'
+@{
+    FunctionsToExport = @(
+        "Placeholder"
+    )
+}
+'@ -Encoding utf8
+
+        Set-Content -Path $fixtureJsonPath -Value '[]' -Encoding utf8
+        Set-Content -Path $fixtureFirefoxJsonPath -Value '[]' -Encoding utf8
+
+        Set-Content -Path $fixtureFunctionPath -Value @'
+function ConvertFrom-TestWidgetJson {
+    [CmdletBinding()]
+    param(
+        [string]$Json
+    )
+
+    return $Json
+}
+
+<#
+.SYNOPSIS
+Gets test widgets.
+#>
+function Get-TestWidget {
+    [CmdletBinding()]
+    param(
+        [string]$WidgetId
+    )
+
+    $Uri = "https://security.microsoft.com/api/widgets/$WidgetId"
+    Invoke-RestMethod -Uri $Uri -Method Get
+}
+'@ -Encoding utf8
+
+        & (Join-Path $fixtureBuildPath 'Sync-CmdletDocumentation.ps1')
+
+        $manifestContent = Get-Content -Path $fixtureManifestPath -Raw
+        $apiMappings = Get-Content -Path $fixtureJsonPath -Raw | ConvertFrom-Json
+        $firefoxApiMappings = Get-Content -Path $fixtureFirefoxJsonPath -Raw | ConvertFrom-Json
+        $readmeContent = Get-Content -Path $fixtureReadmePath -Raw
+
+        $manifestContent | Should -Match '"Get-TestWidget"'
+        $manifestContent | Should -Not -Match '"ConvertFrom-TestWidgetJson"'
+        @($apiMappings).Count | Should -Be 1
+        @($firefoxApiMappings).Count | Should -Be 1
+        @($apiMappings)[0].Cmdlet | Should -Be 'Get-TestWidget'
+        @($firefoxApiMappings)[0].Cmdlet | Should -Be 'Get-TestWidget'
+        $readmeContent | Should -Match '\| Get-TestWidget\s+\| Gets test widgets\.'
+    }
+
+        It 'adds a newly introduced cmdlet to generated outputs' {
+                $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+                $sourceScriptPath = Join-Path $repoRoot 'build\Sync-CmdletDocumentation.ps1'
+                $fixtureRoot = Join-Path $TestDrive 'repo'
+                $fixtureBuildPath = Join-Path $fixtureRoot 'build'
+                $fixtureFunctionsPath = Join-Path $fixtureRoot 'XDRInternals\functions'
+                $fixtureManifestPath = Join-Path $fixtureRoot 'XDRInternals\XDRInternals.psd1'
+                $fixtureReadmePath = Join-Path $fixtureRoot 'README.md'
+                $fixtureJsonPath = Join-Path $fixtureRoot 'XDRay\CmdletApiMapping.json'
+                $fixtureFirefoxJsonPath = Join-Path $fixtureRoot 'XDRay Firefox\CmdletApiMapping.json'
+                $existingFunctionPath = Join-Path $fixtureFunctionsPath 'Get-ExistingWidget.ps1'
+                $newFunctionPath = Join-Path $fixtureFunctionsPath 'Get-NewWidget.ps1'
+
+                $null = New-Item -Path $fixtureBuildPath -ItemType Directory -Force
+                $null = New-Item -Path $fixtureFunctionsPath -ItemType Directory -Force
+                $null = New-Item -Path (Split-Path -Parent $fixtureJsonPath) -ItemType Directory -Force
+                $null = New-Item -Path (Split-Path -Parent $fixtureFirefoxJsonPath) -ItemType Directory -Force
+
+                Copy-Item -Path $sourceScriptPath -Destination (Join-Path $fixtureBuildPath 'Sync-CmdletDocumentation.ps1')
+
+                Set-Content -Path $fixtureReadmePath -Value @'
+## Available Cmdlets
+
+| Cmdlet | Description |
+|--------|-------------|
+| Get-ExistingWidget | Gets existing widgets. |
+
+## Next Section
+'@ -Encoding utf8
+
+                Set-Content -Path $fixtureManifestPath -Value @'
+@{
+        FunctionsToExport = @(
+                "Get-ExistingWidget"
+        )
+}
+'@ -Encoding utf8
+
+                Set-Content -Path $fixtureJsonPath -Value @'
+[
+    {
+        "Cmdlet": "Get-ExistingWidget",
+        "ApiUri": "https://security.microsoft.com/api/existingWidgets/{WidgetId}",
+        "Parameters": {
+            "WidgetId": "WidgetId"
+        }
+    }
+]
+'@ -Encoding utf8
+                Set-Content -Path $fixtureFirefoxJsonPath -Value @'
+[
+    {
+        "Cmdlet": "Get-ExistingWidget",
+        "ApiUri": "https://security.microsoft.com/api/existingWidgets/{WidgetId}",
+        "Parameters": {
+            "WidgetId": "WidgetId"
+        }
+    }
+]
+'@ -Encoding utf8
+
+                Set-Content -Path $existingFunctionPath -Value @'
+<#
+.SYNOPSIS
+Gets existing widgets.
+#>
+function Get-ExistingWidget {
+        [CmdletBinding()]
+        param(
+                [string]$WidgetId
+        )
+
+        $Uri = "https://security.microsoft.com/api/existingWidgets/$WidgetId"
+        Invoke-RestMethod -Uri $Uri -Method Get
+}
+'@ -Encoding utf8
+
+                Set-Content -Path $newFunctionPath -Value @'
+<#
+.SYNOPSIS
+Gets new widgets.
+#>
+function Get-NewWidget {
+        [CmdletBinding()]
+        param(
+                [string]$WidgetId
+        )
+
+        $Uri = "https://security.microsoft.com/api/newWidgets/$WidgetId"
+        Invoke-RestMethod -Uri $Uri -Method Get
+}
+'@ -Encoding utf8
+
+                & (Join-Path $fixtureBuildPath 'Sync-CmdletDocumentation.ps1')
+
+                $manifestContent = Get-Content -Path $fixtureManifestPath -Raw
+                $apiMappings = @(Get-Content -Path $fixtureJsonPath -Raw | ConvertFrom-Json)
+                $firefoxApiMappings = @(Get-Content -Path $fixtureFirefoxJsonPath -Raw | ConvertFrom-Json)
+                $readmeContent = Get-Content -Path $fixtureReadmePath -Raw
+
+                $manifestContent | Should -Match '"Get-ExistingWidget"'
+                $manifestContent | Should -Match '"Get-NewWidget"'
+                $readmeContent | Should -Match '\| Get-ExistingWidget\s+\| Gets existing widgets\.'
+                $readmeContent | Should -Match '\| Get-NewWidget\s+\| Gets new widgets\.'
+                $apiMappings.Cmdlet | Should -Contain 'Get-ExistingWidget'
+                $apiMappings.Cmdlet | Should -Contain 'Get-NewWidget'
+                $firefoxApiMappings.Cmdlet | Should -Contain 'Get-ExistingWidget'
+                $firefoxApiMappings.Cmdlet | Should -Contain 'Get-NewWidget'
+
+                @($apiMappings | Where-Object Cmdlet -eq 'Get-NewWidget').Count | Should -Be 1
+                @($firefoxApiMappings | Where-Object Cmdlet -eq 'Get-NewWidget').Count | Should -Be 1
+                @($apiMappings | Where-Object Cmdlet -eq 'Get-NewWidget')[0].ApiUri | Should -Be 'https://security.microsoft.com/api/newWidgets/{WidgetId}'
+                @($firefoxApiMappings | Where-Object Cmdlet -eq 'Get-NewWidget')[0].ApiUri | Should -Be 'https://security.microsoft.com/api/newWidgets/{WidgetId}'
+        }
+}

--- a/tests/pester.ps1
+++ b/tests/pester.ps1
@@ -40,27 +40,33 @@ $config.TestResult.Enabled = $true
 if ($TestGeneral)
 {
 	Write-Host  "Modules imported, proceeding with general tests"
-	foreach ($file in (Get-ChildItem "$PSScriptRoot\general" | Where-Object Name -like "*.Tests.ps1"))
+	foreach ($testDirectory in @('general', 'build'))
 	{
-		if ($file.Name -notlike $Include) { continue }
-		if ($file.Name -like $Exclude) { continue }
+		$testPath = Join-Path $PSScriptRoot $testDirectory
+		if (-not (Test-Path $testPath)) { continue }
 
-		Write-Host  "  Executing $($file.Name)"
-		$config.TestResult.OutputPath = Join-Path "$PSScriptRoot\..\TestResults" "TEST-$($file.BaseName).xml"
-		$config.Run.Path = $file.FullName
-		$config.Run.PassThru = $true
-		$config.Output.Verbosity = $Output
-    	$results = Invoke-Pester -Configuration $config
-		foreach ($result in $results)
+		foreach ($file in (Get-ChildItem $testPath -File | Where-Object Name -like "*.Tests.ps1"))
 		{
-			$totalRun += $result.TotalCount
-			$totalFailed += $result.FailedCount
-			$result.Tests | Where-Object Result -ne 'Passed' | ForEach-Object {
-				$testresults += [pscustomobject]@{
-					Block    = $_.Block
-					Name	 = "It $($_.Name)"
-					Result   = $_.Result
-					Message  = $_.ErrorRecord.DisplayErrorMessage
+			if ($file.Name -notlike $Include) { continue }
+			if ($file.Name -like $Exclude) { continue }
+
+			Write-Host  "  Executing $($file.Name)"
+			$config.TestResult.OutputPath = Join-Path "$PSScriptRoot\..\TestResults" "TEST-$($file.BaseName).xml"
+			$config.Run.Path = $file.FullName
+			$config.Run.PassThru = $true
+			$config.Output.Verbosity = $Output
+    		$results = Invoke-Pester -Configuration $config
+			foreach ($result in $results)
+			{
+				$totalRun += $result.TotalCount
+				$totalFailed += $result.FailedCount
+				$result.Tests | Where-Object Result -ne 'Passed' | ForEach-Object {
+					$testresults += [pscustomobject]@{
+						Block    = $_.Block
+						Name	 = "It $($_.Name)"
+						Result   = $_.Result
+						Message  = $_.ErrorRecord.DisplayErrorMessage
+					}
 				}
 			}
 		}

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -2,9 +2,10 @@
 
 This is the folder, where all the tests go.
 
-Those are subdivided in two categories:
+Those are subdivided in three categories:
 
  - General
+ - Build
  - Function
 
 ## General Tests
@@ -22,6 +23,12 @@ These test scan answer questions such as:
 Basically, these allow a general module health check.
 
 These tests are already provided as part of the template.
+
+## Build Tests
+
+Build tests validate repository tooling and generation workflows, such as scripts that update documentation, manifests, or browser-extension metadata.
+
+These tests help catch correctness regressions in the automation itself before generated changes are committed.
 
 ## Function Tests
 


### PR DESCRIPTION
## Summary
- fix sync-doc generation so each function file is attributed to the public cmdlet matching the file name instead of the first function in the file
- improve synopsis extraction for comment-based help blocks that end directly with `#>`
- add build-time regression coverage for both helper-first files and introducing a brand new cmdlet file
- wire the new `tests/build` slice into the standard Pester harness

## Validation
- `Invoke-Pester -Path .\\tests\\build\\Sync-CmdletDocumentation.Tests.ps1 -Output Detailed`
- `pwsh -NoProfile -File .\\tests\\pester.ps1 -Output None`
- `pwsh -NoProfile -File .\\build\\Sync-CmdletDocumentation.ps1 -WhatIf -Verbose`

## Context
- follow-up to PR #100
- fixes the remaining generator correctness bug that could attribute metadata to an internal helper when a helper function appears before the public cmdlet in a file