### PR TITLE
Clarify remediation account help defaults

### DIFF
--- a/XDRInternals/functions/Set-XdrIdentityConfigurationRemediationActionAccount.ps1
+++ b/XDRInternals/functions/Set-XdrIdentityConfigurationRemediationActionAccount.ps1
@@ -9,8 +9,8 @@
         when MDI performs automatic remediation actions on identified threats.
 
     .PARAMETER UseLocalSystem
-        Switch parameter to enable the use of Local System account for remediation actions.
-        If not specified, the configuration is set to use a dedicated remediation account.
+        Boolean parameter that controls whether remediation actions use the Local System account.
+        Defaults to $true. Use -UseLocalSystem:$false to configure a dedicated remediation account.
 
     .PARAMETER Confirm
         Prompts for confirmation before creating each rule.
@@ -23,7 +23,7 @@
         Configures MDI to use the Local System account for remediation actions.
 
     .EXAMPLE
-        Set-XdrIdentityConfigurationRemediationActionAccount
+        Set-XdrIdentityConfigurationRemediationActionAccount -UseLocalSystem:$false
         Configures MDI to use a dedicated account for remediation actions.
 
     .OUTPUTS

--- a/XDRInternals/functions/Set-XdrIdentityConfigurationRemediationActionAccount.ps1
+++ b/XDRInternals/functions/Set-XdrIdentityConfigurationRemediationActionAccount.ps1
@@ -19,7 +19,7 @@
         Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
     .EXAMPLE
-        Set-XdrIdentityConfigurationRemediationActionAccount -UseLocalSystem
+        Set-XdrIdentityConfigurationRemediationActionAccount -UseLocalSystem:$true
         Configures MDI to use the Local System account for remediation actions.
 
     .EXAMPLE

--- a/tests/functions/Set-XdrIdentityConfigurationRemediationActionAccount.Tests.ps1
+++ b/tests/functions/Set-XdrIdentityConfigurationRemediationActionAccount.Tests.ps1
@@ -1,0 +1,43 @@
+$helperPath = Join-Path $PSScriptRoot '..\helpers\Xdr.TestHelpers.ps1'
+. $helperPath
+
+Describe 'Set-XdrIdentityConfigurationRemediationActionAccount' -Tag 'Functions', 'Identity' {
+    BeforeEach {
+        Mock Update-XdrConnectionSettings {} -ModuleName XDRInternals
+        Mock Clear-XdrCache {} -ModuleName XDRInternals
+        Mock Invoke-RestMethod { [pscustomobject]@{ ok = $true } } -ModuleName XDRInternals
+    }
+
+    It 'uses Local System by default when the parameter is omitted' {
+        Set-XdrIdentityConfigurationRemediationActionAccount -Confirm:$false | Out-Null
+
+        Should -Invoke Invoke-RestMethod -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+            $payload = $Body | ConvertFrom-Json
+            $Uri -eq 'https://security.microsoft.com/apiproxy/aatp/api/remediationActions/configuration' -and
+            $Method -eq 'Post' -and
+            $payload.IsRemediationWithLocalSystemEnabled -eq $true
+        }
+    }
+
+    It 'allows switching to a dedicated account explicitly' {
+        Set-XdrIdentityConfigurationRemediationActionAccount -UseLocalSystem:$false -Confirm:$false | Out-Null
+
+        Should -Invoke Invoke-RestMethod -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+            $payload = $Body | ConvertFrom-Json
+            $payload.IsRemediationWithLocalSystemEnabled -eq $false
+        }
+    }
+
+    It 'documents the dedicated-account example with an explicit false value' {
+        $help = Get-Help Set-XdrIdentityConfigurationRemediationActionAccount
+        $exampleCode = ($help.Examples.Example[1].Code -split '\r?\n' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })[0].Trim()
+
+        $help.Parameters.Parameter |
+            Where-Object Name -eq 'UseLocalSystem' |
+            Select-Object -ExpandProperty Description |
+            Select-Object -ExpandProperty Text |
+            Should -Match 'Defaults to \$true'
+
+        $exampleCode | Should -Be 'Set-XdrIdentityConfigurationRemediationActionAccount -UseLocalSystem:$false'
+    }
+}

--- a/tests/functions/Set-XdrIdentityConfigurationRemediationActionAccount.Tests.ps1
+++ b/tests/functions/Set-XdrIdentityConfigurationRemediationActionAccount.Tests.ps1
@@ -28,9 +28,17 @@ Describe 'Set-XdrIdentityConfigurationRemediationActionAccount' -Tag 'Functions'
         }
     }
 
-    It 'documents the dedicated-account example with an explicit false value' {
+    It 'does not call the API when WhatIf is specified' {
+        Set-XdrIdentityConfigurationRemediationActionAccount -WhatIf | Out-Null
+
+        Should -Invoke Invoke-RestMethod -ModuleName XDRInternals -Times 0 -Exactly
+        Should -Invoke Clear-XdrCache -ModuleName XDRInternals -Times 0 -Exactly
+    }
+
+    It 'documents both examples with explicit boolean values' {
         $help = Get-Help Set-XdrIdentityConfigurationRemediationActionAccount
-        $exampleCode = ($help.Examples.Example[1].Code -split '\r?\n' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })[0].Trim()
+        $exampleOneCode = ($help.Examples.Example[0].Code -split '\r?\n' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })[0].Trim()
+        $exampleTwoCode = ($help.Examples.Example[1].Code -split '\r?\n' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })[0].Trim()
 
         $help.Parameters.Parameter |
             Where-Object Name -eq 'UseLocalSystem' |
@@ -38,6 +46,7 @@ Describe 'Set-XdrIdentityConfigurationRemediationActionAccount' -Tag 'Functions'
             Select-Object -ExpandProperty Text |
             Should -Match 'Defaults to \$true'
 
-        $exampleCode | Should -Be 'Set-XdrIdentityConfigurationRemediationActionAccount -UseLocalSystem:$false'
+        $exampleOneCode | Should -Be 'Set-XdrIdentityConfigurationRemediationActionAccount -UseLocalSystem:$true'
+        $exampleTwoCode | Should -Be 'Set-XdrIdentityConfigurationRemediationActionAccount -UseLocalSystem:$false'
     }
 }

--- a/tests/functions/Set-XdrIdentityConfigurationRemediationActionAccount.Tests.ps1
+++ b/tests/functions/Set-XdrIdentityConfigurationRemediationActionAccount.Tests.ps1
@@ -1,4 +1,4 @@
-$helperPath = Join-Path $PSScriptRoot '..\helpers\Xdr.TestHelpers.ps1'
+﻿$helperPath = Join-Path $PSScriptRoot '..\helpers\Xdr.TestHelpers.ps1'
 . $helperPath
 
 Describe 'Set-XdrIdentityConfigurationRemediationActionAccount' -Tag 'Functions', 'Identity' {


### PR DESCRIPTION
## Summary
- correct `Set-XdrIdentityConfigurationRemediationActionAccount` help to match the existing `UseLocalSystem` boolean semantics
- make both help examples explicit with `$true`/`$false`
- add focused regression coverage for the default payload, explicit false payload, and `-WhatIf`/`ShouldProcess`

## Validation
- `pwsh -NoLogo -NoProfile -File .\\tests\\pester.ps1`