### PR TITLE
Add resumable large endpoint timeline export

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,54 @@ Get-XdrCloudAppsGovernance
 Get-XdrCloudAppsPolicy -Type OAuth -Metadata
 ```
 
+#### Large endpoint timeline exports
+
+Use `Export-XdrEndpointDeviceTimeline` for long incident-response exports. It writes
+newline-delimited JSON (NDJSON) to disk instead of retaining the complete timeline in
+memory:
+
+```powershell
+$from = (Get-Date).ToUniversalTime().AddDays(-90)
+$to = (Get-Date).ToUniversalTime()
+
+Export-XdrEndpointDeviceTimeline `
+    -DeviceId $deviceId `
+    -FromDate $from `
+    -ToDate $to `
+    -Path '.\timeline-90d.ndjson' `
+    -IncludeSentinelEvents
+```
+
+The export is resumable. If the process, connection, or computer stops during the
+download, run the same command again with the same `Path`; completed parts are validated
+by length and SHA-256 and only incomplete windows are downloaded again. Use `-Force` only
+when intentionally discarding the resumable state.
+
+The cmdlet currently uses four-hour windows, four concurrent workers, and 1,000 records
+per API page. These are deliberately internal implementation choices; `ChunkHours` and
+`ThrottleLimit` are not public parameters. Benchmarking showed that smaller windows and
+more workers can be faster for some short ranges, but they also increased API retries,
+window restarts, or memory use during long exports. More time-range and tenant-specific
+research is needed before exposing tuning options.
+
+The cmdlet emits progress updates and a 30-second informational heartbeat containing
+time coverage, completed windows, event count, bytes written, active/queued work, elapsed
+time, and a rough ETA.
+
+The following physical-disk benchmarks used the same device and a 90-day range. Counts
+can vary slightly because the portal's historical response is not immutable between runs:
+
+| Configuration | Total time | Peak working set | Retries / window restarts |
+| --- | ---: | ---: | ---: |
+| 4-hour / 4 workers | 41m 49s | 1.75 GiB | 0 / 0 |
+| 2-hour / 4 workers | 44m 16s | 1.65 GiB | 20 / 8 |
+| 2-hour / 6 workers | 41m 08s | 2.17 GiB | 50 / 26 |
+
+The 4-hour/four-worker balance is therefore the initial release default: it completed the
+90-day export without retries or restarts while remaining competitive on elapsed time and
+memory. These defaults can be revisited as more devices, tenants, and time ranges are
+available for testing.
+
 #### Azure Data Explorer export
 
 Export XDR data directly to Azure Data Explorer for long-term investigation and custom analytics. The cmdlet supports two modes: **typed source routing** (recommended) which automatically creates well-structured tables, and **manual table** mode for custom schemas.

--- a/README.md
+++ b/README.md
@@ -359,6 +359,9 @@ The cmdlet emits progress updates and a 30-second informational heartbeat contai
 time coverage, completed windows, event count, bytes written, active/queued work, elapsed
 time, and a rough ETA.
 
+See [Timeline export functions](docs/export-functions.md) for the export lifecycle,
+correctness guarantees, resume behavior, and implementation rationale.
+
 The following physical-disk benchmarks used the same device and a 90-day range. Counts
 can vary slightly because the portal's historical response is not immutable between runs:
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Get-XdrTenantContext -Force
 | ConvertTo-XdrEncodedAdvancedHuntingQuery                        | Encodes an Advanced Hunting query for use in Microsoft Defender XDR. |
 | Disconnect-XdrEndpointDeviceLiveResponse                        | Closes an active Live Response session in Microsoft Defender XDR. |
 | Export-XdrAzureDataExplorer                                     | Exports pipeline data to Azure Data Explorer using queued ingestion. |
+| Export-XdrEndpointDeviceTimeline                                | Exports a Microsoft Defender XDR device timeline to NDJSON. |
 | Export-XdrToSentinel                                            | Exports XDR data to a Microsoft Sentinel (Log Analytics) custom table. |
 | Get-XdrActionsCenterHistory                                     | Retrieves historical actions from the Microsoft Defender XDR Action Center. |
 | Get-XdrActionsCenterPending                                     | Retrieves pending actions from the Microsoft Defender XDR Action Center. |

--- a/README.md
+++ b/README.md
@@ -373,8 +373,28 @@ can vary slightly because the portal's historical response is not immutable betw
 
 The 4-hour/four-worker balance is therefore the initial release default: it completed the
 90-day export without retries or restarts while remaining competitive on elapsed time and
-memory. These defaults can be revisited as more devices, tenants, and time ranges are
-available for testing.
+memory. A later fixed-UTC seven-day matrix exercised all 36 combinations of 250, 500, or
+1,000 records per page; two-, four-, or eight-hour windows; and 2, 4, 8, or 16 workers.
+Only 16 combinations completed. The current 1,000/4-hour/4-worker configuration completed
+in 176 seconds with no retries or restarts and a 1.40 GiB peak working set. The nearest
+clean challenger, 1,000/8-hour/4-worker, was only 2% faster and used about 12% more peak
+memory, so it did not meet the 10% speed and memory gates. The defaults remain unchanged
+and can be revisited as more devices, tenants, and time ranges are available for testing.
+
+The baseline and two strongest valid challengers were then run twice over the same fixed
+30-day UTC range, first in baseline/8-hour/2-hour order and then in reverse:
+
+| Configuration | Elapsed pair | Peak working-set pair | Retries / restarts pair |
+| --- | ---: | ---: | ---: |
+| 1,000 / 4-hour / 4 workers | 919s / 924s | 1.47 / 1.48 GiB | 1/0 / 1/0 |
+| 1,000 / 8-hour / 4 workers | 696s / 947s | 1.76 / 1.77 GiB | 0/0 / 1/0 |
+| 1,000 / 2-hour / 4 workers | 787s / 927s | 1.50 / 1.57 GiB | 21/9 / 6/2 |
+
+Each run independently validated 805,109–805,115 lines, 853–998 pages, 4.37 GB, and the
+final SHA-256. The 8-hour challenger exceeded the memory gate in both runs and was slower
+in the reverse comparison. The 2-hour challenger added retries and restarts in both runs
+and was also slower in the reverse comparison. Neither challenger qualified to replace
+the defaults.
 
 #### Azure Data Explorer export
 

--- a/XDRInternals/XDRInternals.psd1
+++ b/XDRInternals/XDRInternals.psd1
@@ -73,6 +73,7 @@
         "ConvertTo-XdrEncodedAdvancedHuntingQuery",
         "Disconnect-XdrEndpointDeviceLiveResponse",
         "Export-XdrAzureDataExplorer",
+        "Export-XdrEndpointDeviceTimeline",
         "Export-XdrToSentinel",
         "Get-XdrActionsCenterHistory",
         "Get-XdrActionsCenterPending",

--- a/XDRInternals/functions/Export-XdrEndpointDeviceTimeline.ps1
+++ b/XDRInternals/functions/Export-XdrEndpointDeviceTimeline.ps1
@@ -1,0 +1,624 @@
+﻿function Export-XdrEndpointDeviceTimeline {
+    <#
+    .SYNOPSIS
+        Exports a Microsoft Defender XDR device timeline to NDJSON.
+
+    .DESCRIPTION
+        Exports a bounded device timeline through the Defender XDR portal timeline API.
+        The requested UTC range is divided into four-hour intervals and downloaded by a
+        background worker. Each completed interval is written as an atomic UTF-8 NDJSON
+        part and recorded in a resumable manifest. Records without a parseable timestamp
+        fail the export because they cannot be safely assigned to a single interval.
+
+        The final file is assembled without parsing or reserializing completed parts. A
+        failed run does not publish the final path and preserves validated parts for the
+        next identical invocation. Successful runs remove temporary part files and retain
+        only the NDJSON export and its compact manifest.
+
+        This cmdlet is intended for large incident-response exports. Use
+        Get-XdrEndpointDeviceTimeline for smaller, interactive in-memory retrieval.
+
+    .PARAMETER DeviceId
+        The 40-character Defender for Endpoint device identifier.
+
+    .PARAMETER FromDate
+        Inclusive beginning of the export range. The value is converted to UTC.
+
+    .PARAMETER ToDate
+        Exclusive end of the export range. The value is converted to UTC. A maximum range
+        of 180 days is supported by the portal timeline experience.
+
+    .PARAMETER Path
+        Destination NDJSON file. The path must end in .ndjson.
+
+    .PARAMETER IncludeSentinelEvents
+        Includes Microsoft Sentinel events in the exported timeline.
+
+    .PARAMETER Force
+        Replaces an existing export and discards incompatible resumable state at Path.
+
+    .EXAMPLE
+        Export-XdrEndpointDeviceTimeline -DeviceId $deviceId -FromDate $from -ToDate $to -Path '.\timeline.ndjson'
+        Exports the requested device timeline and returns a summary object.
+
+    .EXAMPLE
+        Export-XdrEndpointDeviceTimeline -DeviceId $deviceId -FromDate (Get-Date).AddDays(-90) -ToDate (Get-Date) -Path '.\timeline-90d.ndjson' -IncludeSentinelEvents
+        Exports a 90-day device timeline including Sentinel events. If interrupted, running
+        the same command again resumes from validated completed intervals.
+
+    .OUTPUTS
+        PSCustomObject
+        Returns the output path, manifest path, event and page counts, file size and hash,
+        elapsed time, and whether prior chunks were resumed.
+    #>
+    [OutputType([PSCustomObject])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Alias('MachineId', 'SenseMachineId')]
+        [ValidateLength(40, 40)]
+        [ValidatePattern('^[0-9a-fA-F]{40}$')]
+        [string]$DeviceId,
+
+        [Parameter(Mandatory)]
+        [datetime]$FromDate,
+
+        [Parameter(Mandatory)]
+        [datetime]$ToDate,
+
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter()]
+        [switch]$IncludeSentinelEvents,
+
+        [Parameter()]
+        [switch]$Force
+    )
+
+    begin {
+        if ($PSVersionTable.PSVersion.Major -lt 7) {
+            throw 'Export-XdrEndpointDeviceTimeline requires PowerShell 7 or later.'
+        }
+        Update-XdrConnectionSettings
+    }
+
+    process {
+        $operationStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $rangeStart = $FromDate.ToUniversalTime()
+        $rangeEnd = $ToDate.ToUniversalTime()
+        if ($rangeStart -ge $rangeEnd) {
+            throw 'FromDate must be before ToDate.'
+        }
+        if (($rangeEnd - $rangeStart).TotalDays -gt 180) {
+            throw 'The time range between FromDate and ToDate cannot exceed 180 days.'
+        }
+
+        $outputPath = [System.IO.Path]::GetFullPath($Path)
+        if ([System.IO.Path]::GetExtension($outputPath) -ine '.ndjson') {
+            throw "Path '$Path' must use the .ndjson extension."
+        }
+        if (Test-Path -LiteralPath $outputPath -PathType Container) {
+            throw "Path '$Path' resolves to a directory."
+        }
+
+        $outputDirectory = Split-Path -Parent $outputPath
+        if (-not (Test-Path -LiteralPath $outputDirectory)) {
+            New-Item -Path $outputDirectory -ItemType Directory -Force -ErrorAction Stop | Out-Null
+        }
+
+        $manifestPath = "$outputPath.manifest.json"
+        $manifestPartialPath = "$manifestPath.partial"
+        $partsPath = "$outputPath.parts"
+        $outputPartialPath = "$outputPath.partial"
+
+        if ($Force) {
+            foreach ($staleFile in @($outputPath, $manifestPath, $manifestPartialPath, $outputPartialPath)) {
+                if (Test-Path -LiteralPath $staleFile) {
+                    Remove-Item -LiteralPath $staleFile -Force -ErrorAction Stop
+                }
+            }
+            if (Test-Path -LiteralPath $partsPath) {
+                Remove-Item -LiteralPath $partsPath -Recurse -Force -ErrorAction Stop
+            }
+        }
+        elseif (Test-Path -LiteralPath $outputPath) {
+            throw "Path '$outputPath' already exists. Use -Force to replace it."
+        }
+
+        if (Test-Path -LiteralPath $manifestPartialPath) {
+            Remove-Item -LiteralPath $manifestPartialPath -Force -ErrorAction SilentlyContinue
+        }
+        if (Test-Path -LiteralPath $outputPartialPath) {
+            Remove-Item -LiteralPath $outputPartialPath -Force -ErrorAction SilentlyContinue
+        }
+
+        $writeManifest = {
+            param($Manifest, $ManifestPath, $PartialPath)
+
+            $Manifest.UpdatedUtc = [datetime]::UtcNow.ToString('o')
+            $manifestJson = $Manifest | ConvertTo-Json -Depth 16
+            [System.IO.File]::WriteAllText($PartialPath, $manifestJson, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::Move($PartialPath, $ManifestPath, $true)
+        }
+
+        $chunkHours = 4
+        $pageSize = 250
+        # The portal API starts returning incomplete cursor chains under concurrent pagination.
+        # A single background worker preserves heartbeat responsiveness and data reliability.
+        $throttleLimit = 1
+        $requestTimeoutSeconds = 120
+        $maxRetries = 5
+        $maxChunkRestarts = 2
+        $maxPagesPerChunk = 10000
+        $baseUrl = 'https://security.microsoft.com'
+        $manifest = $null
+        $resumedChunkCount = 0
+
+        if (Test-Path -LiteralPath $manifestPath) {
+            try {
+                $manifest = Get-Content -LiteralPath $manifestPath -Raw -ErrorAction Stop | ConvertFrom-Json -AsHashtable -Depth 16 -ErrorAction Stop
+            }
+            catch {
+                throw "Manifest '$manifestPath' could not be read. Use -Force to start a new export. $($_.Exception.Message)"
+            }
+
+            $compatible =
+                [int]$manifest.SchemaVersion -eq 1 -and
+                [string]$manifest.DeviceId -eq $DeviceId -and
+                ([datetime]$manifest.FromDateUtc).ToUniversalTime().Ticks -eq $rangeStart.Ticks -and
+                ([datetime]$manifest.ToDateUtc).ToUniversalTime().Ticks -eq $rangeEnd.Ticks -and
+                [bool]$manifest.IncludeSentinelEvents -eq $IncludeSentinelEvents.IsPresent -and
+                [int]$manifest.ChunkHours -eq $chunkHours -and
+                [int]$manifest.PageSize -eq $pageSize
+
+            if (-not $compatible) {
+                throw "Manifest '$manifestPath' does not match this request. Use -Force to discard it or choose another Path."
+            }
+        }
+        else {
+            $plannedChunks = @(New-XdrEndpointTimelineExportChunk -FromDate $rangeStart -ToDate $rangeEnd -ChunkHours $chunkHours)
+            $manifestChunks = @(
+                foreach ($plannedChunk in $plannedChunks) {
+                    [ordered]@{
+                        Index                  = $plannedChunk.Index
+                        FromDateUtc            = $plannedChunk.FromDate.ToString('o')
+                        ToDateUtc              = $plannedChunk.ToDate.ToString('o')
+                        DurationTicks          = $plannedChunk.DurationTicks
+                        FileName               = $plannedChunk.FileName
+                        Status                 = 'Pending'
+                        EventCount             = 0L
+                        PageCount              = 0
+                        RetryCount             = 0
+                        AttemptCount           = 0
+                        FileBytes              = 0L
+                        FileSha256             = $null
+                        MissingTimestampCount  = 0L
+                        BoundaryTimestampCount = 0L
+                        ElapsedSeconds         = 0.0
+                        Error                  = $null
+                    }
+                }
+            )
+            $manifest = [ordered]@{
+                SchemaVersion         = 1
+                State                 = 'InProgress'
+                DeviceId              = $DeviceId
+                FromDateUtc           = $rangeStart.ToString('o')
+                ToDateUtc             = $rangeEnd.ToString('o')
+                IncludeSentinelEvents = $IncludeSentinelEvents.IsPresent
+                ChunkHours            = $chunkHours
+                PageSize              = $pageSize
+                Ordering              = 'NewestTimeWindowFirst;ApiEventOrderPreserved'
+                CreatedUtc            = [datetime]::UtcNow.ToString('o')
+                UpdatedUtc            = [datetime]::UtcNow.ToString('o')
+                Chunks                = $manifestChunks
+                Summary               = $null
+            }
+        }
+
+        New-Item -Path $partsPath -ItemType Directory -Force -ErrorAction Stop | Out-Null
+
+        foreach ($manifestChunk in @($manifest.Chunks)) {
+            if ([string]$manifestChunk.Status -eq 'Completed') {
+                $partPath = Join-Path $partsPath ([string]$manifestChunk.FileName)
+                $partIsValid = Test-Path -LiteralPath $partPath -PathType Leaf
+                if ($partIsValid) {
+                    $partItem = Get-Item -LiteralPath $partPath
+                    $partIsValid = $partItem.Length -eq [long]$manifestChunk.FileBytes
+                }
+                if ($partIsValid) {
+                    $actualHash = (Get-FileHash -LiteralPath $partPath -Algorithm SHA256).Hash.ToLowerInvariant()
+                    $partIsValid = $actualHash -eq [string]$manifestChunk.FileSha256
+                }
+
+                if ($partIsValid) {
+                    $resumedChunkCount++
+                }
+                else {
+                    if (Test-Path -LiteralPath $partPath) {
+                        Remove-Item -LiteralPath $partPath -Force -ErrorAction SilentlyContinue
+                    }
+                    $manifestChunk.Status = 'Pending'
+                    $manifestChunk.EventCount = 0L
+                    $manifestChunk.PageCount = 0
+                    $manifestChunk.RetryCount = 0
+                    $manifestChunk.AttemptCount = 0
+                    $manifestChunk.FileBytes = 0L
+                    $manifestChunk.FileSha256 = $null
+                    $manifestChunk.Error = 'Previously completed part failed resume validation and was scheduled again.'
+                }
+            }
+            elseif ([string]$manifestChunk.Status -eq 'Failed') {
+                $manifestChunk.Status = 'Pending'
+                $manifestChunk.EventCount = 0L
+                $manifestChunk.PageCount = 0
+                $manifestChunk.RetryCount = 0
+                $manifestChunk.AttemptCount = 0
+                $manifestChunk.FileBytes = 0L
+                $manifestChunk.FileSha256 = $null
+                $manifestChunk.MissingTimestampCount = 0L
+                $manifestChunk.BoundaryTimestampCount = 0L
+                $manifestChunk.ElapsedSeconds = 0.0
+                $manifestChunk.Error = $null
+            }
+        }
+
+        $manifest.State = 'InProgress'
+        & $writeManifest $manifest $manifestPath $manifestPartialPath
+
+        $cookieData = @(
+            foreach ($cookie in $script:session.Cookies.GetCookies([uri]$baseUrl)) {
+                [PSCustomObject]@{
+                    Name   = $cookie.Name
+                    Value  = $cookie.Value
+                    Domain = $cookie.Domain
+                    Path   = $cookie.Path
+                }
+            }
+        )
+        $headersData = @{}
+        foreach ($headerName in $script:headers.Keys) {
+            $headersData[$headerName] = $script:headers[$headerName]
+        }
+
+        $sharedParameters = @{
+            BaseUrl               = $baseUrl
+            DeviceId              = $DeviceId
+            IncludeSentinelEvents = $IncludeSentinelEvents.IsPresent
+            PageSize              = $pageSize
+            MaxRetries            = $maxRetries
+            RequestTimeoutSeconds = $requestTimeoutSeconds
+            MaxPagesPerChunk      = $maxPagesPerChunk
+            PartsPath             = $partsPath
+            CookieData            = $cookieData
+            HeadersData           = $headersData
+        }
+
+        $pendingChunks = @(
+            foreach ($manifestChunk in @($manifest.Chunks | Where-Object Status -eq 'Pending' | Sort-Object { [int]$_['Index'] })) {
+                [PSCustomObject]@{
+                    Index         = [int]$manifestChunk.Index
+                    FromDate      = [datetime]$manifestChunk.FromDateUtc
+                    ToDate        = [datetime]$manifestChunk.ToDateUtc
+                    DurationTicks = [long]$manifestChunk.DurationTicks
+                    FileName      = [string]$manifestChunk.FileName
+                    Attempt       = [int]$manifestChunk.AttemptCount
+                }
+            }
+        )
+
+        $totalChunkCount = @($manifest.Chunks).Count
+        $totalDurationTicks = [long](($manifest.Chunks | ForEach-Object { [long]$_.DurationTicks } | Measure-Object -Sum).Sum)
+        $initialCompletedTicks = [long](($manifest.Chunks | Where-Object Status -eq 'Completed' | ForEach-Object { [long]$_.DurationTicks } | Measure-Object -Sum).Sum)
+        $initialCompletedCount = @($manifest.Chunks | Where-Object Status -eq 'Completed').Count
+        $initialCompletedEvents = [long](($manifest.Chunks | Where-Object Status -eq 'Completed' | ForEach-Object { [long]$_.EventCount } | Measure-Object -Sum).Sum)
+
+        Write-Information "Endpoint timeline export: $totalChunkCount four-hour window(s), $resumedChunkCount resumed, throttle=$throttleLimit, output='$outputPath'." -InformationAction Continue
+
+        $workerScript = New-XdrEndpointTimelineExportWorker
+        $workerScriptText = $workerScript.ToString()
+        $statusMap = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+        $chunkQueue = [System.Collections.Generic.Queue[object]]::new()
+        foreach ($pendingChunk in $pendingChunks) {
+            $chunkQueue.Enqueue($pendingChunk)
+        }
+
+        $runspacePool = [runspacefactory]::CreateRunspacePool(1, $throttleLimit)
+        $activeJobs = [System.Collections.Generic.List[object]]::new()
+        $completedDuringRunTicks = 0L
+        $completedDuringRunCount = 0
+        $completedDuringRunEvents = 0L
+        $failureResults = [System.Collections.Generic.List[object]]::new()
+        $lastProgressUpdate = [datetime]::MinValue
+        $lastHeartbeat = [datetime]::UtcNow
+        $stopScheduling = $false
+        $capturedError = $null
+
+        $startChunkJob = {
+            param($Chunk)
+
+            $powerShell = [powershell]::Create()
+            $powerShell.RunspacePool = $runspacePool
+            [void]$powerShell.AddScript($workerScriptText)
+            [void]$powerShell.AddParameter('chunk', $Chunk)
+            [void]$powerShell.AddParameter('sharedParameters', $sharedParameters)
+            [void]$powerShell.AddParameter('statusMap', $statusMap)
+            return [PSCustomObject]@{
+                PowerShell = $powerShell
+                Handle     = $powerShell.BeginInvoke()
+                Chunk      = $Chunk
+            }
+        }
+
+        try {
+            $runspacePool.Open()
+            while ($chunkQueue.Count -gt 0 -and $activeJobs.Count -lt $throttleLimit) {
+                $activeJobs.Add((& $startChunkJob $chunkQueue.Dequeue()))
+            }
+
+            while ($activeJobs.Count -gt 0) {
+                $completedJobs = @($activeJobs | Where-Object { $_.Handle.IsCompleted })
+                foreach ($job in $completedJobs) {
+                    try {
+                        $jobOutput = @($job.PowerShell.EndInvoke($job.Handle))
+                        $result = $jobOutput | Select-Object -Last 1
+                        if (-not $result) {
+                            throw "Chunk $($job.Chunk.Index) returned no result."
+                        }
+                    }
+                    catch {
+                        $result = [PSCustomObject]@{
+                            Success                = $false
+                            ChunkIndex             = [int]$job.Chunk.Index
+                            EventCount             = 0L
+                            PageCount              = 0
+                            FileBytes              = 0L
+                            FileSha256             = $null
+                            MissingTimestampCount  = 0L
+                            BoundaryTimestampCount = 0L
+                            ElapsedSeconds         = 0.0
+                            RetryCount             = 0
+                            Error                  = $_.ToString()
+                            FailureClass           = 'WorkerFailure'
+                        }
+                    }
+                    finally {
+                        $job.PowerShell.Dispose()
+                        [void]$activeJobs.Remove($job)
+                    }
+
+                    $manifestChunk = @($manifest.Chunks | Where-Object { [int]$_.Index -eq [int]$result.ChunkIndex })[0]
+                    $manifestChunk.RetryCount = [int]$manifestChunk.RetryCount + [int]$result.RetryCount
+                    $manifestChunk.AttemptCount = [int]$job.Chunk.Attempt
+                    $manifestChunk.ElapsedSeconds = [double]$manifestChunk.ElapsedSeconds + [double]$result.ElapsedSeconds
+
+                    if ($result.Success) {
+                        $manifestChunk.Status = 'Completed'
+                        $manifestChunk.EventCount = [long]$result.EventCount
+                        $manifestChunk.PageCount = [int]$result.PageCount
+                        $manifestChunk.FileBytes = [long]$result.FileBytes
+                        $manifestChunk.FileSha256 = $result.FileSha256
+                        $manifestChunk.MissingTimestampCount = [long]$result.MissingTimestampCount
+                        $manifestChunk.BoundaryTimestampCount = [long]$result.BoundaryTimestampCount
+                        $manifestChunk.Error = $null
+                        $completedDuringRunCount++
+                        $completedDuringRunTicks += [long]$manifestChunk.DurationTicks
+                        $completedDuringRunEvents += [long]$result.EventCount
+                    }
+                    elseif ([string]$result.FailureClass -in @('PartialResponse', 'TransientHttp', 'Transport') -and [int]$job.Chunk.Attempt -lt $maxChunkRestarts) {
+                        $nextAttempt = [int]$job.Chunk.Attempt + 1
+                        $manifestChunk.Status = 'Pending'
+                        $manifestChunk.AttemptCount = $nextAttempt
+                        $manifestChunk.EventCount = 0L
+                        $manifestChunk.PageCount = 0
+                        $manifestChunk.FileBytes = 0L
+                        $manifestChunk.FileSha256 = $null
+                        $manifestChunk.MissingTimestampCount = 0L
+                        $manifestChunk.BoundaryTimestampCount = 0L
+                        $manifestChunk.Error = $result.Error
+                        $chunkQueue.Enqueue([PSCustomObject]@{
+                            Index         = [int]$manifestChunk.Index
+                            FromDate      = [datetime]$manifestChunk.FromDateUtc
+                            ToDate        = [datetime]$manifestChunk.ToDateUtc
+                            DurationTicks = [long]$manifestChunk.DurationTicks
+                            FileName      = [string]$manifestChunk.FileName
+                            Attempt       = $nextAttempt
+                        })
+                        Write-Information "Restarting endpoint timeline window $($manifestChunk.Index) with a fresh request context (attempt $($nextAttempt + 1)/$($maxChunkRestarts + 1)) after $($result.FailureClass)." -InformationAction Continue
+                    }
+                    else {
+                        $manifestChunk.Status = 'Failed'
+                        $manifestChunk.EventCount = [long]$result.EventCount
+                        $manifestChunk.PageCount = [int]$result.PageCount
+                        $manifestChunk.FileBytes = [long]$result.FileBytes
+                        $manifestChunk.FileSha256 = $result.FileSha256
+                        $manifestChunk.MissingTimestampCount = [long]$result.MissingTimestampCount
+                        $manifestChunk.BoundaryTimestampCount = [long]$result.BoundaryTimestampCount
+                        $manifestChunk.Error = $result.Error
+                        $failureResults.Add($result)
+                        $stopScheduling = $true
+                    }
+
+                    & $writeManifest $manifest $manifestPath $manifestPartialPath
+
+                    if (-not $stopScheduling -and $chunkQueue.Count -gt 0) {
+                        $activeJobs.Add((& $startChunkJob $chunkQueue.Dequeue()))
+                    }
+                }
+
+                $now = [datetime]::UtcNow
+                if (($now - $lastProgressUpdate).TotalSeconds -ge 2) {
+                    $completedTicks = $initialCompletedTicks + $completedDuringRunTicks
+                    $completedCount = $initialCompletedCount + $completedDuringRunCount
+                    $completedEvents = $initialCompletedEvents + $completedDuringRunEvents
+                    $activeEvents = [long](($statusMap.Values | Measure-Object -Property Events -Sum).Sum)
+                    $completedBytes = [long](($manifest.Chunks | Where-Object Status -eq 'Completed' | ForEach-Object { [long]$_.FileBytes } | Measure-Object -Sum).Sum)
+                    $activeBytes = [long](($statusMap.Values | Measure-Object -Property Bytes -Sum).Sum)
+                    $percentComplete = if ($totalDurationTicks -gt 0) { [math]::Min(100, [math]::Round(($completedTicks / $totalDurationTicks) * 100, 1)) } else { 100 }
+                    $status = "Completed $completedCount/$totalChunkCount windows; events $($completedEvents + $activeEvents); written $([math]::Round(($completedBytes + $activeBytes) / 1MB, 1)) MiB; active $($activeJobs.Count); queued $($chunkQueue.Count)"
+                    Write-Progress -Activity 'Exporting XDR endpoint device timeline' -Status $status -PercentComplete $percentComplete
+                    $lastProgressUpdate = $now
+                }
+
+                if (($now - $lastHeartbeat).TotalSeconds -ge 30) {
+                    $completedTicks = $initialCompletedTicks + $completedDuringRunTicks
+                    $completedCount = $initialCompletedCount + $completedDuringRunCount
+                    $completedEvents = $initialCompletedEvents + $completedDuringRunEvents
+                    $activeEvents = [long](($statusMap.Values | Measure-Object -Property Events -Sum).Sum)
+                    $completedBytes = [long](($manifest.Chunks | Where-Object Status -eq 'Completed' | ForEach-Object { [long]$_.FileBytes } | Measure-Object -Sum).Sum)
+                    $activeBytes = [long](($statusMap.Values | Measure-Object -Property Bytes -Sum).Sum)
+                    $percentComplete = if ($totalDurationTicks -gt 0) { [math]::Round(($completedTicks / $totalDurationTicks) * 100, 1) } else { 100 }
+                    $etaText = 'estimating'
+                    if ($completedDuringRunTicks -gt 0 -and $operationStopwatch.Elapsed.TotalSeconds -gt 0) {
+                        $ticksPerSecond = $completedDuringRunTicks / $operationStopwatch.Elapsed.TotalSeconds
+                        $remainingTicks = [math]::Max([long]0, $totalDurationTicks - $completedTicks)
+                        $etaText = [timespan]::FromSeconds($remainingTicks / $ticksPerSecond).ToString('c')
+                    }
+                    Write-Information "Endpoint timeline heartbeat: $percentComplete% time coverage; windows $completedCount/$totalChunkCount; events $($completedEvents + $activeEvents); written $([math]::Round(($completedBytes + $activeBytes) / 1MB, 1)) MiB; active $($activeJobs.Count); queued $($chunkQueue.Count); elapsed $($operationStopwatch.Elapsed.ToString('c')); rough ETA $etaText." -InformationAction Continue
+                    $lastHeartbeat = $now
+                }
+
+                if ($completedJobs.Count -eq 0) {
+                    Start-Sleep -Milliseconds 200
+                }
+            }
+        }
+        catch {
+            $capturedError = $_
+        }
+        finally {
+            foreach ($job in @($activeJobs)) {
+                try { $job.PowerShell.Stop() } catch { Write-Verbose "Could not stop chunk $($job.Chunk.Index): $_" }
+                $job.PowerShell.Dispose()
+            }
+            $activeJobs.Clear()
+            $runspacePool.Close()
+            $runspacePool.Dispose()
+            Write-Progress -Activity 'Exporting XDR endpoint device timeline' -Completed
+        }
+
+        if ($capturedError) {
+            $manifest.State = 'Failed'
+            $manifest.Summary = [ordered]@{ Error = $capturedError.ToString() }
+            & $writeManifest $manifest $manifestPath $manifestPartialPath
+            throw $capturedError
+        }
+
+        if ($failureResults.Count -gt 0) {
+            $manifest.State = 'Failed'
+            $manifest.Summary = [ordered]@{
+                FailedChunkCount = $failureResults.Count
+                Errors           = @($failureResults | ForEach-Object { "chunk $($_.ChunkIndex): $($_.Error)" })
+            }
+            & $writeManifest $manifest $manifestPath $manifestPartialPath
+            $failureText = $manifest.Summary.Errors -join '; '
+            throw "Endpoint timeline export failed. Completed parts were preserved for resume. $failureText"
+        }
+
+        if ($chunkQueue.Count -gt 0) {
+            throw 'Endpoint timeline export stopped before all planned chunks were scheduled.'
+        }
+
+        $incompleteChunks = @($manifest.Chunks | Where-Object Status -ne 'Completed')
+        if ($incompleteChunks.Count -gt 0) {
+            throw "Endpoint timeline export has $($incompleteChunks.Count) incomplete chunk(s); the final file was not published."
+        }
+
+        $orderedParts = @(
+            foreach ($manifestChunk in @($manifest.Chunks | Sort-Object { [int]$_['Index'] })) {
+                [PSCustomObject]@{
+                    FilePath    = Join-Path $partsPath ([string]$manifestChunk.FileName)
+                    FileSha256 = [string]$manifestChunk.FileSha256
+                    EventCount = [long]$manifestChunk.EventCount
+                }
+            }
+        )
+
+        $totalPartBytes = [long](($manifest.Chunks | ForEach-Object { [long]$_.FileBytes } | Measure-Object -Sum).Sum)
+        $mergeSafetyMarginBytes = [long][math]::Max([long]64MB, [long][math]::Ceiling($totalPartBytes * 0.05))
+        $requiredMergeBytes = $totalPartBytes + $mergeSafetyMarginBytes
+        $outputDrive = [System.IO.DriveInfo]::new([System.IO.Path]::GetPathRoot($outputPath))
+        if ($outputDrive.AvailableFreeSpace -lt $requiredMergeBytes) {
+            $storageError = "Finalizing the endpoint timeline requires at least $([math]::Round($requiredMergeBytes / 1GB, 2)) GiB free on '$($outputDrive.Name)', but only $([math]::Round($outputDrive.AvailableFreeSpace / 1GB, 2)) GiB is available. Completed parts were preserved for resume."
+            $manifest.State = 'Failed'
+            $manifest.Summary = [ordered]@{ Error = $storageError }
+            & $writeManifest $manifest $manifestPath $manifestPartialPath
+            throw $storageError
+        }
+
+        $manifest.State = 'Finalizing'
+        & $writeManifest $manifest $manifestPath $manifestPartialPath
+        $mergeStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        try {
+            $mergeResult = Merge-XdrEndpointTimelineNdjsonPart -Part $orderedParts -DestinationPath $outputPartialPath
+            [System.IO.File]::Move($outputPartialPath, $outputPath, $false)
+        }
+        catch {
+            if (Test-Path -LiteralPath $outputPartialPath) {
+                Remove-Item -LiteralPath $outputPartialPath -Force -ErrorAction SilentlyContinue
+            }
+            $manifest.State = 'Failed'
+            $manifest.Summary = [ordered]@{ Error = "Final validation failed: $($_.Exception.Message)" }
+            & $writeManifest $manifest $manifestPath $manifestPartialPath
+            throw
+        }
+        finally {
+            $mergeStopwatch.Stop()
+        }
+
+        $partsRetained = $false
+        try {
+            Remove-Item -LiteralPath $partsPath -Recurse -Force -ErrorAction Stop
+        }
+        catch {
+            $partsRetained = $true
+            Write-Warning "The export completed, but temporary part files could not be removed from '$partsPath': $($_.Exception.Message)"
+        }
+
+        $operationStopwatch.Stop()
+        $totalPages = [long](($manifest.Chunks | ForEach-Object { [long]$_.PageCount } | Measure-Object -Sum).Sum)
+        $totalRetries = [long](($manifest.Chunks | ForEach-Object { [long]$_.RetryCount } | Measure-Object -Sum).Sum)
+        $totalChunkRestarts = [long](($manifest.Chunks | ForEach-Object { [long]$_.AttemptCount } | Measure-Object -Sum).Sum)
+        $missingTimestampCount = [long](($manifest.Chunks | ForEach-Object { [long]$_.MissingTimestampCount } | Measure-Object -Sum).Sum)
+        $boundaryTimestampCount = [long](($manifest.Chunks | ForEach-Object { [long]$_.BoundaryTimestampCount } | Measure-Object -Sum).Sum)
+        $manifest.State = 'Complete'
+        $manifest.Summary = [ordered]@{
+            OutputPath              = $outputPath
+            EventCount              = [long]$mergeResult.EventCount
+            PageCount               = $totalPages
+            RetryCount              = $totalRetries
+            ChunkRestartCount       = $totalChunkRestarts
+            FileBytes               = [long]$mergeResult.FileBytes
+            FileSha256              = [string]$mergeResult.FileSha256
+            MissingTimestampCount   = $missingTimestampCount
+            BoundaryTimestampCount  = $boundaryTimestampCount
+            ResumedChunkCount       = $resumedChunkCount
+            PartsRetained           = $partsRetained
+            MergeSeconds            = [math]::Round($mergeStopwatch.Elapsed.TotalSeconds, 3)
+            ElapsedSeconds          = [math]::Round($operationStopwatch.Elapsed.TotalSeconds, 3)
+            CompletedUtc            = [datetime]::UtcNow.ToString('o')
+        }
+        & $writeManifest $manifest $manifestPath $manifestPartialPath
+
+        Write-Information "Endpoint timeline export complete: $($mergeResult.EventCount) events, $totalChunkCount windows, $([math]::Round($mergeResult.FileBytes / 1MB, 2)) MiB, elapsed $($operationStopwatch.Elapsed.ToString('c'))." -InformationAction Continue
+
+        return [PSCustomObject]@{
+            OutputPath              = $outputPath
+            ManifestPath            = $manifestPath
+            TotalEvents             = [long]$mergeResult.EventCount
+            TotalPages              = $totalPages
+            TotalRetries            = $totalRetries
+            TotalChunkRestarts      = $totalChunkRestarts
+            TotalChunks             = $totalChunkCount
+            ResumedChunks           = $resumedChunkCount
+            FileBytes               = [long]$mergeResult.FileBytes
+            FileSha256              = [string]$mergeResult.FileSha256
+            MissingTimestampCount   = $missingTimestampCount
+            BoundaryTimestampCount  = $boundaryTimestampCount
+            MergeSeconds            = [math]::Round($mergeStopwatch.Elapsed.TotalSeconds, 3)
+            ElapsedSeconds          = [math]::Round($operationStopwatch.Elapsed.TotalSeconds, 3)
+            TemporaryPartsRetained  = $partsRetained
+        }
+    }
+}

--- a/XDRInternals/functions/Export-XdrEndpointDeviceTimeline.ps1
+++ b/XDRInternals/functions/Export-XdrEndpointDeviceTimeline.ps1
@@ -448,7 +448,9 @@
                 }
 
                 $now = [datetime]::UtcNow
-                if (($now - $lastProgressUpdate).TotalSeconds -ge 2) {
+                $progressIsDue = ($now - $lastProgressUpdate).TotalSeconds -ge 2
+                $heartbeatIsDue = ($now - $lastHeartbeat).TotalSeconds -ge 30
+                if ($progressIsDue -or $heartbeatIsDue) {
                     $completedTicks = $initialCompletedTicks + $completedDuringRunTicks
                     $completedCount = $initialCompletedCount + $completedDuringRunCount
                     $completedEvents = $initialCompletedEvents + $completedDuringRunEvents
@@ -456,27 +458,23 @@
                     $completedBytes = [long](($manifest.Chunks | Where-Object Status -eq 'Completed' | ForEach-Object { [long]$_.FileBytes } | Measure-Object -Sum).Sum)
                     $activeBytes = [long](($statusMap.Values | Measure-Object -Property Bytes -Sum).Sum)
                     $percentComplete = if ($totalDurationTicks -gt 0) { [math]::Min(100, [math]::Round(($completedTicks / $totalDurationTicks) * 100, 1)) } else { 100 }
-                    $status = "Completed $completedCount/$totalChunkCount windows; events $($completedEvents + $activeEvents); written $([math]::Round(($completedBytes + $activeBytes) / 1MB, 1)) MiB; active $($activeJobs.Count); queued $($chunkQueue.Count)"
-                    Write-Progress -Activity 'Exporting XDR endpoint device timeline' -Status $status -PercentComplete $percentComplete
-                    $lastProgressUpdate = $now
-                }
 
-                if (($now - $lastHeartbeat).TotalSeconds -ge 30) {
-                    $completedTicks = $initialCompletedTicks + $completedDuringRunTicks
-                    $completedCount = $initialCompletedCount + $completedDuringRunCount
-                    $completedEvents = $initialCompletedEvents + $completedDuringRunEvents
-                    $activeEvents = [long](($statusMap.Values | Measure-Object -Property Events -Sum).Sum)
-                    $completedBytes = [long](($manifest.Chunks | Where-Object Status -eq 'Completed' | ForEach-Object { [long]$_.FileBytes } | Measure-Object -Sum).Sum)
-                    $activeBytes = [long](($statusMap.Values | Measure-Object -Property Bytes -Sum).Sum)
-                    $percentComplete = if ($totalDurationTicks -gt 0) { [math]::Round(($completedTicks / $totalDurationTicks) * 100, 1) } else { 100 }
-                    $etaText = 'estimating'
-                    if ($completedDuringRunTicks -gt 0 -and $operationStopwatch.Elapsed.TotalSeconds -gt 0) {
-                        $ticksPerSecond = $completedDuringRunTicks / $operationStopwatch.Elapsed.TotalSeconds
-                        $remainingTicks = [math]::Max([long]0, $totalDurationTicks - $completedTicks)
-                        $etaText = [timespan]::FromSeconds($remainingTicks / $ticksPerSecond).ToString('c')
+                    if ($progressIsDue) {
+                        $status = "Completed $completedCount/$totalChunkCount windows; events $($completedEvents + $activeEvents); written $([math]::Round(($completedBytes + $activeBytes) / 1MB, 1)) MiB; active $($activeJobs.Count); queued $($chunkQueue.Count)"
+                        Write-Progress -Activity 'Exporting XDR endpoint device timeline' -Status $status -PercentComplete $percentComplete
+                        $lastProgressUpdate = $now
                     }
-                    Write-Information "Endpoint timeline heartbeat: $percentComplete% time coverage; windows $completedCount/$totalChunkCount; events $($completedEvents + $activeEvents); written $([math]::Round(($completedBytes + $activeBytes) / 1MB, 1)) MiB; active $($activeJobs.Count); queued $($chunkQueue.Count); elapsed $($operationStopwatch.Elapsed.ToString('c')); rough ETA $etaText." -InformationAction Continue
-                    $lastHeartbeat = $now
+
+                    if ($heartbeatIsDue) {
+                        $etaText = 'estimating'
+                        if ($completedDuringRunTicks -gt 0 -and $operationStopwatch.Elapsed.TotalSeconds -gt 0) {
+                            $ticksPerSecond = $completedDuringRunTicks / $operationStopwatch.Elapsed.TotalSeconds
+                            $remainingTicks = [math]::Max([long]0, $totalDurationTicks - $completedTicks)
+                            $etaText = [timespan]::FromSeconds($remainingTicks / $ticksPerSecond).ToString('c')
+                        }
+                        Write-Information "Endpoint timeline heartbeat: $percentComplete% time coverage; windows $completedCount/$totalChunkCount; events $($completedEvents + $activeEvents); written $([math]::Round(($completedBytes + $activeBytes) / 1MB, 1)) MiB; active $($activeJobs.Count); queued $($chunkQueue.Count); elapsed $($operationStopwatch.Elapsed.ToString('c')); rough ETA $etaText." -InformationAction Continue
+                        $lastHeartbeat = $now
+                    }
                 }
 
                 if ($completedJobs.Count -eq 0) {

--- a/XDRInternals/functions/Export-XdrEndpointDeviceTimeline.ps1
+++ b/XDRInternals/functions/Export-XdrEndpointDeviceTimeline.ps1
@@ -35,7 +35,8 @@
         Includes Microsoft Sentinel events in the exported timeline.
 
     .PARAMETER Force
-        Replaces an existing export and discards incompatible resumable state at Path.
+        Replaces an existing export and discards incompatible resumable state at Path. The
+        existing export remains available until its validated replacement is published.
 
     .EXAMPLE
         Export-XdrEndpointDeviceTimeline -DeviceId $deviceId -FromDate $from -ToDate $to -Path '.\timeline.ndjson'
@@ -111,27 +112,7 @@
         $manifestPartialPath = "$manifestPath.partial"
         $partsPath = "$outputPath.parts"
         $outputPartialPath = "$outputPath.partial"
-
-        if ($Force) {
-            foreach ($staleFile in @($outputPath, $manifestPath, $manifestPartialPath, $outputPartialPath)) {
-                if (Test-Path -LiteralPath $staleFile) {
-                    Remove-Item -LiteralPath $staleFile -Force -ErrorAction Stop
-                }
-            }
-            if (Test-Path -LiteralPath $partsPath) {
-                Remove-Item -LiteralPath $partsPath -Recurse -Force -ErrorAction Stop
-            }
-        }
-        elseif (Test-Path -LiteralPath $outputPath) {
-            throw "Path '$outputPath' already exists. Use -Force to replace it."
-        }
-
-        if (Test-Path -LiteralPath $manifestPartialPath) {
-            Remove-Item -LiteralPath $manifestPartialPath -Force -ErrorAction SilentlyContinue
-        }
-        if (Test-Path -LiteralPath $outputPartialPath) {
-            Remove-Item -LiteralPath $outputPartialPath -Force -ErrorAction SilentlyContinue
-        }
+        $replaceExistingOutput = $Force.IsPresent -and (Test-Path -LiteralPath $outputPath -PathType Leaf)
 
         $writeManifest = {
             param($Manifest, $ManifestPath, $PartialPath)
@@ -155,7 +136,17 @@
         $manifest = $null
         $resumedChunkCount = 0
 
-        if (Test-Path -LiteralPath $manifestPath) {
+        if ($Force) {
+            foreach ($staleFile in @($manifestPath, $manifestPartialPath, $outputPartialPath)) {
+                if (Test-Path -LiteralPath $staleFile) {
+                    Remove-Item -LiteralPath $staleFile -Force -ErrorAction Stop
+                }
+            }
+            if (Test-Path -LiteralPath $partsPath) {
+                Remove-Item -LiteralPath $partsPath -Recurse -Force -ErrorAction Stop
+            }
+        }
+        elseif (Test-Path -LiteralPath $manifestPath) {
             try {
                 $manifest = Get-Content -LiteralPath $manifestPath -Raw -ErrorAction Stop | ConvertFrom-Json -AsHashtable -Depth 16 -ErrorAction Stop
             }
@@ -176,7 +167,71 @@
                 throw "Manifest '$manifestPath' does not match this request. Use -Force to discard it or choose another Path."
             }
         }
-        else {
+
+        if (-not $Force -and (Test-Path -LiteralPath $outputPath -PathType Leaf)) {
+            if (-not $manifest -or [string]$manifest.State -ne 'Finalizing') {
+                throw "Path '$outputPath' already exists. Use -Force to replace it."
+            }
+
+            $summary = $manifest.Summary
+            $hasPublishMetadata =
+                $summary -and
+                $null -ne $summary.FileBytes -and
+                -not [string]::IsNullOrWhiteSpace([string]$summary.FileSha256)
+            $publishedFile = Get-Item -LiteralPath $outputPath -ErrorAction Stop
+            $publishedFileIsValid = $hasPublishMetadata -and $publishedFile.Length -eq [long]$summary.FileBytes
+            if ($publishedFileIsValid) {
+                $publishedHash = (Get-FileHash -LiteralPath $outputPath -Algorithm SHA256).Hash.ToLowerInvariant()
+                $publishedFileIsValid = $publishedHash -eq [string]$summary.FileSha256
+            }
+            if (-not $publishedFileIsValid) {
+                throw "Finalizing manifest '$manifestPath' does not validate the published file. Use -Force to replace it."
+            }
+
+            $partsRetained = $false
+            if (Test-Path -LiteralPath $partsPath) {
+                try {
+                    Remove-Item -LiteralPath $partsPath -Recurse -Force -ErrorAction Stop
+                }
+                catch {
+                    $partsRetained = $true
+                    Write-Warning "The published export was recovered, but temporary part files could not be removed from '$partsPath': $($_.Exception.Message)"
+                }
+            }
+            $operationStopwatch.Stop()
+            $manifest.State = 'Complete'
+            $manifest.Summary.PartsRetained = $partsRetained
+            $manifest.Summary.CompletedUtc = [datetime]::UtcNow.ToString('o')
+            & $writeManifest $manifest $manifestPath $manifestPartialPath
+
+            Write-Information "Recovered the completed endpoint timeline export at '$outputPath'." -InformationAction Continue
+            return [PSCustomObject]@{
+                OutputPath              = $outputPath
+                ManifestPath            = $manifestPath
+                TotalEvents             = [long]$summary.EventCount
+                TotalPages              = [long]$summary.PageCount
+                TotalRetries            = [long]$summary.RetryCount
+                TotalChunkRestarts      = [long]$summary.ChunkRestartCount
+                TotalChunks             = @($manifest.Chunks).Count
+                ResumedChunks           = [long]$summary.ResumedChunkCount
+                FileBytes               = [long]$summary.FileBytes
+                FileSha256              = [string]$summary.FileSha256
+                MissingTimestampCount   = [long]$summary.MissingTimestampCount
+                BoundaryTimestampCount  = [long]$summary.BoundaryTimestampCount
+                MergeSeconds            = [double]$summary.MergeSeconds
+                ElapsedSeconds          = [double]$manifest.Summary.ElapsedSeconds
+                TemporaryPartsRetained  = $partsRetained
+            }
+        }
+
+        if (Test-Path -LiteralPath $manifestPartialPath) {
+            Remove-Item -LiteralPath $manifestPartialPath -Force -ErrorAction SilentlyContinue
+        }
+        if (Test-Path -LiteralPath $outputPartialPath) {
+            Remove-Item -LiteralPath $outputPartialPath -Force -ErrorAction SilentlyContinue
+        }
+
+        if (-not $manifest) {
             $plannedChunks = @(New-XdrEndpointTimelineExportChunk -FromDate $rangeStart -ToDate $rangeEnd -ChunkHours $chunkHours)
             $manifestChunks = @(
                 foreach ($plannedChunk in $plannedChunks) {
@@ -246,6 +301,9 @@
                     $manifestChunk.AttemptCount = 0
                     $manifestChunk.FileBytes = 0L
                     $manifestChunk.FileSha256 = $null
+                    $manifestChunk.MissingTimestampCount = 0L
+                    $manifestChunk.BoundaryTimestampCount = 0L
+                    $manifestChunk.ElapsedSeconds = 0.0
                     $manifestChunk.Error = 'Previously completed part failed resume validation and was scheduled again.'
                 }
             }
@@ -550,7 +608,6 @@
         $mergeStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         try {
             $mergeResult = Merge-XdrEndpointTimelineNdjsonPart -Part $orderedParts -DestinationPath $outputPartialPath
-            [System.IO.File]::Move($outputPartialPath, $outputPath, $false)
         }
         catch {
             if (Test-Path -LiteralPath $outputPartialPath) {
@@ -565,22 +622,11 @@
             $mergeStopwatch.Stop()
         }
 
-        $partsRetained = $false
-        try {
-            Remove-Item -LiteralPath $partsPath -Recurse -Force -ErrorAction Stop
-        }
-        catch {
-            $partsRetained = $true
-            Write-Warning "The export completed, but temporary part files could not be removed from '$partsPath': $($_.Exception.Message)"
-        }
-
-        $operationStopwatch.Stop()
         $totalPages = [long](($manifest.Chunks | ForEach-Object { [long]$_.PageCount } | Measure-Object -Sum).Sum)
         $totalRetries = [long](($manifest.Chunks | ForEach-Object { [long]$_.RetryCount } | Measure-Object -Sum).Sum)
         $totalChunkRestarts = [long](($manifest.Chunks | ForEach-Object { [long]$_.AttemptCount } | Measure-Object -Sum).Sum)
         $missingTimestampCount = [long](($manifest.Chunks | ForEach-Object { [long]$_.MissingTimestampCount } | Measure-Object -Sum).Sum)
         $boundaryTimestampCount = [long](($manifest.Chunks | ForEach-Object { [long]$_.BoundaryTimestampCount } | Measure-Object -Sum).Sum)
-        $manifest.State = 'Complete'
         $manifest.Summary = [ordered]@{
             OutputPath              = $outputPath
             EventCount              = [long]$mergeResult.EventCount
@@ -592,11 +638,35 @@
             MissingTimestampCount   = $missingTimestampCount
             BoundaryTimestampCount  = $boundaryTimestampCount
             ResumedChunkCount       = $resumedChunkCount
-            PartsRetained           = $partsRetained
+            PartsRetained           = $true
             MergeSeconds            = [math]::Round($mergeStopwatch.Elapsed.TotalSeconds, 3)
             ElapsedSeconds          = [math]::Round($operationStopwatch.Elapsed.TotalSeconds, 3)
-            CompletedUtc            = [datetime]::UtcNow.ToString('o')
+            CompletedUtc            = $null
         }
+        & $writeManifest $manifest $manifestPath $manifestPartialPath
+
+        try {
+            [System.IO.File]::Move($outputPartialPath, $outputPath, $replaceExistingOutput)
+        }
+        catch {
+            throw "The endpoint timeline was validated but could not be published to '$outputPath'. Running the same command again can retry finalization. $($_.Exception.Message)"
+        }
+
+        $operationStopwatch.Stop()
+        $manifest.State = 'Complete'
+        $manifest.Summary.CompletedUtc = [datetime]::UtcNow.ToString('o')
+        $manifest.Summary.ElapsedSeconds = [math]::Round($operationStopwatch.Elapsed.TotalSeconds, 3)
+        & $writeManifest $manifest $manifestPath $manifestPartialPath
+
+        $partsRetained = $false
+        try {
+            Remove-Item -LiteralPath $partsPath -Recurse -Force -ErrorAction Stop
+        }
+        catch {
+            $partsRetained = $true
+            Write-Warning "The export completed, but temporary part files could not be removed from '$partsPath': $($_.Exception.Message)"
+        }
+        $manifest.Summary.PartsRetained = $partsRetained
         & $writeManifest $manifest $manifestPath $manifestPartialPath
 
         Write-Information "Endpoint timeline export complete: $($mergeResult.EventCount) events, $totalChunkCount windows, $([math]::Round($mergeResult.FileBytes / 1MB, 2)) MiB, elapsed $($operationStopwatch.Elapsed.ToString('c'))." -InformationAction Continue

--- a/XDRInternals/functions/Export-XdrEndpointDeviceTimeline.ps1
+++ b/XDRInternals/functions/Export-XdrEndpointDeviceTimeline.ps1
@@ -426,6 +426,7 @@
                         }
                     }
                     catch {
+                        $workerError = "Chunk $($job.Chunk.Index) worker failed before returning a structured result."
                         $result = [PSCustomObject]@{
                             Success                = $false
                             ChunkIndex             = [int]$job.Chunk.Index
@@ -437,7 +438,7 @@
                             BoundaryTimestampCount = 0L
                             ElapsedSeconds         = 0.0
                             RetryCount             = 0
-                            Error                  = $_.ToString()
+                            Error                  = $workerError
                             FailureClass           = 'WorkerFailure'
                         }
                     }
@@ -556,9 +557,10 @@
 
         if ($capturedError) {
             $manifest.State = 'Failed'
-            $manifest.Summary = [ordered]@{ Error = $capturedError.ToString() }
+            $capturedErrorMessage = 'Endpoint timeline export failed before completion.'
+            $manifest.Summary = [ordered]@{ Error = $capturedErrorMessage }
             & $writeManifest $manifest $manifestPath $manifestPartialPath
-            throw $capturedError
+            throw $capturedErrorMessage
         }
 
         if ($failureResults.Count -gt 0) {

--- a/XDRInternals/functions/Export-XdrEndpointDeviceTimeline.ps1
+++ b/XDRInternals/functions/Export-XdrEndpointDeviceTimeline.ps1
@@ -143,10 +143,10 @@
         }
 
         $chunkHours = 4
-        $pageSize = 250
-        # The portal API starts returning incomplete cursor chains under concurrent pagination.
-        # A single background worker preserves heartbeat responsiveness and data reliability.
-        $throttleLimit = 1
+        # Larger pages reduce request pressure enough for bounded parallel pagination to
+        # remain reliable while materially improving incident-response export speed.
+        $pageSize = 1000
+        $throttleLimit = 4
         $requestTimeoutSeconds = 120
         $maxRetries = 5
         $maxChunkRestarts = 2

--- a/XDRInternals/internal/functions/Merge-XdrEndpointTimelineNdjsonPart.ps1
+++ b/XDRInternals/internal/functions/Merge-XdrEndpointTimelineNdjsonPart.ps1
@@ -1,0 +1,111 @@
+﻿function Merge-XdrEndpointTimelineNdjsonPart {
+    <#
+    .SYNOPSIS
+        Concatenates validated endpoint timeline NDJSON part files.
+
+    .DESCRIPTION
+        Copies part files into one destination without parsing JSON. Each part hash is
+        verified while it is copied, and the final SHA-256 hash is calculated in the same pass.
+
+    .PARAMETER Part
+        Ordered part metadata containing FilePath, FileSha256, and EventCount.
+
+    .PARAMETER DestinationPath
+        Path to create. The destination must not already exist.
+
+    .EXAMPLE
+        Merge-XdrEndpointTimelineNdjsonPart -Part $parts -DestinationPath $partialPath
+        Creates and hashes the combined NDJSON file.
+    #>
+    [OutputType([PSCustomObject])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [object[]]$Part,
+
+        [Parameter(Mandatory)]
+        [string]$DestinationPath
+    )
+
+    if (Test-Path -LiteralPath $DestinationPath) {
+        throw "DestinationPath '$DestinationPath' already exists."
+    }
+
+    $destination = $null
+    $outputHasher = $null
+    $hashingDestination = $null
+    $totalEvents = 0L
+
+    try {
+        $destination = [System.IO.FileStream]::new(
+            $DestinationPath,
+            [System.IO.FileMode]::CreateNew,
+            [System.IO.FileAccess]::Write,
+            [System.IO.FileShare]::None,
+            1MB,
+            [System.IO.FileOptions]::SequentialScan
+        )
+        $outputHasher = [System.Security.Cryptography.SHA256]::Create()
+        $hashingDestination = [System.Security.Cryptography.CryptoStream]::new(
+            $destination,
+            $outputHasher,
+            [System.Security.Cryptography.CryptoStreamMode]::Write,
+            $true
+        )
+
+        foreach ($partItem in $Part) {
+            $source = $null
+            $partHasher = $null
+            $hashingSource = $null
+            try {
+                $source = [System.IO.FileStream]::new(
+                    [string]$partItem.FilePath,
+                    [System.IO.FileMode]::Open,
+                    [System.IO.FileAccess]::Read,
+                    [System.IO.FileShare]::Read,
+                    1MB,
+                    [System.IO.FileOptions]::SequentialScan
+                )
+                $partHasher = [System.Security.Cryptography.SHA256]::Create()
+                $hashingSource = [System.Security.Cryptography.CryptoStream]::new(
+                    $source,
+                    $partHasher,
+                    [System.Security.Cryptography.CryptoStreamMode]::Read,
+                    $true
+                )
+                $hashingSource.CopyTo($hashingDestination, 1MB)
+            }
+            finally {
+                if ($hashingSource) { $hashingSource.Dispose() }
+                if ($source) { $source.Dispose() }
+            }
+
+            $actualPartHash = [Convert]::ToHexString($partHasher.Hash).ToLowerInvariant()
+            $partHasher.Dispose()
+            if ($actualPartHash -ne [string]$partItem.FileSha256) {
+                throw "Endpoint timeline part '$($partItem.FilePath)' failed SHA-256 validation."
+            }
+
+            $totalEvents += [long]$partItem.EventCount
+        }
+
+        $hashingDestination.FlushFinalBlock()
+        $hashingDestination.Dispose()
+        $hashingDestination = $null
+        $destination.Flush($true)
+        $destination.Dispose()
+        $destination = $null
+
+        return [PSCustomObject]@{
+            FilePath    = $DestinationPath
+            FileSha256 = [Convert]::ToHexString($outputHasher.Hash).ToLowerInvariant()
+            FileBytes   = (Get-Item -LiteralPath $DestinationPath).Length
+            EventCount = $totalEvents
+        }
+    }
+    finally {
+        if ($hashingDestination) { $hashingDestination.Dispose() }
+        if ($outputHasher) { $outputHasher.Dispose() }
+        if ($destination) { $destination.Dispose() }
+    }
+}

--- a/XDRInternals/internal/functions/New-XdrEndpointTimelineExportChunk.ps1
+++ b/XDRInternals/internal/functions/New-XdrEndpointTimelineExportChunk.ps1
@@ -1,0 +1,67 @@
+﻿function New-XdrEndpointTimelineExportChunk {
+    <#
+    .SYNOPSIS
+        Creates newest-first time chunks for an endpoint timeline export.
+
+    .DESCRIPTION
+        Creates adjacent, non-overlapping UTC intervals. Chunks are ordered newest first
+        so concatenating their API-ordered NDJSON files preserves descending time windows.
+
+    .PARAMETER FromDate
+        Inclusive start of the export range.
+
+    .PARAMETER ToDate
+        Exclusive end of the export range.
+
+    .PARAMETER ChunkHours
+        Size of each chunk in hours.
+
+    .EXAMPLE
+        New-XdrEndpointTimelineExportChunk -FromDate $from -ToDate $to -ChunkHours 4
+        Creates four-hour export chunks.
+    #>
+    [OutputType([PSCustomObject[]])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Private planner that only returns in-memory chunk descriptors.')]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [datetime]$FromDate,
+
+        [Parameter(Mandatory)]
+        [datetime]$ToDate,
+
+        [Parameter()]
+        [ValidateRange(1, 24)]
+        [int]$ChunkHours = 4
+    )
+
+    $rangeStart = $FromDate.ToUniversalTime()
+    $rangeEnd = $ToDate.ToUniversalTime()
+    if ($rangeStart -ge $rangeEnd) {
+        throw 'FromDate must be before ToDate.'
+    }
+
+    $chunks = [System.Collections.Generic.List[object]]::new()
+    $chunkEnd = $rangeEnd
+    $index = 0
+
+    while ($chunkEnd -gt $rangeStart) {
+        $chunkStart = $chunkEnd.AddHours(-$ChunkHours)
+        if ($chunkStart -lt $rangeStart) {
+            $chunkStart = $rangeStart
+        }
+
+        $chunks.Add([PSCustomObject]@{
+                Index         = $index
+                FromDate      = $chunkStart
+                ToDate        = $chunkEnd
+                DurationTicks = ($chunkEnd - $chunkStart).Ticks
+                FileName      = ('chunk_{0:D4}_{1:yyyyMMddTHHmmssfffZ}_{2:yyyyMMddTHHmmssfffZ}.ndjson' -f $index, $chunkStart, $chunkEnd)
+            })
+
+        $index++
+        $chunkEnd = $chunkStart
+    }
+
+    return [PSCustomObject[]]$chunks.ToArray()
+}

--- a/XDRInternals/internal/functions/New-XdrEndpointTimelineExportWorker.ps1
+++ b/XDRInternals/internal/functions/New-XdrEndpointTimelineExportWorker.ps1
@@ -1,0 +1,284 @@
+﻿function New-XdrEndpointTimelineExportWorker {
+    <#
+    .SYNOPSIS
+        Creates the self-contained endpoint timeline export worker.
+
+    .DESCRIPTION
+        Returns a scriptblock that downloads one bounded timeline interval, follows only
+        Prev continuation links, and writes UTF-8 NDJSON with an in-flight SHA-256 hash.
+
+    .EXAMPLE
+        $worker = New-XdrEndpointTimelineExportWorker
+        Creates the worker used by Export-XdrEndpointDeviceTimeline.
+    #>
+    [OutputType([scriptblock])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Private factory that only returns a worker scriptblock.')]
+    [CmdletBinding()]
+    param ()
+
+    return {
+        param($chunk, $sharedParameters, $statusMap)
+
+        $chunkIndex = [int]$chunk.Index
+        $chunkFromDate = ([datetime]$chunk.FromDate).ToUniversalTime()
+        $chunkToDate = ([datetime]$chunk.ToDate).ToUniversalTime()
+        $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+        $partialPath = "$filePath.partial"
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $fileStream = $null
+        $fileHasher = $null
+        $hashingStream = $null
+        $writer = $null
+        $eventCount = 0L
+        $pageCount = 0
+        $retryCount = 0
+        $missingTimestampCount = 0L
+        $boundaryTimestampCount = 0L
+        $failureClass = 'Protocol'
+
+        try {
+            if (Test-Path -LiteralPath $partialPath) {
+                Remove-Item -LiteralPath $partialPath -Force
+            }
+
+            $webSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            foreach ($cookieInfo in $sharedParameters.CookieData) {
+                $cookie = [System.Net.Cookie]::new(
+                    [string]$cookieInfo.Name,
+                    [string]$cookieInfo.Value,
+                    [string]$cookieInfo.Path,
+                    [string]$cookieInfo.Domain
+                )
+                $webSession.Cookies.Add($cookie)
+            }
+
+            $queryParameters = @(
+                'generateIdentityEvents=true'
+                'includeIdentityEvents=true'
+                'supportMdiOnlyEvents=true'
+                "fromDate=$([System.Uri]::EscapeDataString($chunkFromDate.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')))"
+                "toDate=$([System.Uri]::EscapeDataString($chunkToDate.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')))"
+                "correlationId=$([guid]::NewGuid())"
+                'doNotUseCache=false'
+                'forceUseCache=false'
+                "pageSize=$($sharedParameters.PageSize)"
+                "includeSentinelEvents=$($sharedParameters.IncludeSentinelEvents.ToString().ToLowerInvariant())"
+            )
+            $requestUri = "$($sharedParameters.BaseUrl)/apiproxy/mtp/mdeTimelineExperience/machines/$($sharedParameters.DeviceId)/events/?$($queryParameters -join '&')"
+            $seenUris = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+
+            $fileStream = [System.IO.FileStream]::new(
+                $partialPath,
+                [System.IO.FileMode]::CreateNew,
+                [System.IO.FileAccess]::Write,
+                [System.IO.FileShare]::None,
+                1MB,
+                [System.IO.FileOptions]::SequentialScan
+            )
+            $fileHasher = [System.Security.Cryptography.SHA256]::Create()
+            $hashingStream = [System.Security.Cryptography.CryptoStream]::new(
+                $fileStream,
+                $fileHasher,
+                [System.Security.Cryptography.CryptoStreamMode]::Write,
+                $true
+            )
+            $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+            $writer = [System.IO.StreamWriter]::new($hashingStream, $utf8NoBom, 1MB, $true)
+            $writer.NewLine = "`n"
+
+            while ($requestUri) {
+                if (-not $seenUris.Add($requestUri)) {
+                    throw "Chunk $chunkIndex encountered a repeated pagination URI."
+                }
+                if ($pageCount -ge [int]$sharedParameters.MaxPagesPerChunk) {
+                    throw "Chunk $chunkIndex exceeded the internal page limit of $($sharedParameters.MaxPagesPerChunk)."
+                }
+
+                $response = $null
+                $partialResponseAttempts = 2
+                for ($attempt = 1; $attempt -le [int]$sharedParameters.MaxRetries; $attempt++) {
+                    try {
+                        $response = Invoke-RestMethod -Uri $requestUri -ContentType 'application/json' -WebSession $webSession -Headers $sharedParameters.HeadersData -TimeoutSec $sharedParameters.RequestTimeoutSeconds -ErrorAction Stop
+                        $partialReasons = @($response.PartialResponseReasons | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })
+                        if ($partialReasons.Count -gt 0) {
+                            if ($attempt -ge $partialResponseAttempts -or $attempt -eq [int]$sharedParameters.MaxRetries) {
+                                $failureClass = 'PartialResponse'
+                                throw "Chunk $chunkIndex received a partial API response after $attempt attempt(s): $($partialReasons -join '; ')"
+                            }
+                            $retryCount++
+                            $delaySeconds = [math]::Min(30, [math]::Pow(2, $attempt - 1) + (Get-Random -Minimum 0 -Maximum 3))
+                            Start-Sleep -Seconds $delaySeconds
+                            $response = $null
+                            continue
+                        }
+                        $failureClass = 'Protocol'
+                        break
+                    }
+                    catch {
+                        $statusCode = $null
+                        if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+                            $statusCode = [int]$_.Exception.Response.StatusCode
+                        }
+                        if ($failureClass -eq 'PartialResponse') {
+                            throw
+                        }
+
+                        $isTransient = $null -eq $statusCode -or $statusCode -in @(408, 429, 500, 502, 503, 504)
+                        if (-not $isTransient -or $attempt -eq [int]$sharedParameters.MaxRetries) {
+                            $failureClass = if ($statusCode -in @(401, 403)) {
+                                'Authentication'
+                            }
+                            elseif ($isTransient -and $null -eq $statusCode) {
+                                'Transport'
+                            }
+                            elseif ($isTransient) {
+                                'TransientHttp'
+                            }
+                            else {
+                                'PermanentHttp'
+                            }
+                            throw
+                        }
+
+                        $retryCount++
+                        $delaySeconds = [math]::Min(30, [math]::Pow(2, $attempt - 1) + (Get-Random -Minimum 0 -Maximum 3))
+                        Start-Sleep -Seconds $delaySeconds
+                    }
+                }
+
+                $pageCount++
+
+                foreach ($eventItem in @($response.Items)) {
+                    $timestampValue = if ($eventItem.ActionTimeIsoString) { $eventItem.ActionTimeIsoString } else { $eventItem.ActionTime }
+                    $timestampParsed = $false
+                    $utcTimestamp = [datetime]::MinValue
+                    if ($timestampValue -is [datetime]) {
+                        $utcTimestamp = ([datetime]$timestampValue).ToUniversalTime()
+                        $timestampParsed = $true
+                    }
+                    elseif ($timestampValue -is [datetimeoffset]) {
+                        $utcTimestamp = ([datetimeoffset]$timestampValue).UtcDateTime
+                        $timestampParsed = $true
+                    }
+                    else {
+                        $parsedTimestamp = [datetimeoffset]::MinValue
+                        $dateStyles = [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+                        $timestampParsed = $timestampValue -and [datetimeoffset]::TryParse(
+                            [string]$timestampValue,
+                            [System.Globalization.CultureInfo]::InvariantCulture,
+                            $dateStyles,
+                            [ref]$parsedTimestamp
+                        )
+                        if ($timestampParsed) {
+                            $utcTimestamp = $parsedTimestamp.UtcDateTime
+                        }
+                    }
+
+                    if (-not $timestampParsed) {
+                        $missingTimestampCount++
+                        throw "Chunk $chunkIndex received an event without a parseable timestamp."
+                    }
+                    if ($utcTimestamp -lt $chunkFromDate -or $utcTimestamp -gt $chunkToDate) {
+                        throw "Chunk $chunkIndex received an event outside its requested interval: $($utcTimestamp.ToString('o'))."
+                    }
+                    if ($utcTimestamp -eq $chunkFromDate -or $utcTimestamp -eq $chunkToDate) {
+                        $boundaryTimestampCount++
+                    }
+                    if ($utcTimestamp -eq $chunkToDate) {
+                        continue
+                    }
+
+                    $writer.WriteLine(($eventItem | ConvertTo-Json -Depth 100 -Compress))
+                    $eventCount++
+                }
+
+                $statusMap[$chunkIndex] = [PSCustomObject]@{
+                    Pages      = $pageCount
+                    Events     = $eventCount
+                    Bytes      = $fileStream.Position
+                    UpdatedUtc = [datetime]::UtcNow
+                }
+
+                if ([string]::IsNullOrWhiteSpace([string]$response.Prev)) {
+                    $requestUri = $null
+                }
+                else {
+                    $continuationUri = "$($sharedParameters.BaseUrl)/apiproxy/mtp/mdeTimelineExperience$($response.Prev)"
+                    $parsedContinuationUri = [uri]$continuationUri
+                    if ($parsedContinuationUri.Host -ne ([uri]$sharedParameters.BaseUrl).Host -or
+                        -not $parsedContinuationUri.AbsolutePath.StartsWith('/apiproxy/mtp/mdeTimelineExperience/', [System.StringComparison]::Ordinal)) {
+                        throw "Chunk $chunkIndex received an invalid pagination URI."
+                    }
+                    $requestUri = $continuationUri
+                }
+
+                $response = $null
+            }
+
+            $writer.Flush()
+            $writer.Dispose()
+            $writer = $null
+            $hashingStream.FlushFinalBlock()
+            $hashingStream.Dispose()
+            $hashingStream = $null
+            $fileStream.Flush($true)
+            $fileStream.Dispose()
+            $fileStream = $null
+
+            $fileSha256 = [Convert]::ToHexString($fileHasher.Hash).ToLowerInvariant()
+            $fileHasher.Dispose()
+            $fileHasher = $null
+            [System.IO.File]::Move($partialPath, $filePath, $true)
+            $stopwatch.Stop()
+
+            return [PSCustomObject]@{
+                Success                = $true
+                ChunkIndex             = $chunkIndex
+                FromDate               = $chunkFromDate
+                ToDate                 = $chunkToDate
+                FilePath               = $filePath
+                FileSha256             = $fileSha256
+                FileBytes              = (Get-Item -LiteralPath $filePath).Length
+                EventCount             = $eventCount
+                PageCount              = $pageCount
+                RetryCount             = $retryCount
+                MissingTimestampCount  = $missingTimestampCount
+                BoundaryTimestampCount = $boundaryTimestampCount
+                ElapsedSeconds         = [math]::Round($stopwatch.Elapsed.TotalSeconds, 3)
+                Error                  = $null
+                FailureClass           = $null
+            }
+        }
+        catch {
+            $errorText = $_.ToString()
+            $stopwatch.Stop()
+            return [PSCustomObject]@{
+                Success                = $false
+                ChunkIndex             = $chunkIndex
+                FromDate               = $chunkFromDate
+                ToDate                 = $chunkToDate
+                FilePath               = $filePath
+                FileSha256             = $null
+                FileBytes              = 0L
+                EventCount             = $eventCount
+                PageCount              = $pageCount
+                RetryCount             = $retryCount
+                MissingTimestampCount  = $missingTimestampCount
+                BoundaryTimestampCount = $boundaryTimestampCount
+                ElapsedSeconds         = [math]::Round($stopwatch.Elapsed.TotalSeconds, 3)
+                Error                  = $errorText
+                FailureClass           = $failureClass
+            }
+        }
+        finally {
+            if ($writer) { $writer.Dispose() }
+            if ($hashingStream) { $hashingStream.Dispose() }
+            if ($fileHasher) { $fileHasher.Dispose() }
+            if ($fileStream) { $fileStream.Dispose() }
+            if (Test-Path -LiteralPath $partialPath) {
+                Remove-Item -LiteralPath $partialPath -Force -ErrorAction SilentlyContinue
+            }
+            [void]$statusMap.TryRemove($chunkIndex, [ref]$null)
+        }
+    }
+}

--- a/XDRInternals/internal/functions/New-XdrEndpointTimelineExportWorker.ps1
+++ b/XDRInternals/internal/functions/New-XdrEndpointTimelineExportWorker.ps1
@@ -201,6 +201,7 @@
 
                 $pageCount++
 
+                $oldestPageTimestampUtc = $null
                 foreach ($eventItem in @($response.Items)) {
                     $timestampValue = if ($eventItem.ActionTimeIsoString) { $eventItem.ActionTimeIsoString } else { $eventItem.ActionTime }
                     $timestampParsed = $false
@@ -238,6 +239,7 @@
                         throw "Chunk $chunkIndex received events that were not in newest-first order: $($utcTimestamp.ToString('o')) followed $($previousTimestampUtc.ToString('o'))."
                     }
                     $previousTimestampUtc = $utcTimestamp
+                    $oldestPageTimestampUtc = $utcTimestamp
                     if ($utcTimestamp -eq $chunkFromDate -or $utcTimestamp -eq $chunkToDate) {
                         $boundaryTimestampCount++
                     }
@@ -284,6 +286,7 @@
                     $previousQuery = if ($querySeparator -ge 0) { $previousReference.Substring($querySeparator + 1) } else { '' }
                     $queryParts = @($previousQuery -split '&')
                     $queryKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                    $queryValues = [System.Collections.Generic.Dictionary[string, string]]::new([System.StringComparer]::OrdinalIgnoreCase)
                     $queryIsValid = -not [string]::IsNullOrWhiteSpace($previousQuery) -and $previousQuery -notmatch '%(?![0-9A-Fa-f]{2})'
                     foreach ($queryPart in $queryParts) {
                         if ($queryPart -notmatch '^(?<Key>[A-Za-z][A-Za-z0-9._-]*)=.+$' -or
@@ -292,8 +295,61 @@
                             $queryIsValid = $false
                             break
                         }
+                        try {
+                            $queryValues[$Matches.Key] = [System.Uri]::UnescapeDataString(
+                                $queryPart.Substring($queryPart.IndexOf('=') + 1)
+                            )
+                        }
+                        catch {
+                            $queryIsValid = $false
+                            break
+                        }
                     }
                     if ($queryKeys.Count -ne $expectedQueryKeys.Count) {
+                        $queryIsValid = $false
+                    }
+
+                    $expectedStaticValues = @{
+                        generateIdentityEvents = 'true'
+                        includeIdentityEvents  = 'true'
+                        supportMdiOnlyEvents   = 'true'
+                        doNotUseCache          = 'false'
+                        forceUseCache          = 'false'
+                        pageSize               = [string]$sharedParameters.PageSize
+                        includeSentinelEvents  = $sharedParameters.IncludeSentinelEvents.ToString().ToLowerInvariant()
+                        IsScrollingForward     = 'false'
+                    }
+                    foreach ($expectedValue in $expectedStaticValues.GetEnumerator()) {
+                        if (-not $queryValues.ContainsKey($expectedValue.Key) -or
+                            -not $queryValues[$expectedValue.Key].Equals([string]$expectedValue.Value, [System.StringComparison]::OrdinalIgnoreCase)) {
+                            $queryIsValid = $false
+                            break
+                        }
+                    }
+
+                    $continuationFromUtc = [datetimeoffset]::MinValue
+                    $continuationToUtc = [datetimeoffset]::MinValue
+                    $continuationDateStyles = [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+                    $fromDateIsValid = $queryValues.ContainsKey('fromDate') -and [datetimeoffset]::TryParse(
+                        $queryValues['fromDate'],
+                        [System.Globalization.CultureInfo]::InvariantCulture,
+                        $continuationDateStyles,
+                        [ref]$continuationFromUtc
+                    ) -and $continuationFromUtc.UtcDateTime -eq $chunkFromDate
+                    $toDateIsValid = $queryValues.ContainsKey('toDate') -and [datetimeoffset]::TryParse(
+                        $queryValues['toDate'],
+                        [System.Globalization.CultureInfo]::InvariantCulture,
+                        $continuationDateStyles,
+                        [ref]$continuationToUtc
+                    ) -and $continuationToUtc.UtcDateTime -ge $chunkFromDate -and
+                        $continuationToUtc.UtcDateTime -lt $chunkToDate
+                    if ($toDateIsValid -and $null -ne $oldestPageTimestampUtc) {
+                        $toDateIsValid = $oldestPageTimestampUtc -gt [datetime]::MinValue -and
+                            $continuationToUtc.UtcDateTime -eq $oldestPageTimestampUtc.AddTicks(-1)
+                    }
+                    $reportIdIsValid = $queryValues.ContainsKey('ReportIdForScrolling') -and
+                        -not [string]::IsNullOrWhiteSpace($queryValues['ReportIdForScrolling'])
+                    if (-not $fromDateIsValid -or -not $toDateIsValid -or -not $reportIdIsValid) {
                         $queryIsValid = $false
                     }
 

--- a/XDRInternals/internal/functions/New-XdrEndpointTimelineExportWorker.ps1
+++ b/XDRInternals/internal/functions/New-XdrEndpointTimelineExportWorker.ps1
@@ -36,6 +36,7 @@
         $boundaryTimestampCount = 0L
         $previousTimestampUtc = $null
         $failureClass = 'Protocol'
+        $failureMessage = $null
 
         try {
             if (Test-Path -LiteralPath $partialPath) {
@@ -67,6 +68,7 @@
             )
             $requestUri = "$($sharedParameters.BaseUrl)/apiproxy/mtp/mdeTimelineExperience/machines/$($sharedParameters.DeviceId)/events/?$($queryParameters -join '&')"
             $seenUris = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+            $currentRequestToUtc = $chunkToDate
 
             $fileStream = [System.IO.FileStream]::new(
                 $partialPath,
@@ -104,7 +106,8 @@
                         if ($partialReasons.Count -gt 0) {
                             if ($attempt -ge $partialResponseAttempts -or $attempt -eq [int]$sharedParameters.MaxRetries) {
                                 $failureClass = 'PartialResponse'
-                                throw "Chunk $chunkIndex received a partial API response after $attempt attempt(s): $($partialReasons -join '; ')"
+                                $failureMessage = "Chunk $chunkIndex received a partial API response after $attempt attempt(s)."
+                                throw $failureMessage
                             }
                             $retryCount++
                             $delaySeconds = [math]::Min(30, [math]::Pow(2, $attempt - 1) + (Get-Random -Minimum 0 -Maximum 3))
@@ -139,6 +142,7 @@
                         }
                         if ($isMalformedJson) {
                             $failureClass = 'Protocol'
+                            $failureMessage = "Chunk $chunkIndex received malformed JSON from the endpoint timeline API."
                             throw
                         }
 
@@ -176,6 +180,13 @@
                             }
                             else {
                                 'PermanentHttp'
+                            }
+                            $failureMessage = switch ($failureClass) {
+                                'Authentication' { "Chunk $chunkIndex endpoint timeline authentication failed (HTTP $statusCode)." }
+                                'PermanentHttp' { "Chunk $chunkIndex endpoint timeline request failed permanently (HTTP $statusCode)." }
+                                'TransientHttp' { "Chunk $chunkIndex endpoint timeline request failed after $attempt attempt(s) (HTTP $statusCode)." }
+                                'Transport' { "Chunk $chunkIndex endpoint timeline transport failed after $attempt attempt(s)." }
+                                default { "Chunk $chunkIndex endpoint timeline request failed with a protocol error." }
                             }
                             throw
                         }
@@ -336,16 +347,23 @@
                         $continuationDateStyles,
                         [ref]$continuationFromUtc
                     ) -and $continuationFromUtc.UtcDateTime -eq $chunkFromDate
-                    $toDateIsValid = $queryValues.ContainsKey('toDate') -and [datetimeoffset]::TryParse(
+                    $toDateWasParsed = $queryValues.ContainsKey('toDate') -and [datetimeoffset]::TryParse(
                         $queryValues['toDate'],
                         [System.Globalization.CultureInfo]::InvariantCulture,
                         $continuationDateStyles,
                         [ref]$continuationToUtc
-                    ) -and $continuationToUtc.UtcDateTime -ge $chunkFromDate -and
-                        $continuationToUtc.UtcDateTime -lt $chunkToDate
-                    if ($toDateIsValid -and $null -ne $oldestPageTimestampUtc) {
-                        $toDateIsValid = $oldestPageTimestampUtc -gt [datetime]::MinValue -and
-                            $continuationToUtc.UtcDateTime -eq $oldestPageTimestampUtc.AddTicks(-1)
+                    )
+                    $toDateIsValid = $toDateWasParsed -and
+                        $continuationToUtc.UtcDateTime -lt $chunkToDate -and
+                        $continuationToUtc.UtcDateTime -le $currentRequestToUtc
+                    if ($toDateIsValid) {
+                        if ($null -ne $oldestPageTimestampUtc) {
+                            $toDateIsValid = $oldestPageTimestampUtc -gt [datetime]::MinValue -and
+                                $continuationToUtc.UtcDateTime -eq $oldestPageTimestampUtc.AddTicks(-1)
+                        }
+                        else {
+                            $toDateIsValid = $continuationToUtc.UtcDateTime -ge $chunkFromDate
+                        }
                     }
                     $reportIdIsValid = $queryValues.ContainsKey('ReportIdForScrolling') -and
                         -not [string]::IsNullOrWhiteSpace($queryValues['ReportIdForScrolling'])
@@ -363,6 +381,7 @@
                     }
                     $continuationUri = "$($sharedParameters.BaseUrl)/apiproxy/mtp/mdeTimelineExperience$previousReference"
                     $requestUri = $continuationUri
+                    $currentRequestToUtc = $continuationToUtc.UtcDateTime
                 }
 
                 $response = $null
@@ -403,7 +422,23 @@
             }
         }
         catch {
-            $errorText = $_.ToString()
+            $errorText = if (-not [string]::IsNullOrWhiteSpace($failureMessage)) {
+                $failureMessage
+            }
+            elseif ($_.Exception -and -not [string]::IsNullOrWhiteSpace($_.Exception.Message)) {
+                $_.Exception.Message
+            }
+            else {
+                "Chunk $chunkIndex endpoint timeline worker failed."
+            }
+            if (-not [string]::IsNullOrWhiteSpace($requestUri)) {
+                $errorText = $errorText.Replace($requestUri, '[request URI redacted]')
+            }
+            $errorText = [regex]::Replace(
+                $errorText,
+                '(?i)(ReportIdForScrolling=)[^&\s"''<>]+',
+                '$1[redacted]'
+            )
             $stopwatch.Stop()
             return [PSCustomObject]@{
                 Success                = $false

--- a/XDRInternals/internal/functions/New-XdrEndpointTimelineExportWorker.ps1
+++ b/XDRInternals/internal/functions/New-XdrEndpointTimelineExportWorker.ps1
@@ -124,16 +124,55 @@
                             throw
                         }
 
-                        $isTransient = $null -eq $statusCode -or $statusCode -in @(408, 429, 500, 502, 503, 504)
+                        $exceptionCursor = $_.Exception
+                        $isMalformedJson = $false
+                        while ($exceptionCursor) {
+                            if ($exceptionCursor -is [System.Text.Json.JsonException] -or
+                                $exceptionCursor.GetType().FullName -in @(
+                                    'Newtonsoft.Json.JsonReaderException',
+                                    'Newtonsoft.Json.JsonSerializationException'
+                                )) {
+                                $isMalformedJson = $true
+                                break
+                            }
+                            $exceptionCursor = $exceptionCursor.InnerException
+                        }
+                        if ($isMalformedJson) {
+                            $failureClass = 'Protocol'
+                            throw
+                        }
+
+                        $isTransportFailure = $false
+                        if ($null -eq $statusCode) {
+                            $exceptionCursor = $_.Exception
+                            while ($exceptionCursor) {
+                                if ($exceptionCursor -is [System.Net.Http.HttpRequestException] -or
+                                    $exceptionCursor -is [System.Net.WebException] -or
+                                    $exceptionCursor -is [System.Net.Sockets.SocketException] -or
+                                    $exceptionCursor -is [System.Threading.Tasks.TaskCanceledException] -or
+                                    $exceptionCursor -is [System.TimeoutException]) {
+                                    $isTransportFailure = $true
+                                    break
+                                }
+                                $exceptionCursor = $exceptionCursor.InnerException
+                            }
+                        }
+
+                        $isTransientHttp = $statusCode -in @(408, 429) -or
+                            ($null -ne $statusCode -and $statusCode -ge 500 -and $statusCode -le 599)
+                        $isTransient = $isTransientHttp -or $isTransportFailure
                         if (-not $isTransient -or $attempt -eq [int]$sharedParameters.MaxRetries) {
                             $failureClass = if ($statusCode -in @(401, 403)) {
                                 'Authentication'
                             }
-                            elseif ($isTransient -and $null -eq $statusCode) {
+                            elseif ($isTransportFailure) {
                                 'Transport'
                             }
                             elseif ($isTransient) {
                                 'TransientHttp'
+                            }
+                            elseif ($null -eq $statusCode) {
+                                'Protocol'
                             }
                             else {
                                 'PermanentHttp'
@@ -142,7 +181,20 @@
                         }
 
                         $retryCount++
-                        $delaySeconds = [math]::Min(30, [math]::Pow(2, $attempt - 1) + (Get-Random -Minimum 0 -Maximum 3))
+                        $delaySeconds = $null
+                        if ($statusCode -eq 429 -and $_.Exception.Response.Headers.RetryAfter) {
+                            $retryAfter = $_.Exception.Response.Headers.RetryAfter
+                            if ($null -ne $retryAfter.Delta) {
+                                $delaySeconds = [math]::Ceiling($retryAfter.Delta.TotalSeconds)
+                            }
+                            elseif ($null -ne $retryAfter.Date) {
+                                $delaySeconds = [math]::Ceiling(($retryAfter.Date.UtcDateTime - [datetime]::UtcNow).TotalSeconds)
+                            }
+                        }
+                        if ($null -eq $delaySeconds) {
+                            $delaySeconds = [math]::Pow(2, $attempt - 1) + (Get-Random -Minimum 0 -Maximum 3)
+                        }
+                        $delaySeconds = [math]::Max(0, [math]::Min(30, $delaySeconds))
                         Start-Sleep -Seconds $delaySeconds
                     }
                 }
@@ -208,12 +260,52 @@
                     $requestUri = $null
                 }
                 else {
-                    $continuationUri = "$($sharedParameters.BaseUrl)/apiproxy/mtp/mdeTimelineExperience$($response.Prev)"
-                    $parsedContinuationUri = [uri]$continuationUri
-                    if ($parsedContinuationUri.Host -ne ([uri]$sharedParameters.BaseUrl).Host -or
-                        -not $parsedContinuationUri.AbsolutePath.StartsWith('/apiproxy/mtp/mdeTimelineExperience/', [System.StringComparison]::Ordinal)) {
+                    $previousReference = [string]$response.Prev
+                    $expectedPath = "/machines/$($sharedParameters.DeviceId)/events"
+                    $expectedQueryKeys = @(
+                        'generateIdentityEvents'
+                        'includeIdentityEvents'
+                        'supportMdiOnlyEvents'
+                        'fromDate'
+                        'toDate'
+                        'doNotUseCache'
+                        'forceUseCache'
+                        'pageSize'
+                        'includeSentinelEvents'
+                        'IsScrollingForward'
+                        'ReportIdForScrolling'
+                    )
+                    $allowedQueryKeys = [System.Collections.Generic.HashSet[string]]::new(
+                        [string[]]$expectedQueryKeys,
+                        [System.StringComparer]::OrdinalIgnoreCase
+                    )
+                    $querySeparator = $previousReference.IndexOf('?')
+                    $previousPath = if ($querySeparator -ge 0) { $previousReference.Substring(0, $querySeparator) } else { $previousReference }
+                    $previousQuery = if ($querySeparator -ge 0) { $previousReference.Substring($querySeparator + 1) } else { '' }
+                    $queryParts = @($previousQuery -split '&')
+                    $queryKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                    $queryIsValid = -not [string]::IsNullOrWhiteSpace($previousQuery) -and $previousQuery -notmatch '%(?![0-9A-Fa-f]{2})'
+                    foreach ($queryPart in $queryParts) {
+                        if ($queryPart -notmatch '^(?<Key>[A-Za-z][A-Za-z0-9._-]*)=.+$' -or
+                            -not $allowedQueryKeys.Contains($Matches.Key) -or
+                            -not $queryKeys.Add($Matches.Key)) {
+                            $queryIsValid = $false
+                            break
+                        }
+                    }
+                    if ($queryKeys.Count -ne $expectedQueryKeys.Count) {
+                        $queryIsValid = $false
+                    }
+
+                    if (-not $previousReference.StartsWith('/', [System.StringComparison]::Ordinal) -or
+                        $previousReference.StartsWith('//', [System.StringComparison]::Ordinal) -or
+                        $previousReference.Contains('#') -or
+                        $previousReference.Contains('\') -or
+                        -not $previousPath.Equals($expectedPath, [System.StringComparison]::OrdinalIgnoreCase) -or
+                        -not $queryIsValid) {
                         throw "Chunk $chunkIndex received an invalid pagination URI."
                     }
+                    $continuationUri = "$($sharedParameters.BaseUrl)/apiproxy/mtp/mdeTimelineExperience$previousReference"
                     $requestUri = $continuationUri
                 }
 

--- a/XDRInternals/internal/functions/New-XdrEndpointTimelineExportWorker.ps1
+++ b/XDRInternals/internal/functions/New-XdrEndpointTimelineExportWorker.ps1
@@ -34,6 +34,7 @@
         $retryCount = 0
         $missingTimestampCount = 0L
         $boundaryTimestampCount = 0L
+        $previousTimestampUtc = $null
         $failureClass = 'Protocol'
 
         try {
@@ -181,6 +182,10 @@
                     if ($utcTimestamp -lt $chunkFromDate -or $utcTimestamp -gt $chunkToDate) {
                         throw "Chunk $chunkIndex received an event outside its requested interval: $($utcTimestamp.ToString('o'))."
                     }
+                    if ($null -ne $previousTimestampUtc -and $utcTimestamp -gt $previousTimestampUtc) {
+                        throw "Chunk $chunkIndex received events that were not in newest-first order: $($utcTimestamp.ToString('o')) followed $($previousTimestampUtc.ToString('o'))."
+                    }
+                    $previousTimestampUtc = $utcTimestamp
                     if ($utcTimestamp -eq $chunkFromDate -or $utcTimestamp -eq $chunkToDate) {
                         $boundaryTimestampCount++
                     }

--- a/docs/export-functions.md
+++ b/docs/export-functions.md
@@ -91,12 +91,16 @@ final merge follows window order.
 Each worker follows only the response's `Prev` continuation reference, regardless of
 page length, and ignores `Next`. Before resolving that reference against the trusted
 Defender base URL, it requires the live-confirmed relative
-`/machines/{deviceId}/events` path and exact continuation query-key set. Absolute or
-network-path URIs, another device or path, fragments, malformed or duplicate query keys,
-empty values, and repeated resolved cursors fail closed. Pagination cannot safely be
-parallelized within one window because later continuation references do not exist until
-earlier pages have been returned. Throughput therefore comes from concurrent independent
-windows.
+`/machines/{deviceId}/events` path and exact continuation query-key set. Identity-event,
+cache, page-size, Sentinel, and scroll-direction values must remain unchanged, and
+`fromDate` must remain the window start. `ReportIdForScrolling` is the only fully opaque
+value. On a nonempty page, the server advances `toDate` to exactly one tick before that
+page's oldest event; an empty-page cursor must still remain inside the requested window.
+Absolute or network-path URIs, another device or path, fragments, malformed or duplicate
+query keys, changed invariant values, empty report IDs, and repeated resolved cursors
+fail closed. Pagination cannot safely be parallelized within one window because later
+continuation references do not exist until earlier pages have been returned. Throughput
+therefore comes from concurrent independent windows.
 
 ## Streaming and memory behavior
 

--- a/docs/export-functions.md
+++ b/docs/export-functions.md
@@ -88,10 +88,15 @@ Windows are scheduled newest first because recent activity is normally the most 
 during an active incident. The service's order within each window is preserved, and the
 final merge follows window order.
 
-Each worker follows only the response's `Prev` continuation URI. It rejects repeated,
-off-host, or unexpected continuation paths. Pagination cannot safely be parallelized
-within one window because later continuation URIs do not exist until earlier pages have
-been returned. Throughput therefore comes from concurrent independent windows.
+Each worker follows only the response's `Prev` continuation reference, regardless of
+page length, and ignores `Next`. Before resolving that reference against the trusted
+Defender base URL, it requires the live-confirmed relative
+`/machines/{deviceId}/events` path and exact continuation query-key set. Absolute or
+network-path URIs, another device or path, fragments, malformed or duplicate query keys,
+empty values, and repeated resolved cursors fail closed. Pagination cannot safely be
+parallelized within one window because later continuation references do not exist until
+earlier pages have been returned. Throughput therefore comes from concurrent independent
+windows.
 
 ## Streaming and memory behavior
 
@@ -119,8 +124,10 @@ until an automatic policy or broadly validated settings can replace manual guess
 
 Recovery occurs at two levels:
 
-- A worker retries transient transport failures, HTTP 408/429/5xx responses, and an
-  initially partial response with bounded exponential backoff and jitter.
+- A worker retries genuine transport failures, HTTP 408/429/5xx responses, and a
+  partial response with bounded exponential backoff and jitter. A valid HTTP
+  429 `Retry-After` delta or date is honored up to 30 seconds; malformed JSON,
+  authentication failures, and permanent HTTP errors are not retried.
 - If a window's continuation context appears poisoned, the coordinator can restart the
   entire window with a fresh correlation ID and request context.
 
@@ -132,7 +139,8 @@ After an interruption, running the same command with the same path validates eac
 completed part by recorded byte length and SHA-256. Valid parts are reused; invalid,
 failed, and in-progress parts are downloaded again. The device ID, time range, Sentinel
 option, window size, and page size must match the manifest. `-Force` deliberately
-discards the output and resumable state.
+discards resumable state and starts a replacement, but an existing published output is
+not replaced unless the new export has been fully validated and atomically published.
 
 ## Correctness and fail-closed behavior
 
@@ -189,6 +197,24 @@ objects, but raw NDJSON is not needed for initial diagnosis. Useful details are:
 Do not silently fall back to a non-Sentinel request when a Sentinel-enabled request is
 empty. An empty response can be legitimate, and fallback would make the file appear
 complete while failing to satisfy the caller's request.
+
+## Follow-up validation evidence
+
+A fixed one-hour UTC export on sanitized device label `known-high-volume-01` traversed
+five live `Prev` pages and published 4,967 lines (18,698,247 bytes) with no retries,
+restarts, warnings, or timestamp diagnostics. The independent line count, file length,
+and SHA-256 matched the completed manifest. The densest live timestamp contained 257
+events, so no equal timestamp crossed a 1,000-record page in that range; the focused
+suite retains a synthetic three-page equal-timestamp proof.
+
+A separate seven-day export was terminated after one part completed. A new authenticated
+process validated and resumed that part, ignored an injected stale partial, and
+atomically published 167,599 lines (1,204,753,184 bytes) with a matching SHA-256 and no
+retries or window restarts.
+
+Sentinel-enabled and disabled probes over the same one-hour range each returned 4,967
+ordinary MDE events. No known Sentinel-backed event was available, so Sentinel-specific
+inclusion remains unproven and behavior was not changed.
 
 ## Why the implementation is not a single download loop
 

--- a/docs/export-functions.md
+++ b/docs/export-functions.md
@@ -1,0 +1,211 @@
+# Timeline export functions
+
+## Purpose
+
+The timeline export cmdlets are designed for large incident-response collections where
+the complete result should not be held in memory. They write newline-delimited JSON
+(NDJSON) to disk and return a compact summary object.
+
+Current and planned coverage:
+
+| Workload | Export cmdlet | Status |
+| --- | --- | --- |
+| Defender for Endpoint device timeline | `Export-XdrEndpointDeviceTimeline` | Implemented |
+| Defender for Identity user timeline | To be determined | Planned |
+| Defender for Cloud Apps activity timeline | To be determined | Planned |
+
+This document describes the common export model and the device implementation. The
+workload-specific sections can be expanded as the identity and Cloud Apps exporters are
+implemented.
+
+## Why `Export-` is separate from `Get-`
+
+`Get-XdrEndpointDeviceTimeline` is intended for smaller queries whose results will be
+used as PowerShell objects. `Export-XdrEndpointDeviceTimeline` is optimized for long
+ranges and bounded resource use:
+
+- it streams records to disk instead of accumulating the timeline in a collection;
+- it downloads independent time windows concurrently;
+- it can resume after process, network, or computer interruption;
+- it does not publish a final file unless every window passes validation;
+- its public parameters intentionally omit unvalidated performance tuning controls.
+
+The public command is small from a caller's perspective. Its internal implementation is
+more involved because it provides concurrency, integrity, and recovery around a portal
+API that was designed for an infinite-scroll user interface rather than bulk export.
+
+## Device timeline export lifecycle
+
+`Export-XdrEndpointDeviceTimeline` performs these stages:
+
+1. Normalize the requested range to UTC and validate the device ID, range, and output
+   path.
+2. Create a new manifest, or load an existing compatible manifest for resume.
+3. Divide the range into adjacent four-hour, newest-first windows.
+4. Validate the length and SHA-256 hash of every previously completed part.
+5. Snapshot the current authenticated session for isolated worker runspaces.
+6. Run up to four windows concurrently. Pagination inside each window remains
+   sequential because every continuation URI comes from the preceding response.
+7. Atomically update the manifest whenever a window completes, restarts, or fails.
+8. Verify and concatenate all parts into a temporary final file, atomically publish the
+   requested path, and remove the parts after success.
+
+The implementation is split across four files:
+
+| File | Responsibility |
+| --- | --- |
+| `XDRInternals/functions/Export-XdrEndpointDeviceTimeline.ps1` | Public validation, manifest state, scheduling, progress, recovery, and finalization |
+| `XDRInternals/internal/functions/New-XdrEndpointTimelineExportChunk.ps1` | Creates adjacent newest-first time windows |
+| `XDRInternals/internal/functions/New-XdrEndpointTimelineExportWorker.ps1` | Downloads and validates one window while streaming NDJSON |
+| `XDRInternals/internal/functions/Merge-XdrEndpointTimelineNdjsonPart.ps1` | Verifies and concatenates completed parts without parsing them again |
+
+## Files and atomic publication
+
+For an output path such as `timeline.ndjson`, an in-progress export can use:
+
+| Path | Purpose |
+| --- | --- |
+| `timeline.ndjson.manifest.json` | Request identity, per-window state, counts, hashes, and final summary |
+| `timeline.ndjson.manifest.json.partial` | Temporary manifest write; renamed over the manifest only after a complete write |
+| `timeline.ndjson.parts/` | Completed per-window NDJSON files |
+| `timeline.ndjson.parts/*.partial` | A worker's current incomplete file; never accepted for resume |
+| `timeline.ndjson.partial` | Verified merged output before final publication |
+| `timeline.ndjson` | Final export; created only after every window succeeds |
+
+The temporary names prevent a terminated process from making an incomplete file look
+complete. A successful export retains the final NDJSON and compact manifest, but removes
+the part directory. If part cleanup fails, the export still succeeds and reports that
+the temporary parts were retained.
+
+## Windowing, ordering, and pagination
+
+The requested range is treated as a half-open interval: `FromDate` is inclusive and
+`ToDate` is exclusive. Adjacent windows therefore do not duplicate an event that lands
+exactly on a boundary. The worker counts boundary events for diagnostics and skips the
+exclusive upper boundary.
+
+Windows are scheduled newest first because recent activity is normally the most useful
+during an active incident. The service's order within each window is preserved, and the
+final merge follows window order.
+
+Each worker follows only the response's `Prev` continuation URI. It rejects repeated,
+off-host, or unexpected continuation paths. Pagination cannot safely be parallelized
+within one window because later continuation URIs do not exist until earlier pages have
+been returned. Throughput therefore comes from concurrent independent windows.
+
+## Streaming and memory behavior
+
+Each response page is serialized one record at a time to UTF-8 NDJSON. The writer also
+computes the part's SHA-256 hash as bytes are written. Once a page has been processed,
+the response reference is released.
+
+The complete timeline and completed parts are never parsed into one in-memory
+collection. Memory is primarily bounded by the active response pages, serialization
+overhead, runspaces, and the underlying PowerShell web stack. Finalization copies and
+hashes byte streams; it does not deserialize the NDJSON.
+
+The current internal settings are:
+
+- four-hour windows;
+- four concurrent workers;
+- 1,000 records per page.
+
+These values are fixed because the benchmark results were not monotonic: smaller
+windows or more workers improved some short runs but increased memory, retries, or
+window restarts in longer runs. `ChunkHours` and `ThrottleLimit` should remain private
+until an automatic policy or broadly validated settings can replace manual guessing.
+
+## Retries, restart, and resume
+
+Recovery occurs at two levels:
+
+- A worker retries transient transport failures, HTTP 408/429/5xx responses, and an
+  initially partial response with bounded exponential backoff and jitter.
+- If a window's continuation context appears poisoned, the coordinator can restart the
+  entire window with a fresh correlation ID and request context.
+
+The entire window is restarted because an arbitrary page is not a durable checkpoint.
+Continuation URIs are service-owned and may expire, and appending a retried page to a
+partial file could introduce gaps or duplicates.
+
+After an interruption, running the same command with the same path validates each
+completed part by recorded byte length and SHA-256. Valid parts are reused; invalid,
+failed, and in-progress parts are downloaded again. The device ID, time range, Sentinel
+option, window size, and page size must match the manifest. `-Force` deliberately
+discards the output and resumable state.
+
+## Correctness and fail-closed behavior
+
+The exporter refuses to publish the final path when it cannot prove completeness. A
+window fails when, for example:
+
+- the service reports a partial response after its bounded recovery attempts;
+- a continuation URI repeats or fails validation;
+- an event has no parseable `ActionTimeIsoString` or `ActionTime`;
+- an event falls outside the requested window;
+- authentication or a permanent HTTP error occurs;
+- a completed part fails length or SHA-256 validation;
+- the output volume cannot be finalized with the available disk space.
+
+This is intentionally stricter than returning whatever data happened to arrive. During
+incident response, a plausible-looking but incomplete timeline is more dangerous than a
+clear failure that preserves resumable work.
+
+## Progress and heartbeat
+
+Interactive progress is refreshed at most every two seconds. A 30-second informational
+heartbeat reports time coverage, completed windows, event and byte counts, active and
+queued work, elapsed time, and a rough ETA.
+
+Workers update only small counters in a concurrent status map. The coordinator reads
+those counters on the existing polling loop, so progress reporting does not scan NDJSON
+files, deserialize events, or issue additional service requests. The ETA is based on
+completed time-window coverage and is deliberately described as rough because event
+density varies across the range.
+
+## `IncludeSentinelEvents`
+
+For the device exporter, `-IncludeSentinelEvents` sends
+`includeSentinelEvents=true` on each window's initial request. Without the switch, the
+request sends `includeSentinelEvents=false`. Continuation URIs come from the service and
+retain the server-side query context.
+
+The option means "include," not "return only." Enabling it should not remove ordinary
+MDE timeline events. It also does not guarantee that Sentinel-specific records exist for
+a device and range; tenant integration, device mapping, and available Sentinel data are
+controlled by the service.
+
+If a Sentinel-enabled export appears empty, compare the same device, UTC range, and a
+new output path without the switch. Preserve the two compact manifests and summary
+objects, but raw NDJSON is not needed for initial diagnosis. Useful details are:
+
+- the exact command with tenant-sensitive values redacted;
+- UTC `FromDate` and `ToDate` values;
+- event/page/retry/restart counts from each summary;
+- manifest state and per-window errors;
+- whether the final file is absent, zero bytes, or contains zero lines;
+- whether the portal shows Sentinel events for the same device and range.
+
+Do not silently fall back to a non-Sentinel request when a Sentinel-enabled request is
+empty. An empty response can be legitimate, and fallback would make the file appear
+complete while failing to satisfy the caller's request.
+
+## Why the implementation is not a single download loop
+
+A shorter implementation would have to give up at least one important property:
+
+| Simplification | Consequence |
+| --- | --- |
+| One sequential request chain | Long exports take substantially longer during active incident response |
+| Accumulate all pages before writing | Memory grows with the exported timeline |
+| Let workers append to one file | Concurrent writes make ordering, integrity, and recovery unsafe |
+| Append pages directly to the final file | Retried pages and power loss can leave gaps, duplicates, or a misleading partial result |
+| Trust every response and continuation | Partial service results or cursor loops can silently lose data |
+| Remove the manifest and hashes | Interrupted exports must restart, and completed bytes cannot be trusted on resume |
+| Remove timestamp boundary checks | Concurrent windows can duplicate or misassign boundary records |
+
+Some code can still be made easier to read, but moving it into more helper functions
+does not remove the underlying states. A shared export engine may become worthwhile once
+the identity and Cloud Apps implementations reveal which behavior is genuinely common.
+Until then, keeping service-specific pagination and validation explicit avoids an
+abstraction that hides important differences between these undocumented portal APIs.

--- a/docs/export-functions.md
+++ b/docs/export-functions.md
@@ -95,7 +95,10 @@ Defender base URL, it requires the live-confirmed relative
 cache, page-size, Sentinel, and scroll-direction values must remain unchanged, and
 `fromDate` must remain the window start. `ReportIdForScrolling` is the only fully opaque
 value. On a nonempty page, the server advances `toDate` to exactly one tick before that
-page's oldest event; an empty-page cursor must still remain inside the requested window.
+page's oldest event. That value may be one tick before the inclusive window start when
+the oldest event is exactly on the lower boundary. Continuation time may stay equal while
+one timestamp spans pages, but it may never move newer. An empty-page cursor must remain
+inside the requested window.
 Absolute or network-path URIs, another device or path, fragments, malformed or duplicate
 query keys, changed invariant values, empty report IDs, and repeated resolved cursors
 fail closed. Pagination cannot safely be parallelized within one window because later
@@ -159,6 +162,10 @@ window fails when, for example:
 - a completed part fails length or SHA-256 validation;
 - the output volume cannot be finalized with the available disk space.
 
+HTTP and runspace failures are reduced to a failure class and compact status message
+before they are written to the resumable manifest. Response bodies and continuation
+values are not retained in manifest errors.
+
 This is intentionally stricter than returning whatever data happened to arrive. During
 incident response, a plausible-looking but incomplete timeline is more dangerous than a
 clear failure that preserves resumable work.
@@ -210,6 +217,13 @@ restarts, warnings, or timestamp diagnostics. The independent line count, file l
 and SHA-256 matched the completed manifest. The densest live timestamp contained 257
 events, so no equal timestamp crossed a 1,000-record page in that range; the focused
 suite retains a synthetic three-page equal-timestamp proof.
+
+A disposable follow-up repeated that fixed range with a 250-record page size. It again
+published 4,967 matching-hash lines across 20 live `Prev` pages, so the 257-event
+timestamp necessarily crossed page boundaries while the non-increasing cursor guard was
+active. A separate request starting exactly at that timestamp returned different event
+membership and could not prove the lower-bound replay; the focused suite therefore also
+retains a three-page proof with every event exactly on the inclusive lower boundary.
 
 A separate seven-day export was terminated after one part completed. A new authenticated
 process validated and resumed that part, ignored an injected stale partial, and

--- a/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
+++ b/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
@@ -349,7 +349,7 @@
         $script:FailOneChunk = $false
         $result = Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $script:ToDate -Path $outputPath
 
-        $result.ResumedChunks | Should -Be 1
+        $result.ResumedChunks | Should -Be 2
         $result.TotalEvents | Should -Be 3
         Test-Path -LiteralPath $outputPath | Should -BeTrue
         Test-Path -LiteralPath "$outputPath.parts" | Should -BeFalse

--- a/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
+++ b/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
@@ -1,0 +1,357 @@
+﻿Describe 'Export-XdrEndpointDeviceTimeline' {
+    BeforeEach {
+        Mock Update-XdrConnectionSettings {} -ModuleName XDRInternals
+        InModuleScope XDRInternals {
+            $script:session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            $script:headers = @{}
+        }
+        $script:DeviceId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $script:FromDate = [datetime]'2026-01-01T00:00:00Z'
+        $script:ToDate = [datetime]'2026-01-01T09:00:00Z'
+    }
+
+    It 'keeps the public parameter surface intentionally small' {
+        $command = Get-Command Export-XdrEndpointDeviceTimeline
+        $publicParameters = @($command.Parameters.Keys | Where-Object { $_ -notin [System.Management.Automation.PSCmdlet]::CommonParameters -and $_ -notin [System.Management.Automation.PSCmdlet]::OptionalCommonParameters })
+
+        $publicParameters | Sort-Object | Should -Be @('DeviceId', 'Force', 'FromDate', 'IncludeSentinelEvents', 'Path', 'ToDate')
+    }
+
+    It 'plans adjacent newest-first four-hour chunks' {
+        InModuleScope XDRInternals -Parameters @{ FromDate = $script:FromDate; ToDate = $script:ToDate } {
+            $chunks = @(New-XdrEndpointTimelineExportChunk -FromDate $FromDate -ToDate $ToDate)
+
+            $chunks.Count | Should -Be 3
+            $chunks[0].FromDate.ToString('o') | Should -Be '2026-01-01T05:00:00.0000000Z'
+            $chunks[0].ToDate.ToString('o') | Should -Be '2026-01-01T09:00:00.0000000Z'
+            $chunks[1].FromDate | Should -Be $chunks[2].ToDate
+            $chunks[1].ToDate | Should -Be $chunks[0].FromDate
+            $chunks[2].FromDate | Should -Be $FromDate.ToUniversalTime()
+        }
+    }
+
+    It 'concatenates parts exactly and validates their hashes' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $firstPath = Join-Path $TestRoot 'first.ndjson'
+            $secondPath = Join-Path $TestRoot 'second.ndjson'
+            $destinationPath = Join-Path $TestRoot 'combined.ndjson'
+            [System.IO.File]::WriteAllText($firstPath, "{`"id`":2}`n", [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText($secondPath, "{`"id`":1}`n", [System.Text.UTF8Encoding]::new($false))
+            $parts = @(
+                [PSCustomObject]@{ FilePath = $firstPath; FileSha256 = (Get-FileHash -LiteralPath $firstPath).Hash.ToLowerInvariant(); EventCount = 1 },
+                [PSCustomObject]@{ FilePath = $secondPath; FileSha256 = (Get-FileHash -LiteralPath $secondPath).Hash.ToLowerInvariant(); EventCount = 1 }
+            )
+
+            $result = Merge-XdrEndpointTimelineNdjsonPart -Part $parts -DestinationPath $destinationPath
+
+            [System.IO.File]::ReadAllText($destinationPath) | Should -Be "{`"id`":2}`n{`"id`":1}`n"
+            $result.EventCount | Should -Be 2
+            $result.FileSha256 | Should -Be (Get-FileHash -LiteralPath $destinationPath).Hash.ToLowerInvariant()
+        }
+    }
+
+    It 'rejects a part whose bytes do not match its recorded hash' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $partPath = Join-Path $TestRoot 'changed.ndjson'
+            $destinationPath = Join-Path $TestRoot 'invalid-combined.ndjson'
+            [System.IO.File]::WriteAllText($partPath, "{`"id`":1}`n", [System.Text.UTF8Encoding]::new($false))
+            $parts = @([PSCustomObject]@{ FilePath = $partPath; FileSha256 = ('0' * 64); EventCount = 1 })
+
+            { Merge-XdrEndpointTimelineNdjsonPart -Part $parts -DestinationPath $destinationPath } | Should -Throw -ExpectedMessage '*failed SHA-256 validation*'
+        }
+    }
+
+    It 'follows Prev, ignores Next, and writes one NDJSON record per event' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:WorkerCall = 0
+            $script:RequestedUris = [System.Collections.Generic.List[string]]::new()
+            $script:WorkerResponses = @(
+                [PSCustomObject]@{
+                    Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T01:30:00Z'; ActionType = 'Newest'; Id = 2 })
+                    PartialResponseReasons = @()
+                    Prev = '/machines/device/events/?cursor=older'
+                    Next = '/machines/device/events/?cursor=must-not-follow'
+                },
+                [PSCustomObject]@{
+                    Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:30:00Z'; ActionType = 'Older'; Id = 1 })
+                    PartialResponseReasons = @()
+                    Prev = $null
+                    Next = '/machines/device/events/?cursor=must-not-follow'
+                }
+            )
+            Mock Invoke-RestMethod {
+                param($Uri)
+                $script:RequestedUris.Add([string]$Uri)
+                $response = $script:WorkerResponses[$script:WorkerCall]
+                $script:WorkerCall++
+                return $response
+            }
+
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{
+                Index = 0
+                FromDate = [datetime]'2026-01-01T00:00:00Z'
+                ToDate = [datetime]'2026-01-01T02:00:00Z'
+                FileName = 'worker.ndjson'
+            }
+            $shared = @{
+                PartsPath = $TestRoot
+                BaseUrl = 'https://security.microsoft.com'
+                DeviceId = $DeviceId
+                CookieData = @()
+                HeadersData = @{}
+                PageSize = 1000
+                IncludeSentinelEvents = $false
+                MaxPagesPerChunk = 10
+                MaxRetries = 1
+                RequestTimeoutSeconds = 30
+            }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+            $lines = @(Get-Content -LiteralPath $result.FilePath)
+
+            $result.Success | Should -BeTrue
+            $result.EventCount | Should -Be 2
+            $result.PageCount | Should -Be 2
+            $lines.Count | Should -Be 2
+            ($lines[0] | ConvertFrom-Json).Id | Should -Be 2
+            ($lines[1] | ConvertFrom-Json).Id | Should -Be 1
+            $script:RequestedUris.Count | Should -Be 2
+            $script:RequestedUris[1] | Should -BeLike '*cursor=older*'
+            ($script:RequestedUris -join "`n") | Should -Not -BeLike '*must-not-follow*'
+        }
+    }
+
+    It 'uses half-open intervals to prevent duplicate boundary events' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{
+                    Items = @(
+                        [PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:00:00Z'; Id = 'included-lower' },
+                        [PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T01:00:00Z'; Id = 'excluded-upper' }
+                    )
+                    PartialResponseReasons = @()
+                    Prev = $null
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'boundaries.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+            $lines = @(Get-Content -LiteralPath $result.FilePath)
+
+            $result.Success | Should -BeTrue
+            $result.EventCount | Should -Be 1
+            $result.BoundaryTimestampCount | Should -Be 2
+            $lines.Count | Should -Be 1
+            ($lines[0] | ConvertFrom-Json).Id | Should -Be 'included-lower'
+        }
+    }
+
+    It 'fails closed when an event has no parseable timestamp' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{ Items = @([PSCustomObject]@{ ActionTimeIsoString = 'not-a-date'; Id = 1 }); PartialResponseReasons = @(); Prev = $null; Next = $null }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'missing-time.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.MissingTimestampCount | Should -Be 1
+            $result.Error | Should -BeLike '*without a parseable timestamp*'
+            Test-Path -LiteralPath (Join-Path $TestRoot 'missing-time.ndjson') | Should -BeFalse
+        }
+    }
+
+    It 'does not publish output when the API reports partial data' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{
+                    Items = @()
+                    PartialResponseReasons = @('backend timeout')
+                    Prev = $null
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'partial.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.Error | Should -BeLike '*partial API response*'
+            Test-Path -LiteralPath (Join-Path $TestRoot 'partial.ndjson') | Should -BeFalse
+            Test-Path -LiteralPath (Join-Path $TestRoot 'partial.ndjson.partial') | Should -BeFalse
+        }
+    }
+
+    It 'retries a partial API response before accepting the page' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:PartialRetryCall = 0
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $script:PartialRetryCall++
+                if ($script:PartialRetryCall -eq 1) {
+                    return [PSCustomObject]@{ Items = @(); PartialResponseReasons = @('6'); Prev = $null; Next = $null }
+                }
+                return [PSCustomObject]@{
+                    Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:30:00Z'; ActionType = 'Recovered'; Id = 1 })
+                    PartialResponseReasons = @()
+                    Prev = $null
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'retried.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 2; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.EventCount | Should -Be 1
+            $result.PageCount | Should -Be 1
+            $result.RetryCount | Should -Be 1
+            Should -Invoke Invoke-RestMethod -Times 2 -Exactly
+            Should -Invoke Start-Sleep -Times 1 -Exactly
+        }
+    }
+
+    It 'restarts a partial window with a fresh request context' {
+        Mock New-XdrEndpointTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                if ([int]$chunk.Attempt -eq 0) {
+                    return [PSCustomObject]@{
+                        Success = $false; ChunkIndex = [int]$chunk.Index; EventCount = 250L; PageCount = 1
+                        FileBytes = 0L; FileSha256 = $null; RetryCount = 1
+                        MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01
+                        Error = 'simulated poisoned cursor'; FailureClass = 'PartialResponse'
+                    }
+                }
+
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                $line = "{`"attempt`":$([int]$chunk.Attempt)}`n"
+                [System.IO.File]::WriteAllText($filePath, $line, [System.Text.UTF8Encoding]::new($false))
+                return [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1
+                    FileBytes = (Get-Item -LiteralPath $filePath).Length
+                    FileSha256 = (Get-FileHash -LiteralPath $filePath).Hash.ToLowerInvariant(); RetryCount = 0
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01
+                    Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'fresh-context.ndjson'
+
+        $result = Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $script:FromDate.AddHours(1) -Path $outputPath
+        $manifest = Get-Content -LiteralPath "$outputPath.manifest.json" -Raw | ConvertFrom-Json
+
+        $result.TotalEvents | Should -Be 1
+        $result.TotalRetries | Should -Be 1
+        $result.TotalChunkRestarts | Should -Be 1
+        (Get-Content -LiteralPath $outputPath -Raw | ConvertFrom-Json).attempt | Should -Be 1
+        $manifest.Summary.ChunkRestartCount | Should -Be 1
+        Test-Path -LiteralPath "$outputPath.parts" | Should -BeFalse
+    }
+
+    It 'publishes a validated export and removes successful temporary parts' {
+        Mock New-XdrEndpointTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                $line = [string]::Format('{{"chunk":{0},"time":"{1}"}}{2}', [int]$chunk.Index, ([datetime]$chunk.ToDate).ToUniversalTime().ToString('o'), "`n")
+                [System.IO.File]::WriteAllText($filePath, $line, [System.Text.UTF8Encoding]::new($false))
+                [PSCustomObject]@{
+                    Success = $true
+                    ChunkIndex = [int]$chunk.Index
+                    EventCount = 1L
+                    PageCount = 1
+                    FileBytes = (Get-Item -LiteralPath $filePath).Length
+                    FileSha256 = (Get-FileHash -LiteralPath $filePath).Hash.ToLowerInvariant()
+                    MissingTimestampCount = 0L
+                    BoundaryTimestampCount = 0L
+                    ElapsedSeconds = 0.01
+                    Error = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'timeline.ndjson'
+        $sevenDayToDate = $script:FromDate.AddDays(7)
+
+        $result = Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $sevenDayToDate -Path $outputPath
+        $lines = @(Get-Content -LiteralPath $outputPath)
+        $manifest = Get-Content -LiteralPath "$outputPath.manifest.json" -Raw | ConvertFrom-Json
+
+        $result.TotalEvents | Should -Be 42
+        $result.TotalPages | Should -Be 42
+        $result.TotalChunks | Should -Be 42
+        $result.FileSha256 | Should -Be (Get-FileHash -LiteralPath $outputPath).Hash.ToLowerInvariant()
+        @($lines | ForEach-Object { ($_ | ConvertFrom-Json).chunk }) | Should -Be @(0..41)
+        $manifest.State | Should -Be 'Complete'
+        $manifest.Summary.PartsRetained | Should -BeFalse
+        Test-Path -LiteralPath "$outputPath.parts" | Should -BeFalse
+    }
+
+    It 'resumes validated chunks after a failed run' {
+        $script:FailOneChunk = $true
+        Mock New-XdrEndpointTimelineExportWorker {
+            if ($script:FailOneChunk) {
+                return {
+                    param($chunk, $sharedParameters, $statusMap)
+                    if ([int]$chunk.Index -eq 1) {
+                        return [PSCustomObject]@{
+                            Success = $false; ChunkIndex = 1; EventCount = 0L; PageCount = 0; FileBytes = 0L; FileSha256 = $null
+                            MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01; Error = 'simulated interruption'
+                        }
+                    }
+                    $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                    $line = [string]::Format('{{"chunk":{0}}}{1}', [int]$chunk.Index, "`n")
+                    [System.IO.File]::WriteAllText($filePath, $line, [System.Text.UTF8Encoding]::new($false))
+                    return [PSCustomObject]@{
+                        Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1
+                        FileBytes = (Get-Item -LiteralPath $filePath).Length
+                        FileSha256 = (Get-FileHash -LiteralPath $filePath).Hash.ToLowerInvariant()
+                        MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01; Error = $null
+                    }
+                }
+            }
+
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                $line = [string]::Format('{{"chunk":{0}}}{1}', [int]$chunk.Index, "`n")
+                [System.IO.File]::WriteAllText($filePath, $line, [System.Text.UTF8Encoding]::new($false))
+                return [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1
+                    FileBytes = (Get-Item -LiteralPath $filePath).Length
+                    FileSha256 = (Get-FileHash -LiteralPath $filePath).Hash.ToLowerInvariant()
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01; Error = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'resumed.ndjson'
+
+        { Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $script:ToDate -Path $outputPath } | Should -Throw -ExpectedMessage '*preserved for resume*'
+        Test-Path -LiteralPath $outputPath | Should -BeFalse
+        Test-Path -LiteralPath "$outputPath.parts" | Should -BeTrue
+
+        $script:FailOneChunk = $false
+        $result = Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $script:ToDate -Path $outputPath
+
+        $result.ResumedChunks | Should -Be 1
+        $result.TotalEvents | Should -Be 3
+        Test-Path -LiteralPath $outputPath | Should -BeTrue
+        Test-Path -LiteralPath "$outputPath.parts" | Should -BeFalse
+    }
+}

--- a/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
+++ b/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
@@ -182,6 +182,43 @@
         }
     }
 
+    It 'preserves equal timestamps spanning three pages at the inclusive lower boundary' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:LowerBoundaryCall = 0
+            Mock Invoke-RestMethod {
+                $script:LowerBoundaryCall++
+                $previous = if ($script:LowerBoundaryCall -lt 3) {
+                    New-TestEndpointTimelinePrev `
+                        -DeviceId $DeviceId `
+                        -Token "lower-page$($script:LowerBoundaryCall + 1)" `
+                        -CursorToDate ([datetime]'2025-12-31T23:59:59.9999999Z') `
+                        -PageSize 1
+                }
+                else {
+                    $null
+                }
+                [PSCustomObject]@{
+                    Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:00:00Z'; Id = "lower-$script:LowerBoundaryCall" })
+                    PartialResponseReasons = @()
+                    Prev = $previous
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'lower-boundary-equal-timestamps.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+            $ids = @(Get-Content -LiteralPath $result.FilePath | ForEach-Object { ($_ | ConvertFrom-Json).Id })
+
+            $result.Success | Should -BeTrue
+            $result.PageCount | Should -Be 3
+            $result.EventCount | Should -Be 3
+            $ids | Should -Be @('lower-1', 'lower-2', 'lower-3')
+        }
+    }
+
     It 'stops on a full page when Prev is absent' {
         InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
             Mock Invoke-RestMethod {
@@ -424,6 +461,39 @@
             $result.Success | Should -BeFalse
             $result.Error | Should -BeLike '*invalid pagination URI*'
             Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+        }
+    }
+
+    It 'rejects an empty-page continuation that moves the cursor newer' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:IncreasingEmptyCursorCall = 0
+            Mock Invoke-RestMethod {
+                $script:IncreasingEmptyCursorCall++
+                if ($script:IncreasingEmptyCursorCall -eq 1) {
+                    return [PSCustomObject]@{
+                        Items = @()
+                        PartialResponseReasons = @()
+                        Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'empty-older' -CursorToDate ([datetime]'2026-01-01T00:20:00Z')
+                        Next = $null
+                    }
+                }
+                [PSCustomObject]@{
+                    Items = @()
+                    PartialResponseReasons = @()
+                    Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'empty-newer' -CursorToDate ([datetime]'2026-01-01T00:30:00Z')
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'empty-page-newer-cursor.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.Error | Should -BeLike '*invalid pagination URI*'
+            Should -Invoke Invoke-RestMethod -Times 2 -Exactly
         }
     }
 
@@ -820,6 +890,81 @@
             Should -Invoke Invoke-RestMethod -Times 1 -Exactly
             Should -Invoke Start-Sleep -Times 0 -Exactly
         }
+    }
+
+    It 'does not retain an HTTP error body or continuation value in worker errors' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $responseBodyMarker = 'response-body-must-not-persist'
+            $cursorMarker = 'cursor-must-not-persist'
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $httpResponse = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::BadRequest)
+                $exception = [Microsoft.PowerShell.Commands.HttpResponseException]::new(
+                    "request failed ReportIdForScrolling=$cursorMarker",
+                    $httpResponse
+                )
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    $exception,
+                    'EndpointTimelineBadRequest',
+                    [System.Management.Automation.ErrorCategory]::InvalidResult,
+                    $null
+                )
+                $errorRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new($responseBodyMarker)
+                throw $errorRecord
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'sanitized-http-error.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 3; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'PermanentHttp'
+            $result.Error | Should -Be 'Chunk 0 endpoint timeline request failed permanently (HTTP 400).'
+            $result.Error | Should -Not -BeLike "*$responseBodyMarker*"
+            $result.Error | Should -Not -BeLike "*$cursorMarker*"
+        }
+    }
+
+    It 'does not retain an error body or continuation value in the resumable manifest' {
+        $responseBodyMarker = 'coordinator-body-must-not-persist'
+        $cursorMarker = 'coordinator-cursor-must-not-persist'
+        Mock New-XdrEndpointTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                $exception = [System.InvalidOperationException]::new(
+                    "worker failed ReportIdForScrolling=coordinator-cursor-must-not-persist"
+                )
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    $exception,
+                    'EndpointTimelineWorkerFailure',
+                    [System.Management.Automation.ErrorCategory]::InvalidResult,
+                    $null
+                )
+                $errorRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new(
+                    'coordinator-body-must-not-persist'
+                )
+                throw $errorRecord
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'sanitized-manifest-error.ndjson'
+
+        $thrownError = $null
+        try {
+            Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $script:FromDate.AddHours(1) -Path $outputPath
+        }
+        catch {
+            $thrownError = $_
+        }
+
+        $thrownError | Should -Not -BeNullOrEmpty
+        $thrownError.Exception.Message | Should -Not -BeLike "*$responseBodyMarker*"
+        $thrownError.Exception.Message | Should -Not -BeLike "*$cursorMarker*"
+        $manifestText = Get-Content -LiteralPath "$outputPath.manifest.json" -Raw
+        $manifestText | Should -Not -BeLike "*$responseBodyMarker*"
+        $manifestText | Should -Not -BeLike "*$cursorMarker*"
+        $manifestText | Should -BeLike '*worker failed before returning a structured result*'
     }
 
     It 'removes the partial part when serialization fails during writing' {

--- a/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
+++ b/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
@@ -8,6 +8,26 @@
         $script:DeviceId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         $script:FromDate = [datetime]'2026-01-01T00:00:00Z'
         $script:ToDate = [datetime]'2026-01-01T09:00:00Z'
+        InModuleScope XDRInternals {
+            function script:New-TestEndpointTimelinePrev {
+                param([string]$DeviceId, [string]$Token)
+
+                $query = @(
+                    'generateIdentityEvents=true'
+                    'includeIdentityEvents=true'
+                    'supportMdiOnlyEvents=true'
+                    'fromDate=2026-01-01T00%3A00%3A00.000Z'
+                    'toDate=2026-01-01T01%3A00%3A00.000Z'
+                    'doNotUseCache=false'
+                    'forceUseCache=false'
+                    'pageSize=1000'
+                    'includeSentinelEvents=false'
+                    'IsScrollingForward=false'
+                    "ReportIdForScrolling=$Token"
+                )
+                return "/machines/$DeviceId/events?$($query -join '&')"
+            }
+        }
     }
 
     It 'keeps the public parameter surface intentionally small' {
@@ -69,7 +89,7 @@
                 [PSCustomObject]@{
                     Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T01:30:00Z'; ActionType = 'Newest'; Id = 2 })
                     PartialResponseReasons = @()
-                    Prev = '/machines/device/events/?cursor=older'
+                    Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'older'
                     Next = '/machines/device/events/?cursor=must-not-follow'
                 },
                 [PSCustomObject]@{
@@ -118,8 +138,130 @@
             ($lines[0] | ConvertFrom-Json).Id | Should -Be 2
             ($lines[1] | ConvertFrom-Json).Id | Should -Be 1
             $script:RequestedUris.Count | Should -Be 2
-            $script:RequestedUris[1] | Should -BeLike '*cursor=older*'
+            $script:RequestedUris[1] | Should -BeLike '*ReportIdForScrolling=older*'
             ($script:RequestedUris -join "`n") | Should -Not -BeLike '*must-not-follow*'
+        }
+    }
+
+    It 'preserves equal timestamps across three continuation pages' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:EqualTimestampCall = 0
+            Mock Invoke-RestMethod {
+                $script:EqualTimestampCall++
+                $previous = if ($script:EqualTimestampCall -lt 3) {
+                    New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token "page$($script:EqualTimestampCall + 1)"
+                }
+                else {
+                    $null
+                }
+                [PSCustomObject]@{
+                    Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:30:00Z'; Id = "page-$script:EqualTimestampCall" })
+                    PartialResponseReasons = @()
+                    Prev = $previous
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'equal-timestamps.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+            $ids = @(Get-Content -LiteralPath $result.FilePath | ForEach-Object { ($_ | ConvertFrom-Json).Id })
+
+            $result.Success | Should -BeTrue
+            $result.PageCount | Should -Be 3
+            $result.EventCount | Should -Be 3
+            $ids | Should -Be @('page-1', 'page-2', 'page-3')
+        }
+    }
+
+    It 'stops on a full page when Prev is absent' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{
+                    Items = @(
+                        [PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:40:00Z'; Id = 2 },
+                        [PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:30:00Z'; Id = 1 }
+                    )
+                    PartialResponseReasons = @()
+                    Prev = $null
+                    Next = '/machines/ignored/events/?cursor=next'
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'full-no-prev.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 2; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.PageCount | Should -Be 1
+            $result.EventCount | Should -Be 2
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+        }
+    }
+
+    It 'fails closed when Prev repeats' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{
+                    Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:30:00Z'; Id = 1 })
+                    PartialResponseReasons = @()
+                    Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'repeated'
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'repeated-prev.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.Error | Should -BeLike '*repeated pagination URI*'
+            Should -Invoke Invoke-RestMethod -Times 2 -Exactly
+            Test-Path -LiteralPath (Join-Path $TestRoot 'repeated-prev.ndjson') | Should -BeFalse
+        }
+    }
+
+    It 'rejects an invalid raw Prev reference: <Name>' -TestCases @(
+        @{ Name = 'absolute URI'; Prev = 'https://evil.example/machines/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events?cursor=1' },
+        @{ Name = 'network-path URI'; Prev = '//evil.example/machines/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events?cursor=1' },
+        @{ Name = 'wrong device'; Prev = '/machines/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/events?cursor=1' },
+        @{ Name = 'wrong path'; Prev = '/machines/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/alerts/?cursor=1' },
+        @{ Name = 'missing query'; Prev = '/machines/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events' },
+        @{ Name = 'empty query value'; Prev = '/machines/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events?cursor=' },
+        @{ Name = 'duplicate query key'; Prev = '/machines/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events?cursor=1&cursor=2' },
+        @{ Name = 'malformed escape'; Prev = '/machines/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events?cursor=%zz' },
+        @{ Name = 'fragment'; Prev = '/machines/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events?cursor=1#fragment' },
+        @{ Name = 'backslash'; Prev = '/machines/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events?cursor=1\extra' },
+        @{ Name = 'unexpected query key'; Prev = '/machines/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events?cursor=1' }
+    ) {
+        param($Name, $Prev)
+
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId; InvalidPrev = $Prev } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{
+                    Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:30:00Z'; Id = 1 })
+                    PartialResponseReasons = @()
+                    Prev = $InvalidPrev
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'invalid-prev.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.Error | Should -BeLike '*invalid pagination URI*'
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+            Test-Path -LiteralPath (Join-Path $TestRoot 'invalid-prev.ndjson') | Should -BeFalse
         }
     }
 
@@ -157,7 +299,7 @@
                     return [PSCustomObject]@{
                         Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:30:00Z'; Id = 'first-page' })
                         PartialResponseReasons = @()
-                        Prev = '/machines/device/events/?cursor=older'
+                        Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'ordering'
                         Next = $null
                     }
                 }
@@ -282,6 +424,265 @@
             $result.RetryCount | Should -Be 1
             Should -Invoke Invoke-RestMethod -Times 2 -Exactly
             Should -Invoke Start-Sleep -Times 1 -Exactly
+        }
+    }
+
+    It 'fails closed when a continuation page reports partial data' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:LaterPartialCall = 0
+            Mock Invoke-RestMethod {
+                $script:LaterPartialCall++
+                if ($script:LaterPartialCall -eq 1) {
+                    return [PSCustomObject]@{
+                        Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:40:00Z'; Id = 'valid-first-page' })
+                        PartialResponseReasons = @()
+                        Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'partial'
+                        Next = $null
+                    }
+                }
+                [PSCustomObject]@{ Items = @(); PartialResponseReasons = @('later backend timeout'); Prev = $null; Next = $null }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'later-partial.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.PageCount | Should -Be 1
+            $result.EventCount | Should -Be 1
+            $result.FailureClass | Should -Be 'PartialResponse'
+            Test-Path -LiteralPath (Join-Path $TestRoot 'later-partial.ndjson') | Should -BeFalse
+            Test-Path -LiteralPath (Join-Path $TestRoot 'later-partial.ndjson.partial') | Should -BeFalse
+        }
+    }
+
+    It 'honors and caps Retry-After for HTTP 429' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:RateLimitCall = 0
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $script:RateLimitCall++
+                if ($script:RateLimitCall -eq 1) {
+                    $httpResponse = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::TooManyRequests)
+                    $httpResponse.Headers.RetryAfter = [System.Net.Http.Headers.RetryConditionHeaderValue]::new([timespan]::FromSeconds(45))
+                    throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('rate limited', $httpResponse)
+                }
+                [PSCustomObject]@{ Items = @(); PartialResponseReasons = @(); Prev = $null; Next = $null }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'rate-limited.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 2; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.RetryCount | Should -Be 1
+            Should -Invoke Start-Sleep -Times 1 -Exactly -ParameterFilter { $Seconds -eq 30 }
+        }
+    }
+
+    It 'honors an HTTP-date Retry-After value' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:RateLimitDateCall = 0
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $script:RateLimitDateCall++
+                if ($script:RateLimitDateCall -eq 1) {
+                    $httpResponse = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::TooManyRequests)
+                    $httpResponse.Headers.RetryAfter = [System.Net.Http.Headers.RetryConditionHeaderValue]::new([datetimeoffset]::UtcNow.AddMinutes(1))
+                    throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('rate limited', $httpResponse)
+                }
+                [PSCustomObject]@{ Items = @(); PartialResponseReasons = @(); Prev = $null; Next = $null }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'rate-limited-date.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 2; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.RetryCount | Should -Be 1
+            Should -Invoke Start-Sleep -Times 1 -Exactly -ParameterFilter { $Seconds -eq 30 }
+        }
+    }
+
+    It 'retries a transient HTTP failure' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:TransientHttpCall = 0
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $script:TransientHttpCall++
+                if ($script:TransientHttpCall -eq 1) {
+                    $httpResponse = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::ServiceUnavailable)
+                    throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('service unavailable', $httpResponse)
+                }
+                [PSCustomObject]@{ Items = @(); PartialResponseReasons = @(); Prev = $null; Next = $null }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'transient-http.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 2; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.RetryCount | Should -Be 1
+            Should -Invoke Invoke-RestMethod -Times 2 -Exactly
+            Should -Invoke Start-Sleep -Times 1 -Exactly
+        }
+    }
+
+    It 'retries any 5xx HTTP failure' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:LessCommon5xxCall = 0
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $script:LessCommon5xxCall++
+                if ($script:LessCommon5xxCall -eq 1) {
+                    $httpResponse = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::InsufficientStorage)
+                    throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('insufficient storage', $httpResponse)
+                }
+                [PSCustomObject]@{ Items = @(); PartialResponseReasons = @(); Prev = $null; Next = $null }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'less-common-5xx.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 2; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.RetryCount | Should -Be 1
+            Should -Invoke Invoke-RestMethod -Times 2 -Exactly
+            Should -Invoke Start-Sleep -Times 1 -Exactly
+        }
+    }
+
+    It 'retries a transport failure' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:TransportCall = 0
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $script:TransportCall++
+                if ($script:TransportCall -eq 1) {
+                    throw [System.Net.Http.HttpRequestException]::new('simulated timeout')
+                }
+                [PSCustomObject]@{ Items = @(); PartialResponseReasons = @(); Prev = $null; Next = $null }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'transport.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 2; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.RetryCount | Should -Be 1
+            Should -Invoke Invoke-RestMethod -Times 2 -Exactly
+            Should -Invoke Start-Sleep -Times 1 -Exactly
+        }
+    }
+
+    It 'retries an explicit timeout failure' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:TimeoutCall = 0
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $script:TimeoutCall++
+                if ($script:TimeoutCall -eq 1) {
+                    throw [System.TimeoutException]::new('simulated request timeout')
+                }
+                [PSCustomObject]@{ Items = @(); PartialResponseReasons = @(); Prev = $null; Next = $null }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'timeout.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 2; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.RetryCount | Should -Be 1
+            Should -Invoke Invoke-RestMethod -Times 2 -Exactly
+            Should -Invoke Start-Sleep -Times 1 -Exactly
+        }
+    }
+
+    It 'treats malformed JSON as a non-retryable protocol failure' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod { throw [System.Text.Json.JsonException]::new('malformed JSON') }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'malformed-json.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 3; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'Protocol'
+            $result.RetryCount | Should -Be 0
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+            Should -Invoke Start-Sleep -Times 0 -Exactly
+        }
+    }
+
+    It 'does not retry a permanent HTTP response: <StatusCode>' -TestCases @(
+        @{ StatusCode = 400; ExpectedClass = 'PermanentHttp' },
+        @{ StatusCode = 401; ExpectedClass = 'Authentication' },
+        @{ StatusCode = 403; ExpectedClass = 'Authentication' },
+        @{ StatusCode = 404; ExpectedClass = 'PermanentHttp' }
+    ) {
+        param($StatusCode, $ExpectedClass)
+
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId; HttpStatusCode = $StatusCode; FailureClass = $ExpectedClass } {
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $httpResponse = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]$HttpStatusCode)
+                throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('permanent failure', $httpResponse)
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'permanent-http.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 3; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be $FailureClass
+            $result.RetryCount | Should -Be 0
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+            Should -Invoke Start-Sleep -Times 0 -Exactly
+        }
+    }
+
+    It 'removes the partial part when serialization fails during writing' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{
+                    Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:30:00Z'; Id = 1 })
+                    PartialResponseReasons = @()
+                    Prev = $null
+                    Next = $null
+                }
+            }
+            Mock ConvertTo-Json { throw [System.IO.IOException]::new('simulated part write failure') }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'write-failure.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'Protocol'
+            $result.Error | Should -BeLike '*simulated part write failure*'
+            Test-Path -LiteralPath (Join-Path $TestRoot 'write-failure.ndjson') | Should -BeFalse
+            Test-Path -LiteralPath (Join-Path $TestRoot 'write-failure.ndjson.partial') | Should -BeFalse
         }
     }
 
@@ -481,6 +882,68 @@
         $chunk.BoundaryTimestampCount | Should -Be 0
         $chunk.ElapsedSeconds | Should -BeLessThan 1
         $chunk.Error | Should -BeNullOrEmpty
+    }
+
+    It 'stops scheduling after authentication failure and resumes completed parts' {
+        $script:AuthenticationFailure = $true
+        Mock New-XdrEndpointTimelineExportWorker {
+            if ($script:AuthenticationFailure) {
+                return {
+                    param($chunk, $sharedParameters, $statusMap)
+                    if ([int]$chunk.Index -eq 0) {
+                        return [PSCustomObject]@{
+                            Success = $false; ChunkIndex = 0; EventCount = 0L; PageCount = 0
+                            FileBytes = 0L; FileSha256 = $null; RetryCount = 0
+                            MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01
+                            Error = 'simulated authentication failure'; FailureClass = 'Authentication'
+                        }
+                    }
+
+                    Start-Sleep -Milliseconds 800
+                    $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                    $line = [string]::Format('{{"chunk":{0}}}{1}', [int]$chunk.Index, "`n")
+                    [System.IO.File]::WriteAllText($filePath, $line, [System.Text.UTF8Encoding]::new($false))
+                    return [PSCustomObject]@{
+                        Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1
+                        FileBytes = (Get-Item -LiteralPath $filePath).Length
+                        FileSha256 = (Get-FileHash -LiteralPath $filePath).Hash.ToLowerInvariant(); RetryCount = 0
+                        MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.8
+                        Error = $null; FailureClass = $null
+                    }
+                }
+            }
+
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                $line = [string]::Format('{{"chunk":{0}}}{1}', [int]$chunk.Index, "`n")
+                [System.IO.File]::WriteAllText($filePath, $line, [System.Text.UTF8Encoding]::new($false))
+                return [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1
+                    FileBytes = (Get-Item -LiteralPath $filePath).Length
+                    FileSha256 = (Get-FileHash -LiteralPath $filePath).Hash.ToLowerInvariant(); RetryCount = 0
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01
+                    Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'authentication-resume.ndjson'
+        $toDate = $script:FromDate.AddHours(17)
+
+        { Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $toDate -Path $outputPath } |
+            Should -Throw -ExpectedMessage '*preserved for resume*'
+        $failedManifest = Get-Content -LiteralPath "$outputPath.manifest.json" -Raw | ConvertFrom-Json
+
+        $failedManifest.Chunks[0].Status | Should -Be 'Failed'
+        @($failedManifest.Chunks | Where-Object Status -eq 'Completed').Count | Should -Be 3
+        $failedManifest.Chunks[4].Status | Should -Be 'Pending'
+
+        $script:AuthenticationFailure = $false
+        $result = Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $toDate -Path $outputPath
+
+        $result.ResumedChunks | Should -Be 3
+        $result.TotalEvents | Should -Be 5
+        Test-Path -LiteralPath $outputPath | Should -BeTrue
     }
 
     It 'resumes validated chunks after a failed run' {

--- a/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
+++ b/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
@@ -10,18 +10,24 @@
         $script:ToDate = [datetime]'2026-01-01T09:00:00Z'
         InModuleScope XDRInternals {
             function script:New-TestEndpointTimelinePrev {
-                param([string]$DeviceId, [string]$Token)
+                param(
+                    [string]$DeviceId,
+                    [string]$Token,
+                    [datetime]$CursorToDate = [datetime]'2026-01-01T00:29:59.9999999Z',
+                    [int]$PageSize = 1000,
+                    [bool]$IncludeSentinelEvents = $false
+                )
 
                 $query = @(
                     'generateIdentityEvents=true'
                     'includeIdentityEvents=true'
                     'supportMdiOnlyEvents=true'
                     'fromDate=2026-01-01T00%3A00%3A00.000Z'
-                    'toDate=2026-01-01T01%3A00%3A00.000Z'
+                    "toDate=$([uri]::EscapeDataString($CursorToDate.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffffffZ')))"
                     'doNotUseCache=false'
                     'forceUseCache=false'
-                    'pageSize=1000'
-                    'includeSentinelEvents=false'
+                    "pageSize=$PageSize"
+                    "includeSentinelEvents=$($IncludeSentinelEvents.ToString().ToLowerInvariant())"
                     'IsScrollingForward=false'
                     "ReportIdForScrolling=$Token"
                 )
@@ -89,7 +95,7 @@
                 [PSCustomObject]@{
                     Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T01:30:00Z'; ActionType = 'Newest'; Id = 2 })
                     PartialResponseReasons = @()
-                    Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'older'
+                    Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'older' -CursorToDate ([datetime]'2026-01-01T01:29:59.9999999Z')
                     Next = '/machines/device/events/?cursor=must-not-follow'
                 },
                 [PSCustomObject]@{
@@ -149,7 +155,7 @@
             Mock Invoke-RestMethod {
                 $script:EqualTimestampCall++
                 $previous = if ($script:EqualTimestampCall -lt 3) {
-                    New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token "page$($script:EqualTimestampCall + 1)"
+                    New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token "page$($script:EqualTimestampCall + 1)" -PageSize 1
                 }
                 else {
                     $null
@@ -209,7 +215,7 @@
                 [PSCustomObject]@{
                     Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:30:00Z'; Id = 1 })
                     PartialResponseReasons = @()
-                    Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'repeated'
+                    Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'repeated' -PageSize 1
                     Next = $null
                 }
             }
@@ -262,6 +268,162 @@
             $result.Error | Should -BeLike '*invalid pagination URI*'
             Should -Invoke Invoke-RestMethod -Times 1 -Exactly
             Test-Path -LiteralPath (Join-Path $TestRoot 'invalid-prev.ndjson') | Should -BeFalse
+        }
+    }
+
+    It 'rejects a continuation whose invariant value changes: <Name>' -TestCases @(
+        @{ Name = 'generate identity events'; QueryKey = 'generateIdentityEvents'; InvalidValue = 'false' },
+        @{ Name = 'include identity events'; QueryKey = 'includeIdentityEvents'; InvalidValue = 'false' },
+        @{ Name = 'MDI-only support'; QueryKey = 'supportMdiOnlyEvents'; InvalidValue = 'false' },
+        @{ Name = 'range start'; QueryKey = 'fromDate'; InvalidValue = '2026-01-01T00:00:00.001Z' },
+        @{ Name = 'malformed range start'; QueryKey = 'fromDate'; InvalidValue = 'not-a-date' },
+        @{ Name = 'page boundary'; QueryKey = 'toDate'; InvalidValue = '2026-01-01T00:30:00.0000000Z' },
+        @{ Name = 'malformed page boundary'; QueryKey = 'toDate'; InvalidValue = 'not-a-date' },
+        @{ Name = 'do-not-use-cache'; QueryKey = 'doNotUseCache'; InvalidValue = 'true' },
+        @{ Name = 'force-use-cache'; QueryKey = 'forceUseCache'; InvalidValue = 'true' },
+        @{ Name = 'page size'; QueryKey = 'pageSize'; InvalidValue = '500' },
+        @{ Name = 'Sentinel inclusion'; QueryKey = 'includeSentinelEvents'; InvalidValue = 'true' },
+        @{ Name = 'scroll direction'; QueryKey = 'IsScrollingForward'; InvalidValue = 'true' },
+        @{ Name = 'empty scrolling report ID'; QueryKey = 'ReportIdForScrolling'; InvalidValue = ' ' }
+    ) {
+        param($Name, $QueryKey, $InvalidValue)
+
+        InModuleScope XDRInternals -Parameters @{
+            TestRoot = $TestDrive
+            DeviceId = $script:DeviceId
+            ChangedQueryKey = $QueryKey
+            ChangedQueryValue = $InvalidValue
+        } {
+            $validPrev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'opaque-token'
+            $separator = $validPrev.IndexOf('?')
+            $changedParts = @(
+                foreach ($part in @($validPrev.Substring($separator + 1) -split '&')) {
+                    if ($part.StartsWith("$ChangedQueryKey=", [System.StringComparison]::OrdinalIgnoreCase)) {
+                        "$ChangedQueryKey=$([uri]::EscapeDataString($ChangedQueryValue))"
+                    }
+                    else {
+                        $part
+                    }
+                }
+            )
+            $invalidPrev = "$($validPrev.Substring(0, $separator))?$($changedParts -join '&')"
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{
+                    Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:30:00Z'; Id = 1 })
+                    PartialResponseReasons = @()
+                    Prev = $invalidPrev
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'changed-prev-value.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.Error | Should -BeLike '*invalid pagination URI*'
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+            Test-Path -LiteralPath (Join-Path $TestRoot 'changed-prev-value.ndjson') | Should -BeFalse
+        }
+    }
+
+    It 'accepts matching Sentinel continuation values' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:SentinelContinuationCall = 0
+            Mock Invoke-RestMethod {
+                $script:SentinelContinuationCall++
+                if ($script:SentinelContinuationCall -eq 1) {
+                    return [PSCustomObject]@{
+                        Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:30:00Z'; Id = 2 })
+                        PartialResponseReasons = @()
+                        Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'sentinel' -IncludeSentinelEvents $true
+                        Next = $null
+                    }
+                }
+                [PSCustomObject]@{
+                    Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:20:00Z'; Id = 1 })
+                    PartialResponseReasons = @()
+                    Prev = $null
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'sentinel-continuation.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $true; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.PageCount | Should -Be 2
+            $result.EventCount | Should -Be 2
+        }
+    }
+
+    It 'follows a valid continuation from an empty page' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:EmptyPageCall = 0
+            Mock Invoke-RestMethod {
+                $script:EmptyPageCall++
+                if ($script:EmptyPageCall -eq 1) {
+                    return [PSCustomObject]@{
+                        Items = @()
+                        PartialResponseReasons = @()
+                        Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'after-empty'
+                        Next = $null
+                    }
+                }
+                [PSCustomObject]@{
+                    Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:20:00Z'; Id = 1 })
+                    PartialResponseReasons = @()
+                    Prev = $null
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'empty-page-prev.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.PageCount | Should -Be 2
+            $result.EventCount | Should -Be 1
+        }
+    }
+
+    It 'rejects an out-of-window continuation from an empty page: <Name>' -TestCases @(
+        @{ Name = 'before lower bound'; CursorToDate = [datetime]'2025-12-31T23:59:59.9999999Z' },
+        @{ Name = 'at exclusive upper bound'; CursorToDate = [datetime]'2026-01-01T01:00:00Z' }
+    ) {
+        param($Name, $CursorToDate)
+
+        InModuleScope XDRInternals -Parameters @{
+            TestRoot = $TestDrive
+            DeviceId = $script:DeviceId
+            InvalidCursorToDate = $CursorToDate
+        } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{
+                    Items = @()
+                    PartialResponseReasons = @()
+                    Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'empty-outside' -CursorToDate $InvalidCursorToDate
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'empty-page-outside.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.Error | Should -BeLike '*invalid pagination URI*'
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly
         }
     }
 
@@ -436,7 +598,7 @@
                     return [PSCustomObject]@{
                         Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:40:00Z'; Id = 'valid-first-page' })
                         PartialResponseReasons = @()
-                        Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'partial'
+                        Prev = New-TestEndpointTimelinePrev -DeviceId $DeviceId -Token 'partial' -CursorToDate ([datetime]'2026-01-01T00:39:59.9999999Z') -PageSize 1
                         Next = $null
                     }
                 }

--- a/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
+++ b/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
@@ -123,6 +123,31 @@
         }
     }
 
+    It 'forwards IncludeSentinelEvents to the initial timeline request' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:SentinelRequestUri = $null
+            Mock Invoke-RestMethod {
+                param($Uri)
+                $script:SentinelRequestUri = [string]$Uri
+                [PSCustomObject]@{
+                    Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:30:00Z'; Id = 1 })
+                    PartialResponseReasons = @()
+                    Prev = $null
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'sentinel.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $true; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $script:SentinelRequestUri | Should -BeLike '*includeSentinelEvents=true*'
+        }
+    }
+
     It 'uses half-open intervals to prevent duplicate boundary events' {
         InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
             Mock Invoke-RestMethod {

--- a/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
+++ b/tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
@@ -148,13 +148,46 @@
         }
     }
 
+    It 'fails closed when a continuation page is newer than the preceding page' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
+            $script:OrderingCall = 0
+            Mock Invoke-RestMethod {
+                $script:OrderingCall++
+                if ($script:OrderingCall -eq 1) {
+                    return [PSCustomObject]@{
+                        Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:30:00Z'; Id = 'first-page' })
+                        PartialResponseReasons = @()
+                        Prev = '/machines/device/events/?cursor=older'
+                        Next = $null
+                    }
+                }
+                return [PSCustomObject]@{
+                    Items = @([PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:45:00Z'; Id = 'newer-continuation' })
+                    PartialResponseReasons = @()
+                    Prev = $null
+                    Next = $null
+                }
+            }
+            $worker = New-XdrEndpointTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'out-of-order.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; DeviceId = $DeviceId; CookieData = @(); HeadersData = @{}; PageSize = 1000; IncludeSentinelEvents = $false; MaxPagesPerChunk = 10; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.Error | Should -BeLike '*not in newest-first order*'
+            Test-Path -LiteralPath (Join-Path $TestRoot 'out-of-order.ndjson') | Should -BeFalse
+        }
+    }
+
     It 'uses half-open intervals to prevent duplicate boundary events' {
         InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; DeviceId = $script:DeviceId } {
             Mock Invoke-RestMethod {
                 [PSCustomObject]@{
                     Items = @(
-                        [PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:00:00Z'; Id = 'included-lower' },
-                        [PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T01:00:00Z'; Id = 'excluded-upper' }
+                        [PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T01:00:00Z'; Id = 'excluded-upper' },
+                        [PSCustomObject]@{ ActionTimeIsoString = '2026-01-01T00:00:00Z'; Id = 'included-lower' }
                     )
                     PartialResponseReasons = @()
                     Prev = $null
@@ -313,8 +346,9 @@
         } -ModuleName XDRInternals
         $outputPath = Join-Path $TestDrive 'timeline.ndjson'
         $sevenDayToDate = $script:FromDate.AddDays(7)
+        [System.IO.File]::WriteAllText($outputPath, "{`"old`":true}`n", [System.Text.UTF8Encoding]::new($false))
 
-        $result = Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $sevenDayToDate -Path $outputPath
+        $result = Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $sevenDayToDate -Path $outputPath -Force
         $lines = @(Get-Content -LiteralPath $outputPath)
         $manifest = Get-Content -LiteralPath "$outputPath.manifest.json" -Raw | ConvertFrom-Json
 
@@ -326,6 +360,127 @@
         $manifest.State | Should -Be 'Complete'
         $manifest.Summary.PartsRetained | Should -BeFalse
         Test-Path -LiteralPath "$outputPath.parts" | Should -BeFalse
+    }
+
+    It 'preserves an existing export when a forced replacement fails' {
+        Mock New-XdrEndpointTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                [PSCustomObject]@{
+                    Success = $false; ChunkIndex = [int]$chunk.Index; EventCount = 0L; PageCount = 0
+                    FileBytes = 0L; FileSha256 = $null; RetryCount = 0
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01
+                    Error = 'simulated replacement failure'; FailureClass = 'PermanentHttp'
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'preserved.ndjson'
+        [System.IO.File]::WriteAllText($outputPath, "{`"old`":true}`n", [System.Text.UTF8Encoding]::new($false))
+
+        { Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $script:FromDate.AddHours(1) -Path $outputPath -Force } |
+            Should -Throw -ExpectedMessage '*preserved for resume*'
+
+        (Get-Content -LiteralPath $outputPath -Raw | ConvertFrom-Json).old | Should -BeTrue
+    }
+
+    It 'recovers a finalizing manifest after the final file was published' {
+        Mock New-XdrEndpointTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                $line = "{`"published`":true}`n"
+                [System.IO.File]::WriteAllText($filePath, $line, [System.Text.UTF8Encoding]::new($false))
+                [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1
+                    FileBytes = (Get-Item -LiteralPath $filePath).Length
+                    FileSha256 = (Get-FileHash -LiteralPath $filePath).Hash.ToLowerInvariant(); RetryCount = 0
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01
+                    Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'recover-finalizing.ndjson'
+        $null = Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $script:FromDate.AddHours(1) -Path $outputPath
+        $manifestPath = "$outputPath.manifest.json"
+        $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+        $originalElapsedSeconds = $manifest.Summary.ElapsedSeconds
+        $manifest.State = 'Finalizing'
+        $manifest.Summary.CompletedUtc = $null
+        $manifest.Summary.PartsRetained = $true
+        [System.IO.File]::WriteAllText($manifestPath, ($manifest | ConvertTo-Json -Depth 16), [System.Text.UTF8Encoding]::new($false))
+        New-Item -Path "$outputPath.parts" -ItemType Directory | Out-Null
+        $script:RecoveryWorkerCalled = $false
+        Mock New-XdrEndpointTimelineExportWorker {
+            $script:RecoveryWorkerCalled = $true
+            throw 'The worker must not run during publication recovery.'
+        } -ModuleName XDRInternals
+
+        $result = Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $script:FromDate.AddHours(1) -Path $outputPath
+        $recoveredManifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+
+        $result.TotalEvents | Should -Be 1
+        $result.FileSha256 | Should -Be (Get-FileHash -LiteralPath $outputPath).Hash.ToLowerInvariant()
+        $result.ElapsedSeconds | Should -Be $originalElapsedSeconds
+        $recoveredManifest.State | Should -Be 'Complete'
+        $recoveredManifest.Summary.PartsRetained | Should -BeFalse
+        $recoveredManifest.Summary.CompletedUtc | Should -Not -BeNullOrEmpty
+        $script:RecoveryWorkerCalled | Should -BeFalse
+        Test-Path -LiteralPath "$outputPath.parts" | Should -BeFalse
+    }
+
+    It 'resets every diagnostic when a completed part fails resume validation' {
+        Mock New-XdrEndpointTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                $line = "{`"redownloaded`":true}`n"
+                [System.IO.File]::WriteAllText($filePath, $line, [System.Text.UTF8Encoding]::new($false))
+                [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1
+                    FileBytes = (Get-Item -LiteralPath $filePath).Length
+                    FileSha256 = (Get-FileHash -LiteralPath $filePath).Hash.ToLowerInvariant(); RetryCount = 0
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01
+                    Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'reset-diagnostics.ndjson'
+        $partsPath = "$outputPath.parts"
+        $manifestPath = "$outputPath.manifest.json"
+        $fileName = 'chunk_0000_test.ndjson'
+        New-Item -Path $partsPath -ItemType Directory | Out-Null
+        [System.IO.File]::WriteAllText((Join-Path $partsPath $fileName), "corrupt`n", [System.Text.UTF8Encoding]::new($false))
+        $manifest = [ordered]@{
+            SchemaVersion = 1; State = 'Failed'; DeviceId = $script:DeviceId
+            FromDateUtc = $script:FromDate.ToUniversalTime().ToString('o')
+            ToDateUtc = $script:FromDate.AddHours(1).ToUniversalTime().ToString('o')
+            IncludeSentinelEvents = $false; ChunkHours = 4; PageSize = 1000
+            Ordering = 'NewestTimeWindowFirst;ApiEventOrderPreserved'
+            CreatedUtc = [datetime]::UtcNow.ToString('o'); UpdatedUtc = [datetime]::UtcNow.ToString('o')
+            Chunks = @([ordered]@{
+                Index = 0; FromDateUtc = $script:FromDate.ToUniversalTime().ToString('o')
+                ToDateUtc = $script:FromDate.AddHours(1).ToUniversalTime().ToString('o')
+                DurationTicks = [timespan]::FromHours(1).Ticks; FileName = $fileName; Status = 'Completed'
+                EventCount = 99L; PageCount = 9; RetryCount = 8; AttemptCount = 7
+                FileBytes = 8L; FileSha256 = ('0' * 64); MissingTimestampCount = 6L
+                BoundaryTimestampCount = 5L; ElapsedSeconds = 100.0; Error = 'stale error'
+            })
+            Summary = $null
+        }
+        [System.IO.File]::WriteAllText($manifestPath, ($manifest | ConvertTo-Json -Depth 16), [System.Text.UTF8Encoding]::new($false))
+
+        $null = Export-XdrEndpointDeviceTimeline -DeviceId $script:DeviceId -FromDate $script:FromDate -ToDate $script:FromDate.AddHours(1) -Path $outputPath
+        $completedManifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+        $chunk = $completedManifest.Chunks[0]
+
+        $chunk.EventCount | Should -Be 1
+        $chunk.PageCount | Should -Be 1
+        $chunk.RetryCount | Should -Be 0
+        $chunk.AttemptCount | Should -Be 0
+        $chunk.MissingTimestampCount | Should -Be 0
+        $chunk.BoundaryTimestampCount | Should -Be 0
+        $chunk.ElapsedSeconds | Should -BeLessThan 1
+        $chunk.Error | Should -BeNullOrEmpty
     }
 
     It 'resumes validated chunks after a failed run' {


### PR DESCRIPTION
## Summary

- Add `Export-XdrEndpointDeviceTimeline`, a resumable NDJSON exporter for large Defender for Endpoint device timelines.
- Preserve half-open UTC windows, newest-first validation, manifest schema version 1, per-part length/SHA-256 validation, `Finalizing` recovery, and safe forced replacement.
- Follow only the server-provided `Prev` reference, regardless of page length, and ignore `Next`.
- Validate the raw `Prev` value before resolution: exact relative device-events path and live-confirmed query shape only; reject absolute/network-path references, wrong devices or paths, fragments, malformed or duplicate queries, changed invariant values, and repeated resolved cursors.
- Honor valid 429 `Retry-After` delta/date values up to 30 seconds. Retry only 408/429/5xx and genuine transport/timeouts; fail immediately on malformed JSON, authentication failures, and permanent 4xx responses.
- Keep the public parameter/output contract and internal defaults unchanged. No event deduplication or benchmark instrumentation was added.

## Why a separate exporter

The Defender XDR timeline endpoint is an undocumented progressive-scroll API. Large incident-response exports need bounded memory, durable intermediate state, and a final file that can be independently validated. A separate `Export-` cmdlet keeps those tradeoffs out of the interactive `Get-` workflow.

## Automated evidence

- Focused exporter suite: **62 passed, 0 failed**, with explicit module import and `FailedCount` enforcement.
- Repository Pester harness: **20,237 passed, 0 failed/errors, 3 expected skips** across 17 suites.
- PSScriptAnalyzer, file integrity, help, documentation sync, and `git diff --check` passed.
- Added synthetic coverage for three equal-timestamp `Prev` pages, short/full page cursor behavior, simultaneous `Prev`/`Next`, repeated and invalid cursors, later-page partials, cross-page ordering, 429 `Retry-After`, all 5xx, transport/timeouts, malformed JSON, authentication/permanent 4xx, part-write failure, and coordinator stop/resume behavior.

## Benchmark evidence

All tuning used a disposable module copy and fresh output path per run. No tuning controls or harness code are committed. Historical live rows are volatile, so separate-run equality was not required.

The fixed seven-day UTC matrix exercised all **36** combinations of page size 250/500/1000, window size 2/4/8 hours, and 2/4/8/16 workers. Sixteen completed; the other configurations failed closed, primarily on partial service responses.

- Current default `1000 / 4h / 4`: **167,599 rows, 189 pages, 1,204,753,184 bytes, 176s, 1.40 GiB peak, 0 retries/restarts**.
- Nearest clean challenger `1000 / 8h / 4`: **172.8s, 1.56 GiB peak, 0 retries/restarts**—only 2% faster and about 12% more memory.
- Higher concurrency sometimes reduced elapsed time but introduced retries/restarts or 2.4–5.6 GiB peak working sets.

The baseline and two strongest valid challengers then ran twice over the same fixed 30-day UTC range, in baseline/8h/2h order and then reversed:

| Configuration | Elapsed pair | Peak working-set pair | Retries / restarts pair |
| --- | ---: | ---: | ---: |
| `1000 / 4h / 4` | 919s / 924s | 1.47 / 1.48 GiB | 1/0 / 1/0 |
| `1000 / 8h / 4` | 696s / 947s | 1.76 / 1.77 GiB | 0/0 / 1/0 |
| `1000 / 2h / 4` | 787s / 927s | 1.50 / 1.57 GiB | 21/9 / 6/2 |

Every 30-day run independently validated **805,109–805,115 lines, 853–998 pages, 4.37 GB, and SHA-256**. The 8-hour challenger exceeded the 110% memory gate in both runs and was slower in reverse order. The 2-hour challenger added retries/restarts in both runs and was slower in reverse order. Defaults remain **1,000 records / 4-hour windows / 4 workers**.

## Recovery evidence

- A real seven-day export was terminated after one part completed. A new authenticated process validated and resumed that part, handled an injected stale partial, and atomically published **167,599 lines, 189 pages, 1,204,753,184 bytes**, with matching SHA-256 and no retries/restarts.
- Controlled fault injection proves `Finalizing` recovery, failed `-Force` replacement preserving the prior output, 401/403 and permanent-failure scheduling stop, completed-part resumability, diagnostic reset after invalid part hashes, and part-write cleanup.
- Authentication or permanent failures stop new scheduling while already completed parts remain available for resume.

## Live-service evidence

- A bounded five-device recent sample found only one event over seven days, so the sanitized known high-volume device label `known-high-volume-01` was used for cursor and export proof.
- Final fixed one-hour UTC export: **4,967 rows, 5 live `Prev` pages, 18,698,247 bytes, 0 retries/restarts/warnings, 0 timestamp diagnostics**, completed manifest, matching line count/length/SHA-256, and atomic publication.
- The densest repeated live timestamp contained **257 events**; no equal timestamp crossed a 1,000-row page in that range. The focused suite retains the three-page equal-timestamp proof.
- Sentinel-enabled and disabled probes over the same range each returned 4,967 ordinary MDE events. No known Sentinel-backed event was available, so Sentinel-specific inclusion remains unproven and behavior is unchanged.
- Raw events, cookies, tokens, continuation values, and full device identifiers were not retained. Disposable exports, harnesses, and module copies were deleted.

## Continuation-value follow-up

- Sanitized live inspection across four continuations confirmed that identity/cache flags, page size, Sentinel mode, scroll direction, and `fromDate` remain invariant. `ReportIdForScrolling` remains opaque and nonempty.
- The service-owned `toDate` is dynamic: on every observed nonempty page it was exactly one 100-nanosecond tick before that page's oldest event. The validator enforces that relationship without requiring `toDate` to decrease between pages, preserving equal-timestamp traversal as the report ID advances. Empty-page cursors remain valid when `toDate` stays inside the requested window.
- Adversarial tests reject changed invariants, malformed dates, incorrect page boundaries, mismatched Sentinel mode, changed scroll direction, empty report IDs, and out-of-window empty-page cursors. Matching Sentinel continuations, equal timestamps across three pages, and valid empty-page continuations remain accepted.
- Current-code live proof completed **4,967 rows across 5 pages, 18,696,648 bytes, 0 retries/restarts/warnings**, with matching line count, length, and SHA-256.
- Sentinel-specific event inclusion remains pending a tenant range with a known Sentinel-backed event; this follow-up does not claim or change that behavior.

## Publication state

Commits `6afa742` and `f64e330` contain only durable worker hardening, focused tests, and compact documentation evidence. This PR remains open and **must not be merged as part of this follow-up**.
