### PR TITLE
Add low fidelity enrichment advanced feature

### DIFF
--- a/XDRInternals/functions/Get-XdrEndpointAdvancedFeatures.ps1
+++ b/XDRInternals/functions/Get-XdrEndpointAdvancedFeatures.ps1
@@ -196,6 +196,12 @@
                 ConfigurableInPortal = $true
             }
             [PSCustomObject]@{
+                Name        = "LowFidelityEnrichmentEnabled"
+                Value       = $BasicAdvancedFeatures.LowFidelityEnrichmentEnabled
+                Description = "When turned on, high-fidelity devices that have been enriched with data from low-fidelity sources will display those sources in the device details pane. Low-fidelity source data is soft-merged using hostname-based correlation and is not guaranteed to be a strong identifier."
+                ConfigurableInPortal = $false
+            }
+            [PSCustomObject]@{
                 Name        = "IsolationExclusionRules"
                 Value       = $BasicAdvancedFeatures.IsolationExclusionOptIn
                 Description = "Define specific IP addresses, process paths, or services that remain accessible when a device is isolated, enabling uninterrupted investigations while maintaining device protection."

--- a/XDRInternals/functions/Set-XdrEndpointAdvancedFeatures.ps1
+++ b/XDRInternals/functions/Set-XdrEndpointAdvancedFeatures.ps1
@@ -70,6 +70,9 @@
     .PARAMETER AggregatedReporting
         Enable aggregated reporting.
 
+    .PARAMETER LowFidelityEnrichmentEnabled
+        Low fidelity enrichment enabled.
+
     .PARAMETER IsolationExclusionRules
         Enable isolation exclusion rules.
 
@@ -192,6 +195,9 @@
         [bool]$AggregatedReporting,
 
         [Parameter(ValueFromPipelineByPropertyName)]
+        [bool]$LowFidelityEnrichmentEnabled,
+
+        [Parameter(ValueFromPipelineByPropertyName)]
         [bool]$IsolationExclusionRules,
 
         [Parameter(ValueFromPipelineByPropertyName)]
@@ -240,7 +246,7 @@
             'MicrosoftDefenderForCloudApps', 'AzureInformationProtection', 'TamperProtection',
             'CustomNetworkIndicators', 'WebContentFiltering', 'MicrosoftEndpointDLP',
             'DownloadQuarantinedFiles', 'RestrictCorrelationToWithinScopedDeviceGroups', 'ExcludeDevices',
-            'ActiveIncidentResponse', 'AggregatedReporting', 'IsolationExclusionRules',
+            'ActiveIncidentResponse', 'AggregatedReporting', 'LowFidelityEnrichmentEnabled', 'IsolationExclusionRules',
             'DefaultToStreamlinedConnectivityWhenOnboardingDevicesInDefenderPortal',
             'ApplyStreamlinedConnectivitySettingsToDevicesManagedByIntuneAndDefenderForCloud'
         )
@@ -326,6 +332,9 @@
             }
             if ($PSBoundParameters.ContainsKey('AggregatedReporting')) {
                 $currentConfig.EnableAggregatedReporting = $AggregatedReporting
+            }
+            if ($PSBoundParameters.ContainsKey('LowFidelityEnrichmentEnabled')) {
+                $currentConfig.LowFidelityEnrichmentEnabled = $LowFidelityEnrichmentEnabled
             }
             if ($PSBoundParameters.ContainsKey('IsolationExclusionRules')) {
                 $currentConfig.IsolationExclusionOptIn = $IsolationExclusionRules

--- a/XDRay Firefox/CmdletApiMapping.json
+++ b/XDRay Firefox/CmdletApiMapping.json
@@ -676,6 +676,7 @@
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
     "ApiUri": "https://security.microsoft.com/apiproxy/mtp/settings/SaveAdvancedFeaturesSetting",
     "Parameters": {
+      "LowFidelityEnrichmentEnabled": "body.LowFidelityEnrichmentEnabled",
       "PreviewFeatures": "body.IsOptIn"
     }
   },

--- a/XDRay/CmdletApiMapping.json
+++ b/XDRay/CmdletApiMapping.json
@@ -676,6 +676,7 @@
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
     "ApiUri": "https://security.microsoft.com/apiproxy/mtp/settings/SaveAdvancedFeaturesSetting",
     "Parameters": {
+      "LowFidelityEnrichmentEnabled": "body.LowFidelityEnrichmentEnabled",
       "PreviewFeatures": "body.IsOptIn"
     }
   },


### PR DESCRIPTION
## Summary
- Add LowFidelityEnrichmentEnabled to Get-XdrEndpointAdvancedFeatures output
- Add -LowFidelityEnrichmentEnabled to Set-XdrEndpointAdvancedFeatures and wire it into SaveAdvancedFeaturesSetting
- Update XDRay mappings for the advanced feature payload

## Validation
- PowerShell parser validation passed for changed functions
- JSON mapping validation passed
- pwsh -NoLogo -NoProfile -File tests/pester.ps1 -TestFunctions:$false -Include 'Manifest.Tests.ps1' -Output None passed: 7005 tests, 0 failures