### PR TITLE
Polish cmdlet caching and output behavior

### DIFF
--- a/XDRInternals/functions/Get-XdrConfigurationAlertServiceSetting.ps1
+++ b/XDRInternals/functions/Get-XdrConfigurationAlertServiceSetting.ps1
@@ -20,9 +20,10 @@
         Forces a fresh retrieval of the alert service settings, bypassing the cache.
 
     .OUTPUTS
-        Object
+        Object[]
         Returns the alert service settings for each workload with translated names and normalized reasons.
     #>
+    [OutputType([object[]])]
     [CmdletBinding()]
     param (
         [Parameter()]
@@ -55,9 +56,7 @@
         }
 
         # Process the result to translate names and normalize reasons
-        $processedResult = @()
-
-        foreach ($property in $result.PSObject.Properties) {
+        $processedResult = foreach ($property in $result.PSObject.Properties) {
             $workloadName = $property.Name
             $workloadData = $property.Value
 
@@ -86,23 +85,17 @@
             }
 
             # Create processed workload object with Service as a property
-            $processedWorkload = [PSCustomObject]@{
+            [PSCustomObject]@{
                 Service         = $translatedName
                 AlertSetting    = $alertSetting
                 Feedback        = $workloadData.feedback
                 DisabledTime    = $workloadData.disabledTime
                 DisablementType = $workloadData.disablementType
             }
-
-            # Add to result array
-            $processedResult += $processedWorkload
         }
 
+        $processedResult = @($processedResult)
         Set-XdrCache -CacheKey "XdrAlertServiceSettings" -Value $processedResult -TTLMinutes 30
         return $processedResult
-    }
-
-    end {
-
     }
 }

--- a/XDRInternals/functions/Get-XdrConfigurationUnifiedRBACWorkload.ps1
+++ b/XDRInternals/functions/Get-XdrConfigurationUnifiedRBACWorkload.ps1
@@ -55,9 +55,7 @@
         }
 
         # Process the result to flatten workloads and add cloudScopingActivationStatus
-        $processedResult = @()
-
-        foreach ($property in $result.workloads.PSObject.Properties) {
+        $processedResult = foreach ($property in $result.workloads.PSObject.Properties) {
             $workloadName = $property.Name
             $workloadData = $property.Value
 
@@ -92,8 +90,7 @@
                 $processedWorkload | Add-Member -MemberType NoteProperty -Name 'IsExoEnabled' -Value $workloadData.isExoEnabled
             }
 
-            # Add to result array
-            $processedResult += $processedWorkload
+            $processedWorkload
         }
 
         # Add CloudScopingActivationStatus as its own workload entry
@@ -111,13 +108,9 @@
             UiTextKey                         = $null
             CloudScopingActivationStatus      = $result.cloudScopingActivationStatus
         }
-        $processedResult += $cloudScopingWorkload
+        $processedResult = @($processedResult) + $cloudScopingWorkload
 
         Set-XdrCache -CacheKey "XdrUnifiedRBACWorkloadConfiguration" -Value $processedResult -TTLMinutes 30
         return $processedResult
-    }
-
-    end {
-
     }
 }

--- a/XDRInternals/functions/Get-XdrIncident.ps1
+++ b/XDRInternals/functions/Get-XdrIncident.ps1
@@ -194,19 +194,19 @@
                 $body.titleSearchTerms = $TitleSearchTerms
             }
 
-            # Create cache key from parameters
-            $cacheKeyParams = @{
-                LookBackInDays          = $LookBackInDays
-                SortByField             = $SortByField
-                SortOrder               = $SortOrder
-                PageSize                = $PageSize
-                PageIndex               = $currentPageIndex
-                DefenderExpertsLicensed = $DefenderExpertsLicensed.IsPresent
-            }
+            # Create a stable cache key from the actual parameter values so repeated calls can reuse the cache.
+            $cacheKeyParts = @(
+                "LookBackInDays=$LookBackInDays"
+                "SortByField=$SortByField"
+                "SortOrder=$SortOrder"
+                "PageSize=$PageSize"
+                "PageIndex=$currentPageIndex"
+                "DefenderExpertsLicensed=$($DefenderExpertsLicensed.IsPresent)"
+            )
             if ($TitleSearchTerms) {
-                $cacheKeyParams.TitleSearchTerms = $TitleSearchTerms -join ","
+                $cacheKeyParts += "TitleSearchTerms=$($TitleSearchTerms -join ',')"
             }
-            $cacheKey = "XdrIncidents_$($cacheKeyParams.GetHashCode())"
+            $cacheKey = "XdrIncidents_{0}" -f ($cacheKeyParts -join ';')
 
             $currentCacheValue = Get-XdrCache -CacheKey $cacheKey -ErrorAction SilentlyContinue
             if (-not $Force -and $currentCacheValue.NotValidAfter -gt (Get-Date)) {

--- a/XDRInternals/functions/Get-XdrIncident.ps1
+++ b/XDRInternals/functions/Get-XdrIncident.ps1
@@ -194,19 +194,24 @@
                 $body.titleSearchTerms = $TitleSearchTerms
             }
 
-            # Create a stable cache key from the actual parameter values so repeated calls can reuse the cache.
-            $cacheKeyParts = @(
-                "LookBackInDays=$LookBackInDays"
-                "SortByField=$SortByField"
-                "SortOrder=$SortOrder"
-                "PageSize=$PageSize"
-                "PageIndex=$currentPageIndex"
-                "DefenderExpertsLicensed=$($DefenderExpertsLicensed.IsPresent)"
-            )
-            if ($TitleSearchTerms) {
-                $cacheKeyParts += "TitleSearchTerms=$($TitleSearchTerms -join ',')"
+            # Preserve parameter types and array boundaries before hashing so distinct requests cannot share a cache key.
+            $cacheKeyPayload = [ordered]@{
+                LookBackInDays          = $LookBackInDays
+                SortByField             = $SortByField
+                SortOrder               = $SortOrder
+                PageSize                = $PageSize
+                PageIndex               = $currentPageIndex
+                DefenderExpertsLicensed = $DefenderExpertsLicensed.IsPresent
+                TitleSearchTerms        = @($TitleSearchTerms)
+            } | ConvertTo-Json -Compress
+            $sha256 = [System.Security.Cryptography.SHA256]::Create()
+            try {
+                $cacheKeyHash = ($sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($cacheKeyPayload)) |
+                    ForEach-Object { $_.ToString('x2') }) -join ''
+            } finally {
+                $sha256.Dispose()
             }
-            $cacheKey = "XdrIncidents_{0}" -f ($cacheKeyParts -join ';')
+            $cacheKey = "XdrIncidents_$cacheKeyHash"
 
             $currentCacheValue = Get-XdrCache -CacheKey $cacheKey -ErrorAction SilentlyContinue
             if (-not $Force -and $currentCacheValue.NotValidAfter -gt (Get-Date)) {

--- a/XDRInternals/functions/New-XdrAdvancedHuntingFunction.ps1
+++ b/XDRInternals/functions/New-XdrAdvancedHuntingFunction.ps1
@@ -135,14 +135,10 @@
                 $result = Invoke-RestMethod -Uri $Uri -Method Post -ContentType "application/json" -Body $body -WebSession $script:session -Headers $script:headers
 
                 Write-Verbose "Successfully created function with ID: $($result.Id)"
-                Write-Host $result
+                $result
             }
         } catch {
             Write-Error "Failed to create Advanced Hunting function '$Name': $($_.Exception.Message)"
         }
-    }
-
-    end {
-
     }
 }

--- a/XDRInternals/functions/New-XdrEndpointConfigurationCustomCollectionRule.ps1
+++ b/XDRInternals/functions/New-XdrEndpointConfigurationCustomCollectionRule.ps1
@@ -156,16 +156,12 @@
                         Clear-XdrCache -CacheKey "XdrEndpointConfigurationCustomCollectionRule" -ErrorAction SilentlyContinue
 
                         Write-Verbose "Successfully created rule with ID: $($result.ruleId)"
-                        Write-Host $result
+                        $result
                     }
                 } catch {
                     Write-Error "Failed to create custom collection rule from file '$($resolvedPath.Path)': $($_.Exception.Message)"
                 }
             }
         }
-    }
-
-    end {
-
     }
 }

--- a/XDRInternals/functions/New-XdrEndpointDeviceRbacGroup.ps1
+++ b/XDRInternals/functions/New-XdrEndpointDeviceRbacGroup.ps1
@@ -28,7 +28,6 @@
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [Parameter()]
-        [ValidateNotNull()]
         [object]$GroupObject
     )
 

--- a/XDRInternals/functions/New-XdrEndpointDeviceRbacGroup.ps1
+++ b/XDRInternals/functions/New-XdrEndpointDeviceRbacGroup.ps1
@@ -8,7 +8,8 @@
         This function includes caching support with a 30-minute TTL to reduce API calls.
 
     .PARAMETER GroupObject
-        The GroupObject to send. If not provided, uses a default structure.
+        The group object to add to the existing RBAC group collection.
+        This cmdlet does not build a default group object when the parameter is omitted.
 
     .PARAMETER WhatIf
         Shows what would happen if the command runs. The command is not run.
@@ -17,16 +18,8 @@
         Prompts for confirmation before making changes.
 
     .EXAMPLE
-        New-XdrEndpointDeviceRbacGroup
-        Creates a device group in Defender for Endpoint used for RBAC and policies.
-
-    .EXAMPLE
-        New-XdrEndpointDeviceRbacGroup -Body $customBody
+        New-XdrEndpointDeviceRbacGroup -GroupObject $customBody
         Creates a device group in Defender for Endpoint used for RBAC and policies with a custom request body.
-
-    .EXAMPLE
-        New-XdrEndpointDeviceRbacGroup -Force
-        Forces a fresh retrieval, bypassing the cache.
 
     .OUTPUTS
         Object
@@ -35,6 +28,7 @@
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [Parameter()]
+        [ValidateNotNull()]
         [object]$GroupObject
     )
 
@@ -44,12 +38,23 @@
 
     process {
         Write-Verbose "Retrieving New-XdrEndpointDeviceRbacGroup data"
-        $existingGroups = Get-XdrEndpointDeviceRbacGroup -Force
-        if ($existingGroups.count -eq 1) {
-            $GroupObject.Priority = 0
-        } else {
-            $GroupObject.Priority = $existingGroups.Priority[-2] + 1
+        if ($null -eq $GroupObject) {
+            throw "GroupObject is required. This cmdlet does not generate a default group object."
         }
+
+        $existingGroups = @(Get-XdrEndpointDeviceRbacGroup -Force | Where-Object { $null -ne $_ })
+        $groupPriority = if ($existingGroups.Count -le 1) {
+            0
+        } else {
+            $existingGroups.Priority[-2] + 1
+        }
+
+        if ($GroupObject.PSObject.Properties['Priority']) {
+            $GroupObject.Priority = $groupPriority
+        } else {
+            $GroupObject | Add-Member -MemberType NoteProperty -Name Priority -Value $groupPriority -Force
+        }
+
         [array]$newGroups = $existingGroups
         $newGroups += $GroupObject
         if ($PSCmdlet.ShouldProcess("DeviceRbacGroups", "Create")) {

--- a/XDRInternals/functions/New-XdrEndpointDeviceRbacGroup.ps1
+++ b/XDRInternals/functions/New-XdrEndpointDeviceRbacGroup.ps1
@@ -5,10 +5,10 @@
 
     .DESCRIPTION
         Creates a device group in Defender for Endpoint used for RBAC and policies.
-        This function includes caching support with a 30-minute TTL to reduce API calls.
+        After a successful create, this cmdlet refreshes the device-group cache for 30 minutes.
 
     .PARAMETER GroupObject
-        The group object to add to the existing RBAC group collection.
+        Required. The group object to add to the existing RBAC group collection.
         This cmdlet does not build a default group object when the parameter is omitted.
 
     .PARAMETER WhatIf
@@ -22,9 +22,10 @@
         Creates a device group in Defender for Endpoint used for RBAC and policies with a custom request body.
 
     .OUTPUTS
-        Object
-        Returns the API response.
+        Object[]
+        Returns the updated device group collection from the API.
     #>
+    [OutputType([object[]])]
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [Parameter()]
@@ -59,16 +60,14 @@
         if ($PSCmdlet.ShouldProcess("DeviceRbacGroups", "Create")) {
             try {
                 $result = Set-XdrEndpointDeviceRbacGroup -GroupObject $newGroups
+                if ($null -ne $result) {
+                    Set-XdrCache -CacheKey "GetXdrEndpointDeviceRbacGroup" -Value $result -TTLMinutes 30
+                }
             } catch {
                 Write-Error "Failed to update DeviceRbacGroups: $_"
             }
         }
 
-        Set-XdrCache -CacheKey "NewXdrEndpointDeviceRbacGroup" -Value $result -TTLMinutes 30
         return $result
-    }
-
-    end {
-
     }
 }

--- a/XDRInternals/functions/Set-XdrAdvancedHuntingFunction.ps1
+++ b/XDRInternals/functions/Set-XdrAdvancedHuntingFunction.ps1
@@ -174,14 +174,10 @@
                 Clear-XdrCache -CacheKey "XdrAdvancedHuntingFunction" -ErrorAction SilentlyContinue
 
                 Write-Verbose "Successfully updated function with ID: $($result.Id)"
-                Write-Host $result
+                $result
             }
         } catch {
             Write-Error "Failed to update Advanced Hunting function with ID '$Id': $($_.Exception.Message)"
         }
-    }
-
-    end {
-
     }
 }

--- a/XDRInternals/functions/Set-XdrEndpointConfigurationCustomCollectionRule.ps1
+++ b/XDRInternals/functions/Set-XdrEndpointConfigurationCustomCollectionRule.ps1
@@ -188,7 +188,7 @@
                             Clear-XdrCache -CacheKey "XdrEndpointConfigurationCustomCollectionRule" -ErrorAction SilentlyContinue
 
                             Write-Verbose "Successfully updated rule with ID: $($result.ruleId)"
-                            Write-Host $result
+                            $result
                         }
                     } catch {
                         Write-Error "Failed to update custom collection rule from file '$($resolvedPath.Path)': $($_.Exception.Message)"
@@ -255,15 +255,11 @@
                     Clear-XdrCache -CacheKey "XdrEndpointConfigurationCustomCollectionRule" -ErrorAction SilentlyContinue
 
                     Write-Verbose "Successfully updated rule with ID: $($result.ruleId)"
-                    Write-Host $result
+                    $result
                 }
             } catch {
                 Write-Error "Failed to update custom collection rule '$($InputObject.ruleName)': $($_.Exception.Message)"
             }
         }
-    }
-
-    end {
-
     }
 }

--- a/build/vsts-validate.ps1
+++ b/build/vsts-validate.ps1
@@ -1,4 +1,2 @@
 ﻿# Run internal pester tests
-& "$PSScriptRoot\..\tests\pester.ps1" `
-    -Exclude @('CmdletOutputAndCaching.Tests.ps1', 'Xdr.TestHelpers.Tests.ps1') `
-    -ExcludeTag @('Live', 'ReviewRegression')
+& "$PSScriptRoot\..\tests\pester.ps1"

--- a/build/vsts-validate.ps1
+++ b/build/vsts-validate.ps1
@@ -1,4 +1,4 @@
 ﻿# Run internal pester tests
 & "$PSScriptRoot\..\tests\pester.ps1" `
-    -Exclude @('Pr111.Cmdlets.Tests.ps1', 'Xdr.TestHelpers.Tests.ps1') `
+    -Exclude @('CmdletOutputAndCaching.Tests.ps1', 'Xdr.TestHelpers.Tests.ps1') `
     -ExcludeTag @('Live', 'ReviewRegression')

--- a/build/vsts-validate.ps1
+++ b/build/vsts-validate.ps1
@@ -1,2 +1,4 @@
 ﻿# Run internal pester tests
-& "$PSScriptRoot\..\tests\pester.ps1"
+& "$PSScriptRoot\..\tests\pester.ps1" `
+    -Exclude @('Pr111.Cmdlets.Tests.ps1', 'Xdr.TestHelpers.Tests.ps1') `
+    -ExcludeTag @('Live', 'ReviewRegression')

--- a/tests/functions/CmdletOutputAndCaching.Tests.ps1
+++ b/tests/functions/CmdletOutputAndCaching.Tests.ps1
@@ -242,18 +242,30 @@ filters:
         $result | Should -HaveCount 3
         $result[0].SeverityName | Should -Be 'Medium'
         @($result[0].DetectionSourceNames) | Should -Contain 'Email'
-        Should -Invoke Get-XdrCache -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
-            $CacheKey -eq 'XdrIncidents_LookBackInDays=7;SortByField=CreatedDate;SortOrder=Ascending;PageSize=2;PageIndex=1;DefenderExpertsLicensed=False;TitleSearchTerms=malware,phishing'
+        Should -Invoke Get-XdrCache -ModuleName XDRInternals -Times 2 -Exactly -ParameterFilter {
+            $CacheKey -match '^XdrIncidents_[0-9a-f]{64}$'
         }
-        Should -Invoke Get-XdrCache -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
-            $CacheKey -eq 'XdrIncidents_LookBackInDays=7;SortByField=CreatedDate;SortOrder=Ascending;PageSize=2;PageIndex=2;DefenderExpertsLicensed=False;TitleSearchTerms=malware,phishing'
+        Should -Invoke Set-XdrCache -ModuleName XDRInternals -Times 2 -Exactly -ParameterFilter {
+            $CacheKey -match '^XdrIncidents_[0-9a-f]{64}$'
         }
-        Should -Invoke Set-XdrCache -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
-            $CacheKey -eq 'XdrIncidents_LookBackInDays=7;SortByField=CreatedDate;SortOrder=Ascending;PageSize=2;PageIndex=1;DefenderExpertsLicensed=False;TitleSearchTerms=malware,phishing'
-        }
-        Should -Invoke Set-XdrCache -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
-            $CacheKey -eq 'XdrIncidents_LookBackInDays=7;SortByField=CreatedDate;SortOrder=Ascending;PageSize=2;PageIndex=2;DefenderExpertsLicensed=False;TitleSearchTerms=malware,phishing'
-        }
+    }
+
+    It 'keeps ambiguous title search term arrays in separate cache entries' {
+        $observedCacheKeys = [System.Collections.Generic.List[string]]::new()
+        Mock Get-XdrCache { $null } -ModuleName XDRInternals
+        Mock Set-XdrCache {
+            $observedCacheKeys.Add($CacheKey)
+        } -ModuleName XDRInternals
+        Mock Invoke-RestMethod {
+            @([pscustomobject]@{ Severity = 64; DetectionSources = @() })
+        } -ModuleName XDRInternals
+
+        $null = Get-XdrIncident -TitleSearchTerms 'alpha,beta', 'gamma' -PageSize 1
+        $null = Get-XdrIncident -TitleSearchTerms 'alpha', 'beta,gamma' -PageSize 1
+
+        $observedCacheKeys | Should -HaveCount 2
+        $observedCacheKeys[0] | Should -Not -Be $observedCacheKeys[1]
+        $observedCacheKeys | ForEach-Object { $_ | Should -Match '^XdrIncidents_[0-9a-f]{64}$' }
     }
 
     It 'returns flattened unified RBAC workload settings plus cloud scoping status' {

--- a/tests/functions/CmdletOutputAndCaching.Tests.ps1
+++ b/tests/functions/CmdletOutputAndCaching.Tests.ps1
@@ -1,7 +1,7 @@
 ﻿$helperPath = Join-Path $PSScriptRoot '..\helpers\Xdr.TestHelpers.ps1'
 . $helperPath
 
-Describe 'PR 111 cmdlet behavior' -Tag 'Functions', 'PR111', 'ReviewRegression' {
+Describe 'Cmdlet output and caching behavior' -Tag 'Functions', 'Output', 'Caching', 'ReviewRegression' {
     BeforeEach {
         Mock Update-XdrConnectionSettings {} -ModuleName XDRInternals
 

--- a/tests/functions/Pr111.Cmdlets.Tests.ps1
+++ b/tests/functions/Pr111.Cmdlets.Tests.ps1
@@ -1,4 +1,4 @@
-$helperPath = Join-Path $PSScriptRoot '..\helpers\Xdr.TestHelpers.ps1'
+﻿$helperPath = Join-Path $PSScriptRoot '..\helpers\Xdr.TestHelpers.ps1'
 . $helperPath
 
 Describe 'PR 111 cmdlet behavior' -Tag 'Functions', 'PR111' {
@@ -114,6 +114,11 @@ filters:
   conditions: []
 '@ | Set-Content -Path $rulePath -Encoding UTF8
 
+        Mock Get-Command {
+            [pscustomobject]@{ Name = 'ConvertFrom-Yaml' }
+        } -ModuleName XDRInternals -ParameterFilter {
+            $Name -eq 'ConvertFrom-Yaml'
+        }
         Mock Get-XdrTenantContext {
             [pscustomobject]@{
                 AuthInfo = [pscustomobject]@{
@@ -122,6 +127,21 @@ filters:
             }
         } -ModuleName XDRInternals
         Mock Get-XdrEndpointConfigurationCustomCollectionRule { @() } -ModuleName XDRInternals
+        Mock ConvertFrom-Yaml {
+            [ordered]@{
+                name        = 'Pester Smoke Rule'
+                description = 'Validation rule'
+                platform    = 'Windows'
+                scope       = 'Organization'
+                table       = 'DeviceEvents'
+                actionType  = 'RegistryValueSet'
+                filters     = [ordered]@{
+                    conditionType   = 'Operational'
+                    logicalOperator = 'AND'
+                    conditions      = @()
+                }
+            }
+        } -ModuleName XDRInternals
         Mock ConvertTo-ApiFilterFormat { @{ parsed = $true } } -ModuleName XDRInternals
         Mock Invoke-RestMethod {
             [pscustomobject]@{

--- a/tests/functions/Pr111.Cmdlets.Tests.ps1
+++ b/tests/functions/Pr111.Cmdlets.Tests.ps1
@@ -1,0 +1,315 @@
+$helperPath = Join-Path $PSScriptRoot '..\helpers\Xdr.TestHelpers.ps1'
+. $helperPath
+
+Describe 'PR 111 cmdlet behavior' -Tag 'Functions', 'PR111' {
+    BeforeEach {
+        Mock Update-XdrConnectionSettings {} -ModuleName XDRInternals
+
+        InModuleScope XDRInternals {
+            $script:session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            $script:headers = @{}
+        }
+    }
+
+    It 'documents and refreshes the device group cache when creating RBAC groups' {
+        Mock Get-XdrEndpointDeviceRbacGroup {
+            @(
+                [pscustomobject]@{ Name = 'Tier 0'; Priority = 0 }
+                [pscustomobject]@{ Name = 'All devices'; Priority = 999 }
+            )
+        } -ModuleName XDRInternals
+        Mock Set-XdrEndpointDeviceRbacGroup {
+            param($GroupObject)
+            @($GroupObject)
+        } -ModuleName XDRInternals
+        Mock Set-XdrCache {} -ModuleName XDRInternals
+
+        $groupObject = [pscustomobject]@{
+            id           = ''
+            name         = 'Pester Smoke Device Group'
+            description  = 'Validation group'
+            machinesRule = @()
+        }
+
+        $result = @(New-XdrEndpointDeviceRbacGroup -GroupObject $groupObject -Confirm:$false)
+        $helpText = Get-Help New-XdrEndpointDeviceRbacGroup -Full | Out-String
+        $outputTypes = (Get-Command New-XdrEndpointDeviceRbacGroup).OutputType.Type.FullName
+
+        $groupObject.Priority | Should -Be 1
+        $result | Should -HaveCount 3
+        $helpText | Should -Not -Match 'includes caching support'
+        $helpText | Should -Match '(?is)GroupObject.*required'
+        $outputTypes | Should -Contain 'System.Object[]'
+        Should -Invoke Set-XdrEndpointDeviceRbacGroup -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+            @($GroupObject).Count -eq 3 -and
+            $GroupObject[-1].name -eq 'Pester Smoke Device Group' -and
+            $GroupObject[-1].Priority -eq 1
+        }
+        Should -Invoke Set-XdrCache -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+            $CacheKey -eq 'GetXdrEndpointDeviceRbacGroup' -and
+            $TTLMinutes -eq 30 -and
+            @($Value).Count -eq 3
+        }
+    }
+
+    It 'still throws a clear error when GroupObject is omitted' {
+        { New-XdrEndpointDeviceRbacGroup -Confirm:$false } |
+            Should -Throw -ExpectedMessage '*GroupObject is required*'
+    }
+
+    It 'returns the created Advanced Hunting function to the pipeline' {
+        Mock Invoke-RestMethod {
+            [pscustomobject]@{
+                Id   = 42
+                Name = 'PesterSmokeFunction'
+            }
+        } -ModuleName XDRInternals
+
+        $result = New-XdrAdvancedHuntingFunction -Name 'PesterSmokeFunction' -KQLQuery 'DeviceInfo | take 1' -Confirm:$false
+
+        $result.Id | Should -Be 42
+        $result.Name | Should -Be 'PesterSmokeFunction'
+    }
+
+    It 'returns the updated Advanced Hunting function to the pipeline' {
+        Mock Get-XdrAdvancedHuntingFunction {
+            [pscustomobject]@{
+                Id              = 42
+                Name            = 'ExistingFunction'
+                Body            = 'DeviceInfo | take 1'
+                Description     = 'Existing description'
+                IsShared        = $false
+                Path            = ''
+                InputParameters = @()
+            }
+        } -ModuleName XDRInternals
+        Mock Invoke-RestMethod {
+            [pscustomobject]@{
+                Id   = 42
+                Name = 'UpdatedFunction'
+            }
+        } -ModuleName XDRInternals
+        Mock Clear-XdrCache {} -ModuleName XDRInternals
+
+        $result = Set-XdrAdvancedHuntingFunction -Id 42 -Name 'UpdatedFunction' -Confirm:$false
+
+        $result.Name | Should -Be 'UpdatedFunction'
+        Should -Invoke Clear-XdrCache -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+            $CacheKey -eq 'XdrAdvancedHuntingFunction'
+        }
+    }
+
+    It 'returns created custom collection rules to the pipeline' {
+        $rulePath = Join-Path $TestDrive 'custom-collection-rule.yaml'
+        @'
+name: Pester Smoke Rule
+description: Validation rule
+platform: Windows
+scope: Organization
+table: DeviceEvents
+actionType: RegistryValueSet
+filters:
+  conditionType: Operational
+  logicalOperator: AND
+  conditions: []
+'@ | Set-Content -Path $rulePath -Encoding UTF8
+
+        Mock Get-XdrTenantContext {
+            [pscustomobject]@{
+                AuthInfo = [pscustomobject]@{
+                    UserName = 'pester@contoso.com'
+                }
+            }
+        } -ModuleName XDRInternals
+        Mock Get-XdrEndpointConfigurationCustomCollectionRule { @() } -ModuleName XDRInternals
+        Mock ConvertTo-ApiFilterFormat { @{ parsed = $true } } -ModuleName XDRInternals
+        Mock Invoke-RestMethod {
+            [pscustomobject]@{
+                ruleId   = '11111111-1111-1111-1111-111111111111'
+                ruleName = 'Pester Smoke Rule'
+            }
+        } -ModuleName XDRInternals
+        Mock Clear-XdrCache {} -ModuleName XDRInternals
+
+        $result = New-XdrEndpointConfigurationCustomCollectionRule -FilePath $rulePath -Enabled:$true -Confirm:$false
+
+        $result.ruleId | Should -Be '11111111-1111-1111-1111-111111111111'
+        Should -Invoke Clear-XdrCache -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+            $CacheKey -eq 'XdrEndpointConfigurationCustomCollectionRule'
+        }
+    }
+
+    It 'returns updated custom collection rules to the pipeline' {
+        $existingRule = [pscustomobject]@{
+            ruleId              = '22222222-2222-2222-2222-222222222222'
+            ruleName            = 'Existing Rule'
+            ruleDescription     = 'Existing description'
+            isEnabled           = $true
+            platform            = 'Windows'
+            scope               = 'Organization'
+            table               = 'DeviceEvents'
+            actionType          = 'RegistryValueSet'
+            filters             = @{}
+            tags                = @()
+            createdBy           = 'pester@contoso.com'
+            creationDateTimeUtc = '2026-01-01T00:00:00Z'
+            version             = 3
+            updateKey           = 'update-key'
+        }
+        Mock Get-XdrTenantContext {
+            [pscustomobject]@{
+                AuthInfo = [pscustomobject]@{
+                    UserName = 'pester@contoso.com'
+                }
+            }
+        } -ModuleName XDRInternals
+        Mock Get-XdrEndpointConfigurationCustomCollectionRule { @($existingRule) } -ModuleName XDRInternals
+        Mock Invoke-RestMethod {
+            [pscustomobject]@{
+                ruleId   = '22222222-2222-2222-2222-222222222222'
+                ruleName = 'Updated Rule'
+            }
+        } -ModuleName XDRInternals
+        Mock Clear-XdrCache {} -ModuleName XDRInternals
+
+        $inputRule = [pscustomobject]@{
+            ruleId          = '22222222-2222-2222-2222-222222222222'
+            ruleName        = 'Updated Rule'
+            ruleDescription = 'Updated description'
+            isEnabled       = $false
+            platform        = 'Windows'
+            scope           = 'Organization'
+            table           = 'DeviceEvents'
+            actionType      = 'RegistryValueSet'
+            filters         = @{}
+            tags            = @()
+        }
+
+        $result = Set-XdrEndpointConfigurationCustomCollectionRule -InputObject $inputRule -Confirm:$false
+
+        $result.ruleName | Should -Be 'Updated Rule'
+        Should -Invoke Clear-XdrCache -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+            $CacheKey -eq 'XdrEndpointConfigurationCustomCollectionRule'
+        }
+    }
+
+    It 'uses stable cache keys for paged incident retrieval' {
+        Mock Get-XdrCache { $null } -ModuleName XDRInternals
+        Mock Set-XdrCache {} -ModuleName XDRInternals
+        Mock ConvertFrom-XdrDetectionSourceId { 'Email' } -ModuleName XDRInternals
+        Mock Invoke-RestMethod {
+            $request = $Body | ConvertFrom-Json
+            switch ($request.pageIndex) {
+                1 {
+                    @(
+                        [pscustomobject]@{ Severity = 128; DetectionSources = @(1) }
+                        [pscustomobject]@{ Severity = 64; DetectionSources = @() }
+                    )
+                }
+                2 {
+                    @(
+                        [pscustomobject]@{ Severity = 32; DetectionSources = @() }
+                    )
+                }
+                default { @() }
+            }
+        } -ModuleName XDRInternals
+
+        $result = @(Get-XdrIncident -TitleSearchTerms 'malware', 'phishing' -LookBackInDays 7 -SortByField CreatedDate -SortOrder Ascending -PageSize 2 -All)
+
+        $result | Should -HaveCount 3
+        $result[0].SeverityName | Should -Be 'Medium'
+        @($result[0].DetectionSourceNames) | Should -Contain 'Email'
+        Should -Invoke Get-XdrCache -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+            $CacheKey -eq 'XdrIncidents_LookBackInDays=7;SortByField=CreatedDate;SortOrder=Ascending;PageSize=2;PageIndex=1;DefenderExpertsLicensed=False;TitleSearchTerms=malware,phishing'
+        }
+        Should -Invoke Get-XdrCache -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+            $CacheKey -eq 'XdrIncidents_LookBackInDays=7;SortByField=CreatedDate;SortOrder=Ascending;PageSize=2;PageIndex=2;DefenderExpertsLicensed=False;TitleSearchTerms=malware,phishing'
+        }
+        Should -Invoke Set-XdrCache -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+            $CacheKey -eq 'XdrIncidents_LookBackInDays=7;SortByField=CreatedDate;SortOrder=Ascending;PageSize=2;PageIndex=1;DefenderExpertsLicensed=False;TitleSearchTerms=malware,phishing'
+        }
+        Should -Invoke Set-XdrCache -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+            $CacheKey -eq 'XdrIncidents_LookBackInDays=7;SortByField=CreatedDate;SortOrder=Ascending;PageSize=2;PageIndex=2;DefenderExpertsLicensed=False;TitleSearchTerms=malware,phishing'
+        }
+    }
+
+    It 'returns flattened unified RBAC workload settings plus cloud scoping status' {
+        Mock Get-XdrCache { $null } -ModuleName XDRInternals
+        Mock Set-XdrCache {} -ModuleName XDRInternals
+        Mock Invoke-RestMethod {
+            [pscustomobject]@{
+                workloads = [pscustomobject]@{
+                    Aad = [pscustomobject]@{
+                        isWorkloadEligible                = $true
+                        isWorkloadProvisioned             = $true
+                        isUrbacEnabled                    = $true
+                        migrationInfo                     = [pscustomobject]@{
+                            lastImportedDate = '2026-01-01T00:00:00Z'
+                            hasRoles         = $true
+                        }
+                        userAccessLevel                   = 'Admin'
+                        maxAccessLevelForAllUnifiedScopes = 'Admin'
+                        maxAccessLevelIgnoreScopes        = 'Reader'
+                        hasEnablementToggle               = $true
+                        uiTextKey                         = 'aad'
+                    }
+                    Mdo = [pscustomobject]@{
+                        isWorkloadEligible                = $true
+                        isWorkloadProvisioned             = $true
+                        isUrbacEnabled                    = $false
+                        migrationInfo                     = [pscustomobject]@{
+                            lastImportedDate = $null
+                            hasRoles         = $false
+                        }
+                        userAccessLevel                   = 'Reader'
+                        maxAccessLevelForAllUnifiedScopes = 'Reader'
+                        maxAccessLevelIgnoreScopes        = 'Reader'
+                        hasEnablementToggle               = $false
+                        uiTextKey                         = 'mdo'
+                        isExoEnabled                      = $true
+                    }
+                }
+                cloudScopingActivationStatus = 'Enabled'
+            }
+        } -ModuleName XDRInternals
+
+        $result = @(Get-XdrConfigurationUnifiedRBACWorkload)
+        $cloudScoping = $result | Where-Object Workload -eq 'CloudScopingActivationStatus'
+        $mdo = $result | Where-Object Workload -eq 'DefenderForOffice365'
+
+        $result | Should -HaveCount 3
+        ($result | Where-Object Workload -eq 'EntraID').IsUrbacEnabled | Should -BeTrue
+        $mdo.IsExoEnabled | Should -BeTrue
+        $cloudScoping.CloudScopingActivationStatus | Should -Be 'Enabled'
+    }
+
+    It 'returns normalized alert service settings as objects' {
+        Mock Get-XdrCache { $null } -ModuleName XDRInternals
+        Mock Set-XdrCache {} -ModuleName XDRInternals
+        Mock Invoke-RestMethod {
+            [pscustomobject]@{
+                Mdc = [pscustomobject]@{
+                    reasons         = @()
+                    feedback        = 'feedback'
+                    disabledTime    = '2026-01-02T00:00:00Z'
+                    disablementType = 'Manual'
+                }
+                Aad = [pscustomobject]@{
+                    reasons         = @('TenantDisabled')
+                    feedback        = $null
+                    disabledTime    = $null
+                    disablementType = 'Inherited'
+                }
+            }
+        } -ModuleName XDRInternals
+
+        $result = @(Get-XdrConfigurationAlertServiceSetting)
+        $outputTypes = (Get-Command Get-XdrConfigurationAlertServiceSetting).OutputType.Type.FullName
+
+        $result | Should -HaveCount 2
+        ($result | Where-Object Service -eq 'DefenderForCloud').AlertSetting | Should -Be 'MonitorAllAlerts'
+        ($result | Where-Object Service -eq 'EntraID').AlertSetting | Should -Be 'TenantDisabled'
+        $outputTypes | Should -Contain 'System.Object[]'
+    }
+}

--- a/tests/functions/Pr111.Cmdlets.Tests.ps1
+++ b/tests/functions/Pr111.Cmdlets.Tests.ps1
@@ -1,7 +1,7 @@
 ﻿$helperPath = Join-Path $PSScriptRoot '..\helpers\Xdr.TestHelpers.ps1'
 . $helperPath
 
-Describe 'PR 111 cmdlet behavior' -Tag 'Functions', 'PR111' {
+Describe 'PR 111 cmdlet behavior' -Tag 'Functions', 'PR111', 'ReviewRegression' {
     BeforeEach {
         Mock Update-XdrConnectionSettings {} -ModuleName XDRInternals
 
@@ -114,11 +114,6 @@ filters:
   conditions: []
 '@ | Set-Content -Path $rulePath -Encoding UTF8
 
-        Mock Get-Command {
-            [pscustomobject]@{ Name = 'ConvertFrom-Yaml' }
-        } -ModuleName XDRInternals -ParameterFilter {
-            $Name -eq 'ConvertFrom-Yaml'
-        }
         Mock Get-XdrTenantContext {
             [pscustomobject]@{
                 AuthInfo = [pscustomobject]@{
@@ -127,7 +122,18 @@ filters:
             }
         } -ModuleName XDRInternals
         Mock Get-XdrEndpointConfigurationCustomCollectionRule { @() } -ModuleName XDRInternals
-        Mock ConvertFrom-Yaml {
+        Mock ConvertTo-ApiFilterFormat { @{ parsed = $true } } -ModuleName XDRInternals
+        Mock Invoke-RestMethod {
+            [pscustomobject]@{
+                ruleId   = '11111111-1111-1111-1111-111111111111'
+                ruleName = 'Pester Smoke Rule'
+            }
+        } -ModuleName XDRInternals
+        Mock Clear-XdrCache {} -ModuleName XDRInternals
+
+        function global:ConvertFrom-Yaml {
+            param([string]$Yaml)
+
             [ordered]@{
                 name        = 'Pester Smoke Rule'
                 description = 'Validation rule'
@@ -141,17 +147,13 @@ filters:
                     conditions      = @()
                 }
             }
-        } -ModuleName XDRInternals
-        Mock ConvertTo-ApiFilterFormat { @{ parsed = $true } } -ModuleName XDRInternals
-        Mock Invoke-RestMethod {
-            [pscustomobject]@{
-                ruleId   = '11111111-1111-1111-1111-111111111111'
-                ruleName = 'Pester Smoke Rule'
-            }
-        } -ModuleName XDRInternals
-        Mock Clear-XdrCache {} -ModuleName XDRInternals
+        }
 
-        $result = New-XdrEndpointConfigurationCustomCollectionRule -FilePath $rulePath -Enabled:$true -Confirm:$false
+        try {
+            $result = New-XdrEndpointConfigurationCustomCollectionRule -FilePath $rulePath -Enabled:$true -Confirm:$false
+        } finally {
+            Remove-Item Function:\ConvertFrom-Yaml -ErrorAction SilentlyContinue
+        }
 
         $result.ruleId | Should -Be '11111111-1111-1111-1111-111111111111'
         Should -Invoke Clear-XdrCache -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {

--- a/tests/pester.ps1
+++ b/tests/pester.ps1
@@ -2,14 +2,16 @@
 	$TestGeneral = $true,
 	
 	$TestFunctions = $true,
+
+	[string[]]$ExcludeTag = @(),
 	
 	[ValidateSet('None', 'Normal', 'Detailed', 'Diagnostic')]
 	[Alias('Show')]
 	$Output = "None",
 	
-	$Include = "*",
+	[string[]]$Include = @("*"),
 	
-	$Exclude = ""
+	[string[]]$Exclude = @()
 )
 
 Write-Host "Starting Tests"
@@ -35,6 +37,9 @@ $totalRun = 0
 $testresults = @()
 $config = [PesterConfiguration]::Default
 $config.TestResult.Enabled = $true
+if (@($ExcludeTag).Count -gt 0) {
+	$config.Filter.ExcludeTag = @($ExcludeTag)
+}
 
 #region Run General Tests
 if ($TestGeneral)
@@ -47,8 +52,8 @@ if ($TestGeneral)
 
 		foreach ($file in (Get-ChildItem $testPath -File | Where-Object Name -like "*.Tests.ps1"))
 		{
-			if ($file.Name -notlike $Include) { continue }
-			if ($file.Name -like $Exclude) { continue }
+			if (-not (@($Include) | Where-Object { $file.Name -like $_ })) { continue }
+			if (@($Exclude) | Where-Object { $file.Name -like $_ }) { continue }
 
 			Write-Host  "  Executing $($file.Name)"
 			$config.TestResult.OutputPath = Join-Path "$PSScriptRoot\..\TestResults" "TEST-$($file.BaseName).xml"
@@ -82,8 +87,8 @@ if ($TestFunctions)
 	Write-Host "Proceeding with individual tests"
 	foreach ($file in (Get-ChildItem "$PSScriptRoot\functions" -Recurse -File | Where-Object Name -like "*Tests.ps1"))
 	{
-		if ($file.Name -notlike $Include) { continue }
-		if ($file.Name -like $Exclude) { continue }
+		if (-not (@($Include) | Where-Object { $file.Name -like $_ })) { continue }
+		if (@($Exclude) | Where-Object { $file.Name -like $_ }) { continue }
 		
 		Write-Host "  Executing $($file.Name)"
 		$config.TestResult.OutputPath = Join-Path "$PSScriptRoot\..\TestResults" "TEST-$($file.BaseName).xml"


### PR DESCRIPTION
## Summary
- guard `New-XdrEndpointDeviceRbacGroup` so it fails clearly when `-GroupObject` is omitted and handles short existing-group lists safely
- replace the unstable hash-based cache key in `Get-XdrIncident` with a stable parameter-derived key
- return success objects to the pipeline in the touched `New-*` / `Set-*` cmdlets instead of writing them only to the host
- simplify result accumulation in two configuration getters without adding shared helpers
- preserve the explicit RBAC missing-input error message after review feedback

## Validation
- `pwsh .\tests\pester.ps1 -Output None`
- live auth via `Connect-XdrBySoftwarePasskey -KeyFilePath C:\GitHub\.resources\secadmin.passkey`
- live cache validation for:
  - `Get-XdrIncident`
  - `Get-XdrConfigurationAlertServiceSetting`
  - `Get-XdrConfigurationUnifiedRBACWorkload`
- live validation for write paths:
  - `New-XdrAdvancedHuntingFunction` (create temporary object)
  - `Set-XdrAdvancedHuntingFunction` (update temporary object)
  - `Remove-XdrAdvancedHuntingFunction` (cleanup temporary object)
  - `Set-XdrEndpointConfigurationCustomCollectionRule` (update existing disabled/test rule)
  - `New-XdrEndpointDeviceRbacGroup` missing-input error path and `WhatIf`

## Notes
- kept the scope reduction-first and file-local
- did not introduce shared helpers or broader refactors