### PR TITLE
Fix cmdlet sync parameter scoping

### DIFF
--- a/XDRay Firefox/CmdletApiMapping.json
+++ b/XDRay Firefox/CmdletApiMapping.json
@@ -648,36 +648,56 @@
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
     "ApiUri": "https://security.microsoft.com/apiproxy/mtp/liveResponseApi/update_properties",
     "Parameters": {
-      "PreviewFeatures": "body.IsOptIn"
+      "LiveResponse": "body.properties.AutomatedIrLiveResponse",
+      "LiveResponseForServers": "body.properties.LiveResponseForServers",
+      "LiveResponseUnsignedScriptExecution": "body.properties.AutomatedIrUnsignedScripts"
     }
   },
   {
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
     "ApiUri": "https://security.microsoft.com/apiproxy/mtp/responseApiPortal/onboarding/intune/deprovision",
     "Parameters": {
-      "PreviewFeatures": "body.IsOptIn"
+      "MicrosoftIntuneConnection": "fixed:false"
     }
   },
   {
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
     "ApiUri": "https://security.microsoft.com/apiproxy/mtp/responseApiPortal/onboarding/intune/provision",
     "Parameters": {
-      "PreviewFeatures": "body.IsOptIn"
+      "MicrosoftIntuneConnection": "fixed:true"
     }
   },
   {
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
-    "ApiUri": "https://security.microsoft.com/apiproxy/mtp/responseApiPortal/senseauth/allownonauthsense",
-    "Parameters": {
-      "PreviewFeatures": "body.IsOptIn"
-    }
+    "ApiUri": "https://security.microsoft.com/apiproxy/mtp/responseApiPortal/senseauth/allownonauthsense"
   },
   {
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
     "ApiUri": "https://security.microsoft.com/apiproxy/mtp/settings/SaveAdvancedFeaturesSetting",
     "Parameters": {
+      "ActiveIncidentResponse": "body.DartDataCollection",
+      "AggregatedReporting": "body.EnableAggregatedReporting",
+      "AllowOrBlockFile": "body.BlockListEnabled",
+      "ApplyStreamlinedConnectivitySettingsToDevicesManagedByIntuneAndDefenderForCloud": "body.UseSimplifiedConnectivityViaApi",
+      "AutomaticallyResolveAlerts": "body.AutoResolveInvestigatedAlerts",
+      "AzureInformationProtection": "body.EnableAipIntegration",
+      "CustomNetworkIndicators": "body.AllowWdavNetworkBlock",
+      "DefaultToStreamlinedConnectivityWhenOnboardingDevicesInDefenderPortal": "body.UseSimplifiedConnectivity",
+      "DownloadQuarantinedFiles": "body.EnableQuarantinedFileDownload",
+      "EnableEDRInBlockMode": "body.EnableWdavPassiveModeRemediation",
+      "EnableMicrosoftDefenderAntivirusInAuditMode": "body.EnableWdavAuditMode",
+      "ExcludeDevices": "body.EnableExcludedDevices",
+      "HidePotentialDuplicateDeviceRecords": "body.HidePotentialDuplications",
+      "IsolationExclusionRules": "body.IsolationExclusionOptIn",
       "LowFidelityEnrichmentEnabled": "body.LowFidelityEnrichmentEnabled",
-      "PreviewFeatures": "body.IsOptIn"
+      "MicrosoftDefenderForCloudApps": "body.EnableMcasIntegration",
+      "MicrosoftDefenderForIdentityIntegration": "body.AatpIntegrationEnabled",
+      "MicrosoftEndpointDLP": "body.EnableEndpointDlp",
+      "RestrictCorrelationToWithinScopedDeviceGroups": "body.IsolateIncidentsWithDifferentDeviceGroups",
+      "ShowUserDetails": "body.ShowUserAadProfile",
+      "SkypeForBusinessIntegration": "body.SkypeIntegrationEnabled",
+      "TamperProtection": "body.EnableWdavAntiTampering",
+      "WebContentFiltering": "body.WebCategoriesEnabled"
     }
   },
   {
@@ -691,7 +711,7 @@
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
     "ApiUri": "https://security.microsoft.com/apiproxy/mtp/wdatpInternalApi/compliance/alertSharing/status/",
     "Parameters": {
-      "PreviewFeatures": "body.IsOptIn"
+      "PurviewSharing": "body"
     }
   },
   {

--- a/XDRay/CmdletApiMapping.json
+++ b/XDRay/CmdletApiMapping.json
@@ -648,36 +648,56 @@
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
     "ApiUri": "https://security.microsoft.com/apiproxy/mtp/liveResponseApi/update_properties",
     "Parameters": {
-      "PreviewFeatures": "body.IsOptIn"
+      "LiveResponse": "body.properties.AutomatedIrLiveResponse",
+      "LiveResponseForServers": "body.properties.LiveResponseForServers",
+      "LiveResponseUnsignedScriptExecution": "body.properties.AutomatedIrUnsignedScripts"
     }
   },
   {
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
     "ApiUri": "https://security.microsoft.com/apiproxy/mtp/responseApiPortal/onboarding/intune/deprovision",
     "Parameters": {
-      "PreviewFeatures": "body.IsOptIn"
+      "MicrosoftIntuneConnection": "fixed:false"
     }
   },
   {
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
     "ApiUri": "https://security.microsoft.com/apiproxy/mtp/responseApiPortal/onboarding/intune/provision",
     "Parameters": {
-      "PreviewFeatures": "body.IsOptIn"
+      "MicrosoftIntuneConnection": "fixed:true"
     }
   },
   {
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
-    "ApiUri": "https://security.microsoft.com/apiproxy/mtp/responseApiPortal/senseauth/allownonauthsense",
-    "Parameters": {
-      "PreviewFeatures": "body.IsOptIn"
-    }
+    "ApiUri": "https://security.microsoft.com/apiproxy/mtp/responseApiPortal/senseauth/allownonauthsense"
   },
   {
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
     "ApiUri": "https://security.microsoft.com/apiproxy/mtp/settings/SaveAdvancedFeaturesSetting",
     "Parameters": {
+      "ActiveIncidentResponse": "body.DartDataCollection",
+      "AggregatedReporting": "body.EnableAggregatedReporting",
+      "AllowOrBlockFile": "body.BlockListEnabled",
+      "ApplyStreamlinedConnectivitySettingsToDevicesManagedByIntuneAndDefenderForCloud": "body.UseSimplifiedConnectivityViaApi",
+      "AutomaticallyResolveAlerts": "body.AutoResolveInvestigatedAlerts",
+      "AzureInformationProtection": "body.EnableAipIntegration",
+      "CustomNetworkIndicators": "body.AllowWdavNetworkBlock",
+      "DefaultToStreamlinedConnectivityWhenOnboardingDevicesInDefenderPortal": "body.UseSimplifiedConnectivity",
+      "DownloadQuarantinedFiles": "body.EnableQuarantinedFileDownload",
+      "EnableEDRInBlockMode": "body.EnableWdavPassiveModeRemediation",
+      "EnableMicrosoftDefenderAntivirusInAuditMode": "body.EnableWdavAuditMode",
+      "ExcludeDevices": "body.EnableExcludedDevices",
+      "HidePotentialDuplicateDeviceRecords": "body.HidePotentialDuplications",
+      "IsolationExclusionRules": "body.IsolationExclusionOptIn",
       "LowFidelityEnrichmentEnabled": "body.LowFidelityEnrichmentEnabled",
-      "PreviewFeatures": "body.IsOptIn"
+      "MicrosoftDefenderForCloudApps": "body.EnableMcasIntegration",
+      "MicrosoftDefenderForIdentityIntegration": "body.AatpIntegrationEnabled",
+      "MicrosoftEndpointDLP": "body.EnableEndpointDlp",
+      "RestrictCorrelationToWithinScopedDeviceGroups": "body.IsolateIncidentsWithDifferentDeviceGroups",
+      "ShowUserDetails": "body.ShowUserAadProfile",
+      "SkypeForBusinessIntegration": "body.SkypeIntegrationEnabled",
+      "TamperProtection": "body.EnableWdavAntiTampering",
+      "WebContentFiltering": "body.WebCategoriesEnabled"
     }
   },
   {
@@ -691,7 +711,7 @@
     "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
     "ApiUri": "https://security.microsoft.com/apiproxy/mtp/wdatpInternalApi/compliance/alertSharing/status/",
     "Parameters": {
-      "PreviewFeatures": "body.IsOptIn"
+      "PurviewSharing": "body"
     }
   },
   {

--- a/build/Sync-CmdletDocumentation.ps1
+++ b/build/Sync-CmdletDocumentation.ps1
@@ -397,7 +397,8 @@ function Get-ScopedApiParameterMapping {
     param(
         [string]$CmdletName,
         [string]$Uri,
-        [hashtable]$DefaultParameters
+        [hashtable]$DefaultParameters,
+        [string[]]$AvailableParameters
     )
 
     $scopedParameters = @{}
@@ -410,6 +411,75 @@ function Get-ScopedApiParameterMapping {
     # deanonymization body parameters off the other discovery endpoints.
     if ($CmdletName -eq 'Get-XdrCloudAppsDiscovery' -and $Uri -notmatch '/deanonymize_entity_names/$') {
         return @{}
+    }
+
+    # Set-XdrEndpointAdvancedFeatures sends different parameters to seven APIs.
+    # The general extractor builds one map for the whole function, so scope this
+    # multi-endpoint cmdlet explicitly instead of applying PreviewFeatures to every URI.
+    if ($CmdletName -eq 'Set-XdrEndpointAdvancedFeatures') {
+        $endpointParameters = switch -Regex ($Uri) {
+            '/settings/SaveAdvancedFeaturesSetting$' {
+                @{
+                    ActiveIncidentResponse = 'body.DartDataCollection'
+                    AggregatedReporting = 'body.EnableAggregatedReporting'
+                    AllowOrBlockFile = 'body.BlockListEnabled'
+                    ApplyStreamlinedConnectivitySettingsToDevicesManagedByIntuneAndDefenderForCloud = 'body.UseSimplifiedConnectivityViaApi'
+                    AutomaticallyResolveAlerts = 'body.AutoResolveInvestigatedAlerts'
+                    AzureInformationProtection = 'body.EnableAipIntegration'
+                    CustomNetworkIndicators = 'body.AllowWdavNetworkBlock'
+                    DefaultToStreamlinedConnectivityWhenOnboardingDevicesInDefenderPortal = 'body.UseSimplifiedConnectivity'
+                    DownloadQuarantinedFiles = 'body.EnableQuarantinedFileDownload'
+                    EnableEDRInBlockMode = 'body.EnableWdavPassiveModeRemediation'
+                    EnableMicrosoftDefenderAntivirusInAuditMode = 'body.EnableWdavAuditMode'
+                    ExcludeDevices = 'body.EnableExcludedDevices'
+                    HidePotentialDuplicateDeviceRecords = 'body.HidePotentialDuplications'
+                    IsolationExclusionRules = 'body.IsolationExclusionOptIn'
+                    LowFidelityEnrichmentEnabled = 'body.LowFidelityEnrichmentEnabled'
+                    MicrosoftDefenderForCloudApps = 'body.EnableMcasIntegration'
+                    MicrosoftDefenderForIdentityIntegration = 'body.AatpIntegrationEnabled'
+                    MicrosoftEndpointDLP = 'body.EnableEndpointDlp'
+                    RestrictCorrelationToWithinScopedDeviceGroups = 'body.IsolateIncidentsWithDifferentDeviceGroups'
+                    ShowUserDetails = 'body.ShowUserAadProfile'
+                    SkypeForBusinessIntegration = 'body.SkypeIntegrationEnabled'
+                    TamperProtection = 'body.EnableWdavAntiTampering'
+                    WebContentFiltering = 'body.WebCategoriesEnabled'
+                }
+                break
+            }
+            '/liveResponseApi/update_properties$' {
+                @{
+                    LiveResponse = 'body.properties.AutomatedIrLiveResponse'
+                    LiveResponseForServers = 'body.properties.LiveResponseForServers'
+                    LiveResponseUnsignedScriptExecution = 'body.properties.AutomatedIrUnsignedScripts'
+                }
+                break
+            }
+            '/settings/SavePreviewExperienceSetting$' {
+                @{ PreviewFeatures = 'body.IsOptIn' }
+                break
+            }
+            '/wdatpInternalApi/compliance/alertSharing/status/$' {
+                @{ PurviewSharing = 'body' }
+                break
+            }
+            '/responseApiPortal/onboarding/intune/provision$' {
+                @{ MicrosoftIntuneConnection = 'fixed:true' }
+                break
+            }
+            '/responseApiPortal/onboarding/intune/deprovision$' {
+                @{ MicrosoftIntuneConnection = 'fixed:false' }
+                break
+            }
+            default { @{} }
+        }
+
+        $scopedParameters = @{}
+        foreach ($parameterName in $endpointParameters.Keys) {
+            if ($AvailableParameters -contains $parameterName) {
+                $scopedParameters[$parameterName] = $endpointParameters[$parameterName]
+            }
+        }
+        return $scopedParameters
     }
 
     return $scopedParameters
@@ -466,6 +536,7 @@ foreach ($file in $cmdletFiles) {
 
     $cmdletName = $functionAst.Name
     $parameters = Get-ApiParameterMapping -Content $content -ExpectedFunctionName $cmdletName
+    $availableParameters = @($functionAst.Body.ParamBlock.Parameters.Name.VariablePath.UserPath)
     
     # Extract synopsis
     $synopsis = ""
@@ -493,7 +564,7 @@ foreach ($file in $cmdletFiles) {
         }
         
         # Create mapping object
-        $mappingParameters = Get-ScopedApiParameterMapping -CmdletName $cmdletName -Uri $uri -DefaultParameters $parameters
+        $mappingParameters = Get-ScopedApiParameterMapping -CmdletName $cmdletName -Uri $uri -DefaultParameters $parameters -AvailableParameters $availableParameters
         $mapping = ConvertTo-ApiMapping -CmdletName $cmdletName -Uri $uri -Parameters $mappingParameters
         
         # Only add unique URIs for this cmdlet
@@ -519,7 +590,7 @@ foreach ($file in $cmdletFiles) {
         }
         
         # Create mapping object
-        $mappingParameters = Get-ScopedApiParameterMapping -CmdletName $cmdletName -Uri $uri -DefaultParameters $parameters
+        $mappingParameters = Get-ScopedApiParameterMapping -CmdletName $cmdletName -Uri $uri -DefaultParameters $parameters -AvailableParameters $availableParameters
         $mapping = ConvertTo-ApiMapping -CmdletName $cmdletName -Uri $uri -Parameters $mappingParameters
         
         # Only add unique URIs for this cmdlet
@@ -699,7 +770,7 @@ Write-Verbose "First 5 cmdlets in sorted array: $($apiMappingArray[0..4].Cmdlet 
 Write-Verbose "API mappings: $($apiMappingArray.Count) total ($newCount new, $updatedCount updated, $deletedCount removed)"
 
 # Convert to JSON with proper formatting
-$jsonContent = $apiMappingArray | ConvertTo-Json -Depth 10
+$jsonContent = ($apiMappingArray | ConvertTo-Json -Depth 10) + [Environment]::NewLine
 
 # Update XDRay/CmdletApiMapping.json
 if ($PSCmdlet.ShouldProcess($jsonPath, "Update API mappings")) {

--- a/tests/build/Sync-CmdletDocumentation.Tests.ps1
+++ b/tests/build/Sync-CmdletDocumentation.Tests.ps1
@@ -194,4 +194,106 @@ function Get-NewWidget {
                 @($apiMappings | Where-Object Cmdlet -eq 'Get-NewWidget')[0].ApiUri | Should -Be 'https://security.microsoft.com/api/newWidgets/{WidgetId}'
                 @($firefoxApiMappings | Where-Object Cmdlet -eq 'Get-NewWidget')[0].ApiUri | Should -Be 'https://security.microsoft.com/api/newWidgets/{WidgetId}'
         }
+
+        It 'scopes endpoint advanced feature parameters to their API request' {
+                $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+                $sourceScriptPath = Join-Path $repoRoot 'build\Sync-CmdletDocumentation.ps1'
+                $fixtureRoot = Join-Path $TestDrive 'endpoint-advanced-features'
+                $fixtureBuildPath = Join-Path $fixtureRoot 'build'
+                $fixtureFunctionsPath = Join-Path $fixtureRoot 'XDRInternals\functions'
+                $fixtureManifestPath = Join-Path $fixtureRoot 'XDRInternals\XDRInternals.psd1'
+                $fixtureReadmePath = Join-Path $fixtureRoot 'README.md'
+                $fixtureJsonPath = Join-Path $fixtureRoot 'XDRay\CmdletApiMapping.json'
+                $fixtureFirefoxJsonPath = Join-Path $fixtureRoot 'XDRay Firefox\CmdletApiMapping.json'
+                $fixtureFunctionPath = Join-Path $fixtureFunctionsPath 'Set-XdrEndpointAdvancedFeatures.ps1'
+
+                $null = New-Item -Path $fixtureBuildPath -ItemType Directory -Force
+                $null = New-Item -Path $fixtureFunctionsPath -ItemType Directory -Force
+                $null = New-Item -Path (Split-Path -Parent $fixtureJsonPath) -ItemType Directory -Force
+                $null = New-Item -Path (Split-Path -Parent $fixtureFirefoxJsonPath) -ItemType Directory -Force
+
+                Copy-Item -Path $sourceScriptPath -Destination (Join-Path $fixtureBuildPath 'Sync-CmdletDocumentation.ps1')
+
+                Set-Content -Path $fixtureReadmePath -Value @'
+## Available Cmdlets
+
+| Cmdlet | Description |
+|--------|-------------|
+| Placeholder | Placeholder |
+
+## Next Section
+'@ -Encoding utf8
+
+                Set-Content -Path $fixtureManifestPath -Value @'
+@{
+        FunctionsToExport = @(
+                "Placeholder"
+        )
+}
+'@ -Encoding utf8
+
+                $staleMappings = @'
+[
+  {
+    "Cmdlet": "Set-XdrEndpointAdvancedFeatures",
+    "ApiUri": "https://security.microsoft.com/apiproxy/mtp/settings/SaveAdvancedFeaturesSetting",
+    "Parameters": {
+      "LowFidelityEnrichmentEnabled": "body.LowFidelityEnrichmentEnabled",
+      "PreviewFeatures": "body.IsOptIn"
+    }
+  }
+]
+'@
+                Set-Content -Path $fixtureJsonPath -Value $staleMappings -Encoding utf8
+                Set-Content -Path $fixtureFirefoxJsonPath -Value $staleMappings -Encoding utf8
+
+                Set-Content -Path $fixtureFunctionPath -Value @'
+<#
+.SYNOPSIS
+Sets endpoint advanced features.
+#>
+function Set-XdrEndpointAdvancedFeatures {
+        [CmdletBinding()]
+        param(
+                [bool]$LowFidelityEnrichmentEnabled,
+                [bool]$LiveResponse,
+                [bool]$PreviewFeatures,
+                [bool]$PurviewSharing,
+                [bool]$MicrosoftIntuneConnection,
+                [bool]$AuthenticatedTelemetry
+        )
+
+        $uri = "https://security.microsoft.com/apiproxy/mtp/settings/SaveAdvancedFeaturesSetting"
+        $uri = "https://security.microsoft.com/apiproxy/mtp/liveResponseApi/update_properties?useV2Api=true"
+        $uri = "https://security.microsoft.com/apiproxy/mtp/settings/SavePreviewExperienceSetting?context=MdatpContext"
+        $uri = "https://security.microsoft.com/apiproxy/mtp/wdatpInternalApi/compliance/alertSharing/status/"
+        $uri = "https://security.microsoft.com/apiproxy/mtp/responseApiPortal/onboarding/intune/provision"
+        $uri = "https://security.microsoft.com/apiproxy/mtp/responseApiPortal/onboarding/intune/deprovision"
+        $uri = "https://security.microsoft.com/apiproxy/mtp/responseApiPortal/senseauth/allownonauthsense"
+        $body = @{ IsOptIn = $PreviewFeatures }
+}
+'@ -Encoding utf8
+
+                & (Join-Path $fixtureBuildPath 'Sync-CmdletDocumentation.ps1')
+
+                $apiMappings = @(Get-Content -Path $fixtureJsonPath -Raw | ConvertFrom-Json)
+                $advanced = $apiMappings | Where-Object ApiUri -Like '*/SaveAdvancedFeaturesSetting'
+                $liveResponse = $apiMappings | Where-Object ApiUri -Like '*/liveResponseApi/update_properties'
+                $preview = $apiMappings | Where-Object ApiUri -Like '*/SavePreviewExperienceSetting'
+                $purview = $apiMappings | Where-Object ApiUri -Like '*/alertSharing/status/'
+                $intuneProvision = $apiMappings | Where-Object ApiUri -Like '*/intune/provision'
+                $intuneDeprovision = $apiMappings | Where-Object ApiUri -Like '*/intune/deprovision'
+                $authenticatedTelemetry = $apiMappings | Where-Object ApiUri -Like '*/senseauth/allownonauthsense'
+
+                @($advanced.Parameters.PSObject.Properties.Name) | Should -Be @('LowFidelityEnrichmentEnabled')
+                $advanced.Parameters.LowFidelityEnrichmentEnabled | Should -Be 'body.LowFidelityEnrichmentEnabled'
+                @($liveResponse.Parameters.PSObject.Properties.Name) | Should -Be @('LiveResponse')
+                $preview.Parameters.PreviewFeatures | Should -Be 'body.IsOptIn'
+                $purview.Parameters.PurviewSharing | Should -Be 'body'
+                $intuneProvision.Parameters.MicrosoftIntuneConnection | Should -Be 'fixed:true'
+                $intuneDeprovision.Parameters.MicrosoftIntuneConnection | Should -Be 'fixed:false'
+                $authenticatedTelemetry.Parameters | Should -BeNullOrEmpty
+                (Get-Content -Path $fixtureJsonPath -Raw).EndsWith([Environment]::NewLine) | Should -BeTrue
+                (Get-Content -Path $fixtureFirefoxJsonPath -Raw).EndsWith([Environment]::NewLine) | Should -BeTrue
+        }
 }


### PR DESCRIPTION
## Summary

- scope `Set-XdrEndpointAdvancedFeatures` parameter mappings to the API request that actually sends them
- preserve `LowFidelityEnrichmentEnabled` and add the other safely reconstructable endpoint mappings
- remove the incorrect `PreviewFeatures` mapping from unrelated endpoints
- preserve the final newline in generated mapping JSON
- add regression coverage for the multi-endpoint cmdlet and stale mapping state

## Root cause

The sync generator extracts one parameter map for an entire function. `Set-XdrEndpointAdvancedFeatures` calls seven APIs, so the directly constructed preview-feature body was applied to all seven mappings. Generated mappings then replaced the cached entry for the same cmdlet and URI, which removed the manually added `LowFidelityEnrichmentEnabled` mapping in #121 (and previously in #114).

This change uses the generator's existing endpoint-scoping layer for this known multi-operation cmdlet and filters the scoped mappings against the cmdlet's current parameters. Inverted values that the XDRay mapping format cannot safely reconstruct are intentionally left unmapped.

Supersedes the generated changes in #121.

## Validation

- full repository suite: 19,727 tests passed
- sync generator regression: 3 tests passed
- PSScriptAnalyzer: no warnings or errors
- repeated sync run produces no further changes
- Chrome and Firefox mapping files are byte-identical
