### PR TITLE
Add unified authentication error handling

### DIFF
--- a/XDRInternals/functions/Connect-XdrByBrowser.ps1
+++ b/XDRInternals/functions/Connect-XdrByBrowser.ps1
@@ -74,7 +74,8 @@
 
     process {
         if ($PrivateSession -and $ProfilePath) {
-            throw 'Do not combine -PrivateSession with -ProfilePath. Private session uses a temporary profile automatically.'
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod Browser -Stage InputValidation -DefaultCode RequestInvalid
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         $authParams = @{
@@ -102,9 +103,15 @@
             $authParams.UserAgent = $UserAgent
         }
 
-        $browserAuth = Invoke-XdrBrowserAuthentication @authParams
+        try {
+            $browserAuth = Invoke-XdrBrowserAuthentication @authParams
+        } catch {
+            $failure = Get-XdrAuthenticationFailure -ErrorRecord $_ -AuthenticationMethod Browser -Stage BrowserSignIn
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure -ErrorRecord $_)
+        }
         if (-not $browserAuth) {
-            throw 'Browser sign-in failed - no authentication cookies were returned.'
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod Browser -Stage ArtifactCapture -DefaultCode NoAuthenticationArtifact
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         $estsAuthCookieValue = if ($browserAuth -is [string]) { $browserAuth } else { $browserAuth.EstsAuthCookieValue }

--- a/XDRInternals/functions/Connect-XdrByCredential.ps1
+++ b/XDRInternals/functions/Connect-XdrByCredential.ps1
@@ -117,7 +117,8 @@
                 Write-Host "Enter credentials for Defender XDR authentication:"
                 $cred = Get-Credential -Message "Enter your Entra ID credentials for Defender XDR"
                 if (-not $cred) {
-                    throw "No credentials provided."
+                    $failure = Get-XdrAuthenticationFailure -AuthenticationMethod Credential -Stage InputValidation -DefaultCode RequestInvalid
+                    throw (New-XdrAuthenticationErrorRecord -Failure $failure)
                 }
 
                 $resolvedUsername = $cred.UserName
@@ -134,17 +135,20 @@
             Write-Host "Enter credentials for Defender XDR authentication:"
             $cred = Get-Credential -Message "Enter your Entra ID credentials for Defender XDR"
             if (-not $cred) {
-                throw "No credentials provided."
+                $failure = Get-XdrAuthenticationFailure -AuthenticationMethod Credential -Stage InputValidation -DefaultCode RequestInvalid
+                throw (New-XdrAuthenticationErrorRecord -Failure $failure)
             }
             $resolvedUsername = $cred.UserName
             $resolvedPassword = $cred.Password
         }
 
         if (-not $resolvedUsername) {
-            throw "No username provided."
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod Credential -Stage InputValidation -DefaultCode RequestInvalid
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
         if (-not $resolvedPassword) {
-            throw "No password provided."
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod Credential -Stage InputValidation -DefaultCode RequestInvalid
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         Write-Host "Authenticating as $resolvedUsername with credential flow..."
@@ -157,10 +161,16 @@
         if ($TotpSecret) { $credParams.TotpSecret = $TotpSecret }
         if ($MfaMethod) { $credParams.MfaMethod = $MfaMethod }
 
-        $estsAuth = Invoke-XdrCredentialAuthentication @credParams
+        try {
+            $estsAuth = Invoke-XdrCredentialAuthentication @credParams
+        } catch {
+            $failure = Get-XdrAuthenticationFailure -ErrorRecord $_ -AuthenticationMethod Credential -Stage SignIn
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure -ErrorRecord $_)
+        }
 
         if (-not $estsAuth) {
-            throw "Credential authentication failed - no ESTS cookie was returned."
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod Credential -Stage ArtifactCapture -DefaultCode NoAuthenticationArtifact
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         Connect-XdrAuthArtifactSet -EstsAuthCookieValue $estsAuth -TenantId $TenantId -UserAgent $UserAgent -FailureLabel 'Credential authentication'

--- a/XDRInternals/functions/Connect-XdrByEstsCookie.ps1
+++ b/XDRInternals/functions/Connect-XdrByEstsCookie.ps1
@@ -105,7 +105,23 @@
 
         if ($SecurityPortal.InputFields.name -notcontains 'code') {
             $portalState = Get-XdrAuthStateFromResponse -Response $SecurityPortal
-            $failure = Get-XdrAuthenticationFailure -AuthState $portalState -Response $SecurityPortal -AuthenticationMethod EstsCookie -Stage PortalAuthorize -DefaultCode ProviderRejected
+            $appControlHost = $null
+            if ([string]$SecurityPortal.Content -match '(?i)https://(?<Host>(?:[a-z0-9-]+\.)*access\.mcas\.ms)(?=[/:?#"''\s]|$)') {
+                $appControlHost = $Matches.Host
+            }
+
+            $failureParams = @{
+                AuthState            = $portalState
+                Response             = $SecurityPortal
+                AuthenticationMethod = 'EstsCookie'
+                Stage                = 'PortalAuthorize'
+                DefaultCode          = if ($appControlHost) { 'ConditionalAccess' } else { 'ProviderRejected' }
+            }
+            if ($appControlHost) {
+                $failureParams.SafeEvidence = @{ Host = $appControlHost }
+            }
+
+            $failure = Get-XdrAuthenticationFailure @failureParams
             throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 

--- a/XDRInternals/functions/Connect-XdrByEstsCookie.ps1
+++ b/XDRInternals/functions/Connect-XdrByEstsCookie.ps1
@@ -96,23 +96,17 @@
             $SecurityPortalUri = "https://security.microsoft.com/"
         }
         Write-Verbose "Initiating authentication flow to $SecurityPortalUri"
-        $SecurityPortal = Invoke-WebRequest -UseBasicParsing -ErrorAction SilentlyContinue -WebSession $session -Method Get -Uri $SecurityPortalUri -Verbose:$false
+        try {
+            $SecurityPortal = Invoke-WebRequest -UseBasicParsing -ErrorAction Stop -WebSession $session -Method Get -Uri $SecurityPortalUri -Verbose:$false
+        } catch {
+            $failure = Get-XdrAuthenticationFailure -ErrorRecord $_ -AuthenticationMethod EstsCookie -Stage PortalAuthorize -DefaultCode BootstrapFailed
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure -ErrorRecord $_)
+        }
 
-        # Error handling for missing for edge cases
-        if ( $SecurityPortal.InputFields.name -notcontains "code" ) {
-            try {
-                $SecurityPortal.Content -match '{(.*)}' | Out-Null
-                $SessionInformation_SecurityPortal = $Matches[0] | ConvertFrom-Json
-            } catch {
-                throw "Failed to complete authentication flow. Please verify the ESTSAUTH cookie value."
-            }
-            if ($SessionInformation_SecurityPortal.sErrorCode -eq "50058") {
-                throw "Session information is not sufficient for single-sign-on. Please use a incognito/private browsing session to obtain a new ESTSAUTH cookie value."
-            } elseif ($SessionInformation_SecurityPortal.sErrorCode) {
-                throw "Authentication flow failed with error code: $($SessionInformation_SecurityPortal.sErrorCode). Please verify the ESTSAUTH cookie value."
-            } else {
-                throw "Authentication flow failed. Please verify the ESTSAUTH cookie value."
-            }
+        if ($SecurityPortal.InputFields.name -notcontains 'code') {
+            $portalState = Get-XdrAuthStateFromResponse -Response $SecurityPortal
+            $failure = Get-XdrAuthenticationFailure -AuthState $portalState -Response $SecurityPortal -AuthenticationMethod EstsCookie -Stage PortalAuthorize -DefaultCode ProviderRejected
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         $requiredFields = @("code", "id_token", "state", "session_state", "correlation_id")
@@ -121,10 +115,8 @@
         # Check if all required fields are present in returned input fields
         foreach ($field in $requiredFields) {
             if (-not ($SecurityPortal.InputFields.name -contains $field)) {
-                $SecurityPortal.Content -match '{(.*)}' | Out-Null
-                $SessionInformation = $Matches[0] | ConvertFrom-Json
-                Write-Verbose "Session information received: $($SessionInformation | ConvertTo-Json -Depth 5)"
-                throw "Required field '$field' is missing from the response."
+                $failure = Get-XdrAuthenticationFailure -AuthenticationMethod EstsCookie -Stage PortalAuthorize -DefaultCode RequestInvalid -SafeEvidence @{ Field = $field }
+                throw (New-XdrAuthenticationErrorRecord -Failure $failure)
             }
         }
         $SessionCookies = $session.Cookies.GetCookies('https://security.microsoft.com') | Select-Object -ExpandProperty Name
@@ -140,8 +132,12 @@
             session_state  = $SecurityPortal.InputFields | Where-Object { $_.name -eq "session_state" } | Select-Object -ExpandProperty value
             correlation_id = $SecurityPortal.InputFields | Where-Object { $_.name -eq "correlation_id" } | Select-Object -ExpandProperty value
         }
-        Write-Verbose "POST Headers: $($Headers | Out-String)"
-        $null = Invoke-WebRequest -UseBasicParsing -ErrorAction SilentlyContinue -WebSession $session -Method Post -Uri $SecurityPortalUri -Body $Body -Verbose:$false
+        try {
+            $null = Invoke-WebRequest -UseBasicParsing -ErrorAction Stop -WebSession $session -Method Post -Uri $SecurityPortalUri -Body $Body -Verbose:$false
+        } catch {
+            $failure = Get-XdrAuthenticationFailure -ErrorRecord $_ -AuthenticationMethod EstsCookie -Stage PortalBootstrap -DefaultCode BootstrapFailed
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure -ErrorRecord $_)
+        }
         $SessionCookies = $session.Cookies.GetCookies('https://security.microsoft.com') | Select-Object -ExpandProperty Name
         Write-Verbose "Session cookies: $( $SessionCookies -join ', ' )"
         Write-Host "Successfully obtained XDR session cookies."

--- a/XDRInternals/functions/Connect-XdrByPhoneSignIn.ps1
+++ b/XDRInternals/functions/Connect-XdrByPhoneSignIn.ps1
@@ -52,12 +52,19 @@
         }
 
         if (-not $resolvedUsername) {
-            throw 'No username provided.'
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod PhoneSignIn -Stage InputValidation -DefaultCode RequestInvalid
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
-        $estsAuth = Invoke-XdrPhoneSignInAuthentication -Username $resolvedUsername -TimeoutSeconds $TimeoutSeconds -UserAgent $UserAgent
+        try {
+            $estsAuth = Invoke-XdrPhoneSignInAuthentication -Username $resolvedUsername -TimeoutSeconds $TimeoutSeconds -UserAgent $UserAgent
+        } catch {
+            $failure = Get-XdrAuthenticationFailure -ErrorRecord $_ -AuthenticationMethod PhoneSignIn -Stage SignIn
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure -ErrorRecord $_)
+        }
         if (-not $estsAuth) {
-            throw 'Phone sign-in failed - no ESTS cookie was returned.'
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod PhoneSignIn -Stage ArtifactCapture -DefaultCode NoAuthenticationArtifact
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         Connect-XdrAuthArtifactSet -EstsAuthCookieValue $estsAuth -TenantId $TenantId -UserAgent $UserAgent -FailureLabel 'Phone sign-in'

--- a/XDRInternals/functions/Connect-XdrBySSO.ps1
+++ b/XDRInternals/functions/Connect-XdrBySSO.ps1
@@ -84,9 +84,15 @@
             $authParams.UserAgent = $UserAgent
         }
 
-        $ssoAuth = Invoke-XdrSsoAuthentication @authParams
+        try {
+            $ssoAuth = Invoke-XdrSsoAuthentication @authParams
+        } catch {
+            $failure = Get-XdrAuthenticationFailure -ErrorRecord $_ -AuthenticationMethod SSO -Stage BrowserSignIn
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure -ErrorRecord $_)
+        }
         if (-not $ssoAuth) {
-            throw 'SSO authentication failed - no authentication cookies were returned.'
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod SSO -Stage ArtifactCapture -DefaultCode NoAuthenticationArtifact
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         $resolvedTenantId = if ($ssoAuth.SelectedTenantId) {

--- a/XDRInternals/functions/Connect-XdrBySoftwarePasskey.ps1
+++ b/XDRInternals/functions/Connect-XdrBySoftwarePasskey.ps1
@@ -96,7 +96,17 @@
         if ($KeyVaultTenantId) { $passkeyParams.KeyVaultTenantId = $KeyVaultTenantId }
         if ($KeyVaultClientId) { $passkeyParams.KeyVaultClientId = $KeyVaultClientId }
 
-        $estsAuth = Invoke-XdrPasskeyAuthentication @passkeyParams
+        try {
+            $estsAuth = Invoke-XdrPasskeyAuthentication @passkeyParams
+        } catch {
+            $failure = Get-XdrAuthenticationFailure -ErrorRecord $_ -AuthenticationMethod SoftwarePasskey -Stage SignIn
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure -ErrorRecord $_)
+        }
+
+        if (-not $estsAuth) {
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod SoftwarePasskey -Stage ArtifactCapture -DefaultCode NoAuthenticationArtifact
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
+        }
 
         Connect-XdrAuthArtifactSet -EstsAuthCookieValue $estsAuth -TenantId $TenantId -UserAgent $UserAgent -FailureLabel 'Software passkey authentication'
     }

--- a/XDRInternals/functions/Connect-XdrByTemporaryAccessPass.ps1
+++ b/XDRInternals/functions/Connect-XdrByTemporaryAccessPass.ps1
@@ -69,16 +69,23 @@
         }
 
         if (-not $resolvedUsername) {
-            throw 'No username provided.'
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod TemporaryAccessPass -Stage InputValidation -DefaultCode RequestInvalid
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         if (-not $resolvedTap) {
-            throw 'No Temporary Access Pass provided.'
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod TemporaryAccessPass -Stage InputValidation -DefaultCode RequestInvalid
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         $resolvedTenantId = $TenantId
         if (-not $resolvedTenantId) {
-            $resolvedTenantId = Resolve-XdrTenantIdFromUsername -Username $resolvedUsername -UserAgent $UserAgent
+            try {
+                $resolvedTenantId = Resolve-XdrTenantIdFromUsername -Username $resolvedUsername -UserAgent $UserAgent
+            } catch {
+                $failure = Get-XdrAuthenticationFailure -ErrorRecord $_ -AuthenticationMethod TemporaryAccessPass -Stage TenantResolution -DefaultCode InvalidTenant
+                throw (New-XdrAuthenticationErrorRecord -Failure $failure -ErrorRecord $_)
+            }
         }
 
         Write-Host "Authenticating as $resolvedUsername with Temporary Access Pass..."
@@ -90,9 +97,15 @@
             UserAgent           = $UserAgent
         }
 
-        $estsAuth = Invoke-XdrTemporaryAccessPassAuthentication @tapParams
+        try {
+            $estsAuth = Invoke-XdrTemporaryAccessPassAuthentication @tapParams
+        } catch {
+            $failure = Get-XdrAuthenticationFailure -ErrorRecord $_ -AuthenticationMethod TemporaryAccessPass -Stage SignIn
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure -ErrorRecord $_)
+        }
         if (-not $estsAuth) {
-            throw 'Temporary Access Pass authentication failed - no ESTS cookie was returned.'
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod TemporaryAccessPass -Stage ArtifactCapture -DefaultCode NoAuthenticationArtifact
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         Connect-XdrAuthArtifactSet -EstsAuthCookieValue $estsAuth -TenantId $resolvedTenantId -UserAgent $UserAgent -FailureLabel 'Temporary Access Pass authentication'

--- a/XDRInternals/internal/functions/Connect-XdrAuthArtifacts.ps1
+++ b/XDRInternals/internal/functions/Connect-XdrAuthArtifacts.ps1
@@ -23,7 +23,8 @@
     $hasPortalCookies = -not [string]::IsNullOrWhiteSpace($SccAuthCookieValue)
 
     if (-not $hasEsts -and -not $hasPortalCookies) {
-        throw "$FailureLabel failed - no supported authentication cookies were returned."
+        $failure = Get-XdrAuthenticationFailure -AuthenticationMethod $FailureLabel -Stage ArtifactCapture -DefaultCode NoAuthenticationArtifact
+        throw (New-XdrAuthenticationErrorRecord -Failure $failure)
     }
 
     $estsConnectParams = $null
@@ -54,6 +55,8 @@
         @('Ests', 'Portal')
     }
 
+    $attemptFailures = [ordered]@{}
+    $lastError = $null
     foreach ($attempt in $attemptOrder) {
         switch ($attempt) {
             'Ests' {
@@ -64,14 +67,20 @@
                 try {
                     return Connect-XdrByEstsCookie @estsConnectParams
                 } catch {
+                    $lastError = $_
+                    $attemptFailure = Get-XdrAuthenticationFailure -ErrorRecord $_ -AuthenticationMethod $FailureLabel -Stage EstsBootstrap -DefaultCode BootstrapFailed
+                    $attemptFailures['ESTS'] = $attemptFailure.Code
+                    if ($attemptFailures.Count -ge 2) {
+                        continue
+                    }
                     if (-not $FallbackToPortalOnEstsBootstrapFailure -or -not $portalConnectParams) {
-                        throw
+                        throw (New-XdrAuthenticationErrorRecord -Failure $attemptFailure -ErrorRecord $_)
                     }
 
-                    if ($_.Exception.Message -match 'Session information is not sufficient for single-sign-on') {
+                    if ($attemptFailure.Code -eq 'SessionUnavailable') {
                         Write-Verbose 'ESTS bootstrap was not sufficient for Defender SSO. Falling back to the captured Defender portal session cookies.'
                     } else {
-                        Write-Verbose "ESTS bootstrap failed: $($_.Exception.Message). Falling back to the captured Defender portal session cookies."
+                        Write-Verbose "ESTS bootstrap failed with classification $($attemptFailure.Code). Falling back to the captured Defender portal session cookies."
                     }
 
                     continue
@@ -86,16 +95,24 @@
                 try {
                     return Set-XdrConnectionSettings @portalConnectParams
                 } catch {
+                    $lastError = $_
+                    $attemptFailure = Get-XdrAuthenticationFailure -ErrorRecord $_ -AuthenticationMethod $FailureLabel -Stage PortalBootstrap -DefaultCode BootstrapFailed
+                    $attemptFailures['Portal'] = $attemptFailure.Code
+                    if ($attemptFailures.Count -ge 2) {
+                        continue
+                    }
                     if (-not $estsConnectParams -or $ConnectionPreference -ne 'PreferPortal') {
-                        throw
+                        throw (New-XdrAuthenticationErrorRecord -Failure $attemptFailure -ErrorRecord $_)
                     }
 
-                    Write-Verbose "Defender portal bootstrap failed: $($_.Exception.Message). Falling back to ESTS cookie bootstrap."
+                    Write-Verbose "Defender portal bootstrap failed with classification $($attemptFailure.Code). Falling back to ESTS cookie bootstrap."
                     continue
                 }
             }
         }
     }
 
-    throw "$FailureLabel failed - no supported authentication cookies were returned."
+    $attemptSummary = @($attemptFailures.GetEnumerator() | ForEach-Object { "$($_.Key):$($_.Value)" }) -join '; '
+    $failure = Get-XdrAuthenticationFailure -AuthenticationMethod $FailureLabel -Stage Bootstrap -DefaultCode BootstrapFailed -SafeEvidence @{ Attempt = $attemptSummary }
+    throw (New-XdrAuthenticationErrorRecord -Failure $failure -ErrorRecord $lastError)
 }

--- a/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
+++ b/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
@@ -1,0 +1,259 @@
+﻿function Get-XdrAuthenticationFailure {
+    [CmdletBinding()]
+    param(
+        [System.Management.Automation.ErrorRecord]$ErrorRecord,
+        [object]$AuthState,
+        [string]$RedirectUri,
+        [object]$SasResult,
+        [object]$Response,
+        [string]$AuthenticationMethod = 'Unknown',
+        [string]$Stage = 'Authentication',
+        [ValidateSet(
+            'InvalidCredentials', 'AccountNotFound', 'AccountDisabled', 'SignInBlocked', 'PasswordExpired', 'PasswordMissing',
+            'MfaEnrollmentRequired', 'MfaRequired', 'MfaDenied', 'MfaTimeout', 'MfaTemporarilyUnavailable', 'FlowExpired', 'SessionUnavailable',
+            'ConditionalAccess', 'AppAssignmentRequired', 'ConsentRequired', 'InvalidTenant',
+            'CredentialFileInvalid', 'PasskeyUnavailable', 'PasskeyAssertionFailed', 'KeyVaultAccessFailed',
+            'ProviderUnavailable', 'Throttled', 'RequestInvalid', 'BrowserClosed', 'BrowserTimeout', 'BrowserStartupFailed',
+            'TenantSelectionFailed', 'NoAuthenticationArtifact', 'BootstrapFailed', 'ProviderRejected', 'UnknownFailure'
+        )]
+        [string]$DefaultCode = 'UnknownFailure',
+        [System.Collections.IDictionary]$SafeEvidence
+    )
+
+    $getValue = {
+        param($InputObject, [string[]]$Names)
+
+        if ($null -eq $InputObject) { return $null }
+        foreach ($name in $Names) {
+            if ($InputObject -is [System.Collections.IDictionary]) {
+                foreach ($key in $InputObject.Keys) {
+                    if ([string]$key -ieq $name) { return $InputObject[$key] }
+                }
+            } else {
+                $property = $InputObject.PSObject.Properties | Where-Object Name -IEQ $name | Select-Object -First 1
+                if ($property) { return $property.Value }
+            }
+        }
+        return $null
+    }
+
+    $parsedError = if ($ErrorRecord) { Get-XdrParsedErrorDetail -ErrorRecord $ErrorRecord } else { $null }
+    $sources = @($AuthState, $SasResult, $Response, $parsedError) | Where-Object { $null -ne $_ }
+
+    $providerCode = $null
+    foreach ($source in $sources) {
+        $candidate = & $getValue $source @('sErrorCode', 'iErrorCode', 'ErrCode', 'errorCode', 'code')
+        if (-not $candidate) {
+            $nestedError = & $getValue $source @('error')
+            if ($nestedError -and $nestedError -isnot [string]) {
+                $candidate = & $getValue $nestedError @('code')
+            }
+        }
+        if ($candidate) {
+            $providerCode = [string]$candidate
+            break
+        }
+    }
+
+    $oauthError = $null
+    if (-not [string]::IsNullOrWhiteSpace($RedirectUri)) {
+        try {
+            $redirect = [uri]$RedirectUri
+            foreach ($component in @($redirect.Query.TrimStart('?'), $redirect.Fragment.TrimStart('#'))) {
+                foreach ($pair in @($component -split '&')) {
+                    if ([string]::IsNullOrWhiteSpace($pair)) { continue }
+                    $parts = $pair -split '=', 2
+                    $name = [uri]::UnescapeDataString(($parts[0] -replace '\+', ' '))
+                    if ($name -ieq 'error' -and $parts.Count -gt 1) {
+                        $oauthError = [uri]::UnescapeDataString(($parts[1] -replace '\+', ' '))
+                    }
+                }
+            }
+        } catch {
+            # An invalid redirect URI is classified by the caller's fallback.
+            $oauthError = $null
+        }
+    }
+
+    if (-not $providerCode -and $oauthError) { $providerCode = $oauthError }
+    if ($providerCode -and $providerCode -match '(?i)AADSTS(\d+)') { $providerCode = $Matches[1] }
+    if ($providerCode -and $providerCode -notmatch '^[A-Za-z0-9._-]{1,64}$') { $providerCode = $null }
+
+    $statusCode = $null
+    foreach ($source in @($Response, $(if ($ErrorRecord) { $ErrorRecord.Exception.Response }))) {
+        if (-not $source) { continue }
+        $candidateStatus = & $getValue $source @('StatusCode', 'status')
+        if ($candidateStatus) {
+            try {
+                $statusCode = [int]$candidateStatus
+            } catch {
+                $statusCode = $null
+            }
+            if ($statusCode) { break }
+        }
+    }
+
+    $entraMappings = @{
+        '50034' = 'AccountNotFound'; '50053' = 'SignInBlocked'; '50055' = 'PasswordExpired'; '50056' = 'PasswordMissing'
+        '50057' = 'AccountDisabled'; '50126' = 'InvalidCredentials'; '50058' = 'SessionUnavailable'
+        '50072' = 'MfaEnrollmentRequired'; '50079' = 'MfaEnrollmentRequired'; '50074' = 'MfaRequired'; '50076' = 'MfaRequired'
+        '50078' = 'MfaTimeout'; '50087' = 'MfaTemporarilyUnavailable'; '50088' = 'MfaTemporarilyUnavailable'; '50089' = 'FlowExpired'
+        '50105' = 'AppAssignmentRequired'; '65001' = 'ConsentRequired'; '90008' = 'ConsentRequired'; '90094' = 'ConsentRequired'; '90095' = 'ConsentRequired'
+        '90002' = 'InvalidTenant'; '53000' = 'ConditionalAccess'; '53001' = 'ConditionalAccess'; '53002' = 'ConditionalAccess'
+        '53003' = 'ConditionalAccess'; '53004' = 'ConditionalAccess'; '53009' = 'ConditionalAccess'
+        '90006' = 'ProviderUnavailable'; '90024' = 'ProviderUnavailable'; '90033' = 'ProviderUnavailable'
+    }
+
+    $code = $null
+    if ($providerCode -and $entraMappings.ContainsKey($providerCode)) {
+        $code = $entraMappings[$providerCode]
+    } elseif ($oauthError) {
+        $code = switch -Regex ($oauthError) {
+            '^interaction_required$' { 'MfaRequired'; break }
+            '^(user_cancelled|user_denied)$' { 'MfaDenied'; break }
+            '^temporarily_unavailable$' { 'ProviderUnavailable'; break }
+            '^invalid_tenant$' { 'InvalidTenant'; break }
+            '^consent_required$' { 'ConsentRequired'; break }
+            default { 'ProviderRejected' }
+        }
+    } elseif ($SasResult) {
+        $sasValue = [string](& $getValue $SasResult @('ResultValue', 'Outcome', 'AuthorizationState'))
+        $sasRetry = & $getValue $SasResult @('Retry')
+        $code = switch -Regex ($sasValue) {
+            '(?i)denied|declined|rejected' { 'MfaDenied'; break }
+            '(?i)timeout|expired' { 'MfaTimeout'; break }
+            '(?i)pending' { if ($sasRetry -eq $false) { 'MfaTimeout' } else { 'MfaRequired' }; break }
+            default { $null }
+        }
+    }
+
+    if (-not $code -and $statusCode) {
+        $code = switch ($statusCode) {
+            429 { 'Throttled' }
+            { $_ -in @(502, 503, 504) } { 'ProviderUnavailable' }
+            400 { 'RequestInvalid' }
+            { $_ -in @(401, 403) } { 'ProviderRejected' }
+            default { $null }
+        }
+    }
+
+    if (-not $code -and $DefaultCode -ne 'UnknownFailure') { $code = $DefaultCode }
+
+    if (-not $code -and $ErrorRecord) {
+        $legacyMessage = [string]$ErrorRecord.Exception.Message
+        $code = switch -Regex ($legacyMessage) {
+            '(?i)browser.+(closed|exited)|websocket.+closed' { 'BrowserClosed'; break }
+            '(?i)timed out|timeout expired' { 'BrowserTimeout'; break }
+            '(?i)tenant.+(not found|did not return|could not validate)' { 'TenantSelectionFailed'; break }
+            '(?i)credential file.+(not found|invalid|missing)|invalid JSON in credential' { 'CredentialFileInvalid'; break }
+            '(?i)key vault.+(token|access|sign)' { 'KeyVaultAccessFailed'; break }
+            '(?i)passkey.+(not available|requires PowerShell)' { 'PasskeyUnavailable'; break }
+            '(?i)passkey.+(assertion|validation)|signature generation failed' { 'PasskeyAssertionFailed'; break }
+            default { 'UnknownFailure' }
+        }
+    }
+    if (-not $code) { $code = $DefaultCode }
+
+    $definitions = @{
+        InvalidCredentials = @('The username or password was not accepted.', 'Verify the username and password, then try again.', 'AuthenticationError', $false)
+        AccountNotFound = @('The account could not be found in the selected tenant.', 'Verify the username and tenant, then try again.', 'ObjectNotFound', $false)
+        AccountDisabled = @('The account is disabled.', 'Ask a tenant administrator to enable the account before retrying.', 'PermissionDenied', $false)
+        SignInBlocked = @('Entra ID blocked this sign-in.', 'Review the Entra sign-in logs to determine whether the account is locked or the sign-in originated from a blocked IP address.', 'PermissionDenied', $false)
+        PasswordExpired = @('The account password has expired.', 'Change the password, then start a new connection attempt.', 'AuthenticationError', $false)
+        PasswordMissing = @('The account has no valid password configured.', 'Reset or configure the account password before retrying.', 'AuthenticationError', $false)
+        MfaEnrollmentRequired = @('The account must register multifactor authentication.', 'Complete the required MFA registration in an interactive sign-in, then retry.', 'PermissionDenied', $false)
+        MfaRequired = @('Additional multifactor authentication is required.', 'Complete the requested MFA challenge and start a new connection attempt.', 'AuthenticationError', $true)
+        MfaDenied = @('The multifactor authentication request was denied.', 'Approve a new MFA request only if you initiated it, then retry.', 'AuthenticationError', $true)
+        MfaTimeout = @('The multifactor authentication request expired or timed out.', 'Start a new connection attempt and complete the MFA request promptly.', 'OperationTimeout', $true)
+        MfaTemporarilyUnavailable = @('The multifactor authentication service is temporarily unavailable or limited.', 'Wait before starting a new connection attempt; review sign-in logs if the condition persists.', 'ResourceUnavailable', $true)
+        FlowExpired = @('The authentication flow expired.', 'Start a new connection attempt.', 'OperationTimeout', $true)
+        SessionUnavailable = @('The existing sign-in session is not sufficient for single sign-on.', 'Obtain a fresh authentication session and try again.', 'AuthenticationError', $true)
+        ConditionalAccess = @('A Conditional Access policy blocked this sign-in.', 'Review the Entra sign-in logs and satisfy the reported Conditional Access requirements before retrying.', 'PermissionDenied', $false)
+        AppAssignmentRequired = @('This account is not assigned to the required application.', 'Ask a tenant administrator to assign the account or group to the application.', 'PermissionDenied', $false)
+        ConsentRequired = @('The application requires user or administrator consent.', 'Grant the required consent in the tenant, then retry.', 'PermissionDenied', $false)
+        InvalidTenant = @('The requested tenant is invalid or unavailable.', 'Verify the tenant identifier and that the account has access to it.', 'InvalidArgument', $false)
+        CredentialFileInvalid = @('The software passkey credential file is missing or invalid.', 'Verify the credential file path and required fields without sharing its contents.', 'InvalidData', $false)
+        PasskeyUnavailable = @('Passkey authentication is not available for this account or environment.', 'Verify that the account has a supported passkey and that the local requirements are installed.', 'NotImplemented', $false)
+        PasskeyAssertionFailed = @('The passkey assertion could not be created or accepted.', 'Verify the passkey credential and start a new connection attempt.', 'AuthenticationError', $false)
+        KeyVaultAccessFailed = @('The passkey could not be used through Azure Key Vault.', 'Verify Key Vault authentication, key permissions, key name, and network access.', 'PermissionDenied', $false)
+        ProviderUnavailable = @('The authentication provider is temporarily unavailable.', 'Wait briefly, then start a new connection attempt.', 'ResourceUnavailable', $true)
+        Throttled = @('The authentication provider throttled the request.', 'Wait before starting a new connection attempt.', 'LimitsExceeded', $true)
+        RequestInvalid = @('The authentication provider rejected an invalid request.', 'Start a new connection attempt; if this persists, collect the safe diagnostic identifiers and report the issue.', 'InvalidArgument', $false)
+        BrowserClosed = @('The authentication browser closed before sign-in completed.', 'Keep the authentication browser open until Defender XDR finishes loading.', 'OperationStopped', $true)
+        BrowserTimeout = @('Browser authentication did not complete before the timeout.', 'Complete sign-in more quickly or increase TimeoutSeconds, then retry.', 'OperationTimeout', $true)
+        BrowserStartupFailed = @('The authentication browser could not be started.', 'Verify BrowserPath and that a supported Chromium-based browser can run.', 'OpenError', $false)
+        TenantSelectionFailed = @('The requested Defender tenant could not be selected.', 'Verify the tenant identifier and that the signed-in account can access it.', 'ObjectNotFound', $false)
+        NoAuthenticationArtifact = @('Authentication completed without a usable session artifact.', 'Start a new connection attempt and complete every sign-in prompt.', 'AuthenticationError', $true)
+        BootstrapFailed = @('The authenticated session could not be established with Defender XDR.', 'Start a new connection attempt; use the safe diagnostic evidence if the problem persists.', 'ConnectionError', $true)
+        ProviderRejected = @('The authentication provider rejected the sign-in.', 'Review the Entra sign-in logs using the diagnostic identifiers, then retry after resolving the reported cause.', 'AuthenticationError', $false)
+        UnknownFailure = @('Authentication failed for an unclassified reason.', 'Retry once; if the failure persists, use the safe diagnostic identifiers when reporting the issue.', 'NotSpecified', $false)
+    }
+
+    $definition = $definitions[$code]
+    $retryable = [bool]$definition[3]
+    if ($providerCode -eq '50088') { $retryable = $false }
+
+    $correlationId = $null
+    $traceId = $null
+    $requestId = $null
+    foreach ($source in $sources) {
+        if (-not $correlationId) { $correlationId = & $getValue $source @('correlation_id', 'correlationId', 'CorrelationId') }
+        if (-not $traceId) { $traceId = & $getValue $source @('trace_id', 'traceId', 'TraceId') }
+        if (-not $requestId) { $requestId = & $getValue $source @('request_id', 'requestId', 'RequestId') }
+    }
+
+    $safeIdentifier = {
+        param($Value)
+        if ($null -eq $Value) { return $null }
+        $text = [string]$Value
+        if ($text -match '^[A-Za-z0-9._:-]{1,128}$') { return $text }
+        return $null
+    }
+
+    $conditionalAccessScenarios = @{
+        '53000' = 'DeviceNotCompliant'; '53001' = 'DeviceNotDomainJoined'; '53002' = 'ApplicationBlocked'
+        '53003' = 'PolicyBlocked'; '53004' = 'ProofUpRequired'; '53009' = 'ApplicationRequiresProtectionPolicy'
+    }
+
+    $evidence = @()
+    $allowedEvidenceKeys = @('Attempt', 'PageTitle', 'Host', 'Status', 'Field', 'BrowserState')
+    if ($SafeEvidence) {
+        foreach ($key in $SafeEvidence.Keys) {
+            if ([string]$key -notin $allowedEvidenceKeys) { continue }
+            $value = [string]$SafeEvidence[$key]
+            if ($value.Length -gt 256) { $value = $value.Substring(0, 256) }
+            if ($value -match '(?i)(password|cookie|assertion|authorization.?code|token|sft|sctx|canary|session.?id)\s*[:=]') { continue }
+            if ($value -match 'https?://') {
+                try { $value = ([uri]$value).Host } catch { continue }
+            }
+            $evidence += [pscustomobject]@{ Name = [string]$key; Value = $value }
+            if ($evidence.Count -ge 6) { break }
+        }
+    }
+
+    $safeCorrelationId = if ($null -ne $correlationId) { & $safeIdentifier $correlationId } else { $null }
+    $safeTraceId = if ($null -ne $traceId) { & $safeIdentifier $traceId } else { $null }
+    $safeRequestId = if ($null -ne $requestId) { & $safeIdentifier $requestId } else { $null }
+    $conditionalAccessScenario = if ($providerCode -and $conditionalAccessScenarios.ContainsKey($providerCode)) {
+        $conditionalAccessScenarios[$providerCode]
+    } else {
+        $null
+    }
+
+    return [pscustomobject][ordered]@{
+        Code                      = $code
+        ProviderCode              = $providerCode
+        AuthenticationMethod      = $AuthenticationMethod
+        Stage                     = $Stage
+        StatusCode                = $statusCode
+        Retryable                 = $retryable
+        CorrelationId             = $safeCorrelationId
+        TraceId                   = $safeTraceId
+        RequestId                 = $safeRequestId
+        ConditionalAccessScenario = $conditionalAccessScenario
+        SafeEvidence              = $evidence
+        Message                   = $definition[0]
+        RecommendedAction         = $definition[1]
+        ErrorCategory             = [System.Management.Automation.ErrorCategory]::$($definition[2])
+    }
+}

--- a/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
+++ b/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
@@ -55,6 +55,10 @@
         }
     }
 
+    if (-not $providerCode -and $ErrorRecord -and $ErrorRecord.Exception.Message -match '(?i)(?:AADSTS|error(?:\s+code)?[: (]+)(\d{5,8})') {
+        $providerCode = $Matches[1]
+    }
+
     $oauthError = $null
     if (-not [string]::IsNullOrWhiteSpace($RedirectUri)) {
         try {
@@ -142,6 +146,7 @@
     if (-not $code -and $ErrorRecord) {
         $legacyMessage = [string]$ErrorRecord.Exception.Message
         $code = switch -Regex ($legacyMessage) {
+            '(?i)no supported Chromium|browser (executable|application bundle).+(not found|does not contain)|DevTools endpoint.+waiting' { 'BrowserStartupFailed'; break }
             '(?i)browser.+(closed|exited)|websocket.+closed' { 'BrowserClosed'; break }
             '(?i)timed out|timeout expired' { 'BrowserTimeout'; break }
             '(?i)tenant.+(not found|did not return|could not validate)' { 'TenantSelectionFailed'; break }

--- a/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
+++ b/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
@@ -142,13 +142,15 @@
     }
 
     $entraMappings = @{
-        '16000' = 'AccountNotFound'; '50034' = 'AccountNotFound'; '50053' = 'SignInBlocked'; '50055' = 'PasswordExpired'; '50056' = 'PasswordMissing'
+        '16000' = 'AccountNotFound'; '50005' = 'ConditionalAccess'; '50034' = 'AccountNotFound'; '50053' = 'SignInBlocked'; '50055' = 'PasswordExpired'; '50056' = 'PasswordMissing'
         '50057' = 'AccountDisabled'; '50126' = 'InvalidCredentials'; '50058' = 'SessionUnavailable'
         '50072' = 'MfaEnrollmentRequired'; '50079' = 'MfaEnrollmentRequired'; '50074' = 'MfaRequired'; '50076' = 'MfaRequired'
         '50078' = 'MfaTimeout'; '50087' = 'MfaTemporarilyUnavailable'; '50088' = 'MfaTemporarilyUnavailable'; '50089' = 'FlowExpired'
-        '50105' = 'AppAssignmentRequired'; '65001' = 'ConsentRequired'; '90008' = 'ConsentRequired'; '90094' = 'ConsentRequired'; '90095' = 'ConsentRequired'
+        '50105' = 'AppAssignmentRequired'; '50131' = 'ConditionalAccess'; '50142' = 'PasswordExpired'
+        '65001' = 'ConsentRequired'; '90008' = 'ConsentRequired'; '90094' = 'ConsentRequired'; '90095' = 'ConsentRequired'
         '90002' = 'InvalidTenant'; '53000' = 'ConditionalAccess'; '53001' = 'ConditionalAccess'; '53002' = 'ConditionalAccess'
-        '53003' = 'ConditionalAccess'; '53004' = 'ConditionalAccess'; '53009' = 'ConditionalAccess'
+        '53003' = 'ConditionalAccess'; '53004' = 'ConditionalAccess'; '53009' = 'ConditionalAccess'; '53010' = 'ConditionalAccess'
+        '530035' = 'SignInBlocked'; '53011' = 'SignInBlocked'; '530034' = 'SignInBlocked'
         '130503' = 'InvalidCredentials'; '701013' = 'MfaTemporarilyUnavailable'
         '90006' = 'ProviderUnavailable'; '90024' = 'ProviderUnavailable'; '90033' = 'ProviderUnavailable'
     }
@@ -266,8 +268,11 @@
     }
 
     $conditionalAccessScenarios = @{
+        '50005' = 'UnsupportedDevicePlatform'; '50131' = 'PolicyEvaluationFailed'; '50142' = 'PasswordChangeRequired'
         '53000' = 'DeviceNotCompliant'; '53001' = 'DeviceNotDomainJoined'; '53002' = 'ApplicationBlocked'
         '53003' = 'PolicyBlocked'; '53004' = 'ProofUpRequired'; '53009' = 'ApplicationRequiresProtectionPolicy'
+        '53010' = 'SecurityInfoRegistrationRestricted'; '530035' = 'SecurityDefaultsBlocked'
+        '53011' = 'HomeTenantRisk'; '530034' = 'DelegatedAdminRisk'
     }
 
     $evidence = @()
@@ -291,6 +296,8 @@
     $safeRequestId = if ($null -ne $requestId) { & $safeIdentifier $requestId } else { $null }
     $conditionalAccessScenario = if ($providerCode -and $conditionalAccessScenarios.ContainsKey($providerCode)) {
         $conditionalAccessScenarios[$providerCode]
+    } elseif ($evidence | Where-Object { $_.Name -eq 'Host' -and $_.Value -match '(?i)(?:^|\.)access\.mcas\.ms$' } | Select-Object -First 1) {
+        'AppControlProxy'
     } else {
         $null
     }
@@ -300,6 +307,42 @@
     if ($conditionalAccessScenario -eq 'DeviceNotCompliant') {
         $message = 'A Conditional Access policy requires a compliant device, and the sign-in device did not meet that requirement.'
         $recommendedAction = 'Retry from a device marked compliant in Entra ID, or ask a tenant administrator to review the device-compliance grant control in the sign-in logs.'
+    } elseif ($conditionalAccessScenario -eq 'UnsupportedDevicePlatform') {
+        $message = 'A Conditional Access policy does not support the device platform used for this sign-in.'
+        $recommendedAction = 'Retry from an allowed device platform, or ask a tenant administrator to review the device-platform condition in the sign-in logs.'
+    } elseif ($conditionalAccessScenario -eq 'PolicyEvaluationFailed') {
+        $message = 'Conditional Access evaluation failed because of a device-state, risk, access-policy, or security-policy decision.'
+        $recommendedAction = 'Review the matching Entra sign-in event using the diagnostic identifiers to determine the exact policy decision before retrying.'
+    } elseif ($conditionalAccessScenario -eq 'PasswordChangeRequired') {
+        $message = 'A Conditional Access policy requires the account password to be changed.'
+        $recommendedAction = 'Change the password in a policy-supported interactive session, then start a new connection attempt.'
+    } elseif ($conditionalAccessScenario -eq 'DeviceNotDomainJoined') {
+        $message = 'A Conditional Access policy requires a Microsoft Entra hybrid joined device.'
+        $recommendedAction = 'Retry from a Microsoft Entra hybrid joined device, or ask a tenant administrator to review the hybrid-join grant control in the sign-in logs.'
+    } elseif ($conditionalAccessScenario -eq 'ApplicationBlocked') {
+        $message = 'A Conditional Access policy requires an approved client application, and this authentication client is not approved.'
+        $recommendedAction = 'Use an approved client application, or ask a tenant administrator to review the approved-client-app grant control in the sign-in logs.'
+    } elseif ($conditionalAccessScenario -eq 'ProofUpRequired') {
+        $message = 'Access is blocked until the account completes required multifactor authentication registration.'
+        $recommendedAction = 'Complete security-info registration in a policy-supported interactive session, then retry. Review the sign-in logs if registration is also blocked.'
+    } elseif ($conditionalAccessScenario -eq 'ApplicationRequiresProtectionPolicy') {
+        $message = 'The application requires an Intune app protection policy that this authentication client cannot enforce.'
+        $recommendedAction = 'Use an application protected by the required Intune policy, or ask a tenant administrator to review the app-protection grant control in the sign-in logs.'
+    } elseif ($conditionalAccessScenario -eq 'SecurityInfoRegistrationRestricted') {
+        $message = 'The organization permits security-info registration only from specific locations or devices.'
+        $recommendedAction = 'Register the required authentication method from an allowed location and device, or ask a tenant administrator to review the security-info registration policy.'
+    } elseif ($conditionalAccessScenario -eq 'SecurityDefaultsBlocked') {
+        $message = 'Microsoft Entra security defaults blocked this sign-in because the request was considered unsafe or used an unsupported legacy authentication pattern.'
+        $recommendedAction = 'Use a supported modern authentication flow and review the Entra sign-in logs. If the block is unexpected, ask a tenant administrator to review security defaults.'
+    } elseif ($conditionalAccessScenario -eq 'HomeTenantRisk') {
+        $message = 'The account was blocked because of risk detected in its home tenant.'
+        $recommendedAction = 'Ask an administrator in the account home tenant to review and remediate the risky sign-in or risky user event before retrying.'
+    } elseif ($conditionalAccessScenario -eq 'DelegatedAdminRisk') {
+        $message = 'The delegated administrator was blocked because of suspicious activity or account risk in the home tenant.'
+        $recommendedAction = 'Ask an administrator in the delegated account home tenant to review and remediate the risk event before retrying.'
+    } elseif ($conditionalAccessScenario -eq 'AppControlProxy') {
+        $message = 'A Conditional Access App Control policy redirected Defender XDR through the Defender for Cloud Apps reverse proxy.'
+        $recommendedAction = 'Open Defender XDR in a policy-supported browser session, or ask a tenant administrator to review the Conditional Access App Control session control for this account. XDRInternals cannot continue the Defender session through the reverse proxy.'
     } elseif ($providerCode -eq '130503' -and $AuthenticationMethod -eq 'TemporaryAccessPass') {
         $message = 'The Temporary Access Pass was not accepted.'
         $recommendedAction = 'Ask an authentication administrator for a new Temporary Access Pass, then retry.'

--- a/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
+++ b/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
@@ -1,4 +1,48 @@
 ﻿function Get-XdrAuthenticationFailure {
+    <#
+    .SYNOPSIS
+        Classifies an authentication failure into the internal XDR authentication error contract.
+
+    .DESCRIPTION
+        Normalizes exact Entra error state, OAuth redirects, SAS results, HTTP responses, and
+        native PowerShell errors into a secret-safe authentication failure description.
+
+    .PARAMETER ErrorRecord
+        A native PowerShell error to inspect for structured response details and status.
+
+    .PARAMETER AuthState
+        Parsed Entra authentication state containing exact provider error fields.
+
+    .PARAMETER RedirectUri
+        An OAuth redirect URI whose error fields should be classified without retaining other values.
+
+    .PARAMETER SasResult
+        A Server Authentication State result to classify.
+
+    .PARAMETER Response
+        An HTTP response whose status and safe identifiers should be inspected.
+
+    .PARAMETER AuthenticationMethod
+        The Connect authentication method that encountered the failure.
+
+    .PARAMETER Stage
+        The authentication stage that encountered the failure.
+
+    .PARAMETER DefaultCode
+        The stable fallback classification to use when no stronger structured signal exists.
+
+    .PARAMETER SafeEvidence
+        A small dictionary of allowlisted diagnostic evidence. Unknown or sensitive fields are discarded.
+
+    .EXAMPLE
+        Get-XdrAuthenticationFailure -AuthState $authState -AuthenticationMethod Credential -Stage Password
+
+        Classifies exact Entra state returned after password submission.
+
+    .OUTPUTS
+        PSCustomObject containing the normalized authentication failure.
+    #>
+    [OutputType([pscustomobject])]
     [CmdletBinding()]
     param(
         [System.Management.Automation.ErrorRecord]$ErrorRecord,

--- a/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
+++ b/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
@@ -149,6 +149,7 @@
         '50105' = 'AppAssignmentRequired'; '65001' = 'ConsentRequired'; '90008' = 'ConsentRequired'; '90094' = 'ConsentRequired'; '90095' = 'ConsentRequired'
         '90002' = 'InvalidTenant'; '53000' = 'ConditionalAccess'; '53001' = 'ConditionalAccess'; '53002' = 'ConditionalAccess'
         '53003' = 'ConditionalAccess'; '53004' = 'ConditionalAccess'; '53009' = 'ConditionalAccess'
+        '130503' = 'InvalidCredentials'; '701013' = 'MfaTemporarilyUnavailable'
         '90006' = 'ProviderUnavailable'; '90024' = 'ProviderUnavailable'; '90033' = 'ProviderUnavailable'
     }
 
@@ -192,7 +193,12 @@
         $code = switch -Regex ($legacyMessage) {
             '(?i)no supported Chromium|browser (executable|application bundle).+(not found|does not contain)|DevTools endpoint.+waiting' { 'BrowserStartupFailed'; break }
             '(?i)browser.+(closed|exited)|websocket.+closed' { 'BrowserClosed'; break }
-            '(?i)timed out|timeout expired' { 'BrowserTimeout'; break }
+            '(?i)timed out|timeout expired' {
+                if ($AuthenticationMethod -eq 'PhoneSignIn') { 'MfaTimeout' }
+                elseif ($AuthenticationMethod -in @('Browser', 'SSO')) { 'BrowserTimeout' }
+                else { 'UnknownFailure' }
+                break
+            }
             '(?i)tenant.+(not found|did not return|could not validate)' { 'TenantSelectionFailed'; break }
             '(?i)credential file.+(not found|invalid|missing)|invalid JSON in credential' { 'CredentialFileInvalid'; break }
             '(?i)key vault.+(token|access|sign)' { 'KeyVaultAccessFailed'; break }
@@ -294,6 +300,9 @@
     if ($conditionalAccessScenario -eq 'DeviceNotCompliant') {
         $message = 'A Conditional Access policy requires a compliant device, and the sign-in device did not meet that requirement.'
         $recommendedAction = 'Retry from a device marked compliant in Entra ID, or ask a tenant administrator to review the device-compliance grant control in the sign-in logs.'
+    } elseif ($providerCode -eq '130503' -and $AuthenticationMethod -eq 'TemporaryAccessPass') {
+        $message = 'The Temporary Access Pass was not accepted.'
+        $recommendedAction = 'Ask an authentication administrator for a new Temporary Access Pass, then retry.'
     }
 
     return [pscustomobject][ordered]@{

--- a/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
+++ b/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
@@ -142,7 +142,7 @@
     }
 
     $entraMappings = @{
-        '50034' = 'AccountNotFound'; '50053' = 'SignInBlocked'; '50055' = 'PasswordExpired'; '50056' = 'PasswordMissing'
+        '16000' = 'AccountNotFound'; '50034' = 'AccountNotFound'; '50053' = 'SignInBlocked'; '50055' = 'PasswordExpired'; '50056' = 'PasswordMissing'
         '50057' = 'AccountDisabled'; '50126' = 'InvalidCredentials'; '50058' = 'SessionUnavailable'
         '50072' = 'MfaEnrollmentRequired'; '50079' = 'MfaEnrollmentRequired'; '50074' = 'MfaRequired'; '50076' = 'MfaRequired'
         '50078' = 'MfaTimeout'; '50087' = 'MfaTemporarilyUnavailable'; '50088' = 'MfaTemporarilyUnavailable'; '50089' = 'FlowExpired'

--- a/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
+++ b/XDRInternals/internal/functions/Get-XdrAuthenticationFailure.ps1
@@ -289,6 +289,13 @@
         $null
     }
 
+    $message = $definition[0]
+    $recommendedAction = $definition[1]
+    if ($conditionalAccessScenario -eq 'DeviceNotCompliant') {
+        $message = 'A Conditional Access policy requires a compliant device, and the sign-in device did not meet that requirement.'
+        $recommendedAction = 'Retry from a device marked compliant in Entra ID, or ask a tenant administrator to review the device-compliance grant control in the sign-in logs.'
+    }
+
     return [pscustomobject][ordered]@{
         Code                      = $code
         ProviderCode              = $providerCode
@@ -301,8 +308,8 @@
         RequestId                 = $safeRequestId
         ConditionalAccessScenario = $conditionalAccessScenario
         SafeEvidence              = $evidence
-        Message                   = $definition[0]
-        RecommendedAction         = $definition[1]
+        Message                   = $message
+        RecommendedAction         = $recommendedAction
         ErrorCategory             = [System.Management.Automation.ErrorCategory]::$($definition[2])
     }
 }

--- a/XDRInternals/internal/functions/Invoke-XdrBrowserAuthentication.ps1
+++ b/XDRInternals/internal/functions/Invoke-XdrBrowserAuthentication.ps1
@@ -1091,6 +1091,8 @@ function Invoke-XdrBrowserAuthentication {
         $selectedXsrfToken = $null
         $firstEstsCookieObservedAt = $null
         $lastObservedTargetDescription = $null
+        $lastObservedTargetTitle = $null
+        $lastObservedTargetHost = $null
 
         do {
             Start-Sleep -Seconds 2
@@ -1098,12 +1100,11 @@ function Invoke-XdrBrowserAuthentication {
             if ($browserProcess) {
                 $browserProcess.Refresh()
                 if ($browserProcess.HasExited) {
-                    $message = 'The browser window was closed before the browser sign-in completed.'
-                    if ($lastObservedTargetDescription) {
-                        $message += " Last observed browser page: $lastObservedTargetDescription"
+                    $failure = Get-XdrAuthenticationFailure -AuthenticationMethod Browser -Stage BrowserSignIn -DefaultCode BrowserClosed -SafeEvidence @{
+                        PageTitle = $lastObservedTargetTitle
+                        Host = $lastObservedTargetHost
                     }
-
-                    throw $message
+                    throw (New-XdrAuthenticationErrorRecord -Failure $failure)
                 }
             }
 
@@ -1112,6 +1113,8 @@ function Invoke-XdrBrowserAuthentication {
                 $currentTargetDescription = Format-XdrBrowserTargetDescription -Url $targetContext.Url -Title $targetContext.Title
                 if ($currentTargetDescription -and $currentTargetDescription -ne $lastObservedTargetDescription) {
                     $lastObservedTargetDescription = $currentTargetDescription
+                    $lastObservedTargetTitle = [string]$targetContext.Title
+                    try { $lastObservedTargetHost = ([uri]$targetContext.Url).Host } catch { $lastObservedTargetHost = $null }
                     Write-Verbose "Observed browser page: $currentTargetDescription"
                 }
 
@@ -1136,12 +1139,11 @@ function Invoke-XdrBrowserAuthentication {
         } while ((Get-Date) -lt $deadline)
 
         if (-not $selectedSccAuth -and -not $selectedEstsCookie) {
-            $message = 'Browser sign-in did not produce Defender portal or ESTS authentication cookies before the timeout expired.'
-            if ($lastObservedTargetDescription) {
-                $message += " Last observed browser page: $lastObservedTargetDescription"
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod Browser -Stage BrowserSignIn -DefaultCode BrowserTimeout -SafeEvidence @{
+                PageTitle = $lastObservedTargetTitle
+                Host = $lastObservedTargetHost
             }
-
-            throw $message
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         if ($selectedSccAuth) {

--- a/XDRInternals/internal/functions/Invoke-XdrBrowserAuthentication.ps1
+++ b/XDRInternals/internal/functions/Invoke-XdrBrowserAuthentication.ps1
@@ -822,11 +822,18 @@ function Format-XdrBrowserTargetDescription {
         return $null
     }
 
-    if ([string]::IsNullOrWhiteSpace($Title)) {
-        return $Url
+    try {
+        $parsedUrl = [uri]$Url
+        $safeUrl = "$($parsedUrl.Scheme)://$($parsedUrl.Host)$($parsedUrl.AbsolutePath)"
+    } catch {
+        return $null
     }
 
-    return "$Title [$Url]"
+    if ([string]::IsNullOrWhiteSpace($Title)) {
+        return $safeUrl
+    }
+
+    return "$Title [$safeUrl]"
 }
 
 function Invoke-XdrBrowserCdpCommand {
@@ -893,6 +900,75 @@ function Invoke-XdrBrowserCdpCommand {
     } finally {
         $webSocket.Dispose()
         $cancellation.Dispose()
+    }
+}
+
+function Get-XdrBrowserAuthenticationPageError {
+    <#
+    .SYNOPSIS
+        Reads allowlisted authentication error state from the current browser page.
+
+    .DESCRIPTION
+        Uses the Chrome DevTools Runtime domain to project only numeric Entra error code and
+        correlation identifiers from the page's $Config object. It does not read provider error
+        text, HTML, DOM content, scripts, or authentication flow and session fields.
+
+    .PARAMETER WebSocketUrl
+        The DevTools WebSocket URL for the current browser page target.
+
+    .EXAMPLE
+        Get-XdrBrowserAuthenticationPageError -WebSocketUrl $targetContext.WebSocketUrl
+
+        Returns allowlisted error state when the current sign-in page exposes an exact error code.
+
+    .OUTPUTS
+        PSCustomObject containing exact provider error state, or no output when none is available.
+    #>
+    [OutputType([pscustomobject])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$WebSocketUrl
+    )
+
+    $expression = @'
+(() => {
+    const config = globalThis.$Config;
+    if (!config || typeof config !== 'object') return null;
+    const projected = {};
+    for (const key of ['sErrorCode', 'iErrorCode', 'correlationId', 'traceId']) {
+        const value = config[key];
+        if (value !== undefined && value !== null && value !== '') projected[key] = String(value);
+    }
+    return Object.keys(projected).length ? JSON.stringify(projected) : null;
+})()
+'@
+
+    $evaluation = Invoke-XdrBrowserCdpCommand -WebSocketUrl $WebSocketUrl -Method 'Runtime.evaluate' -Params @{
+        expression    = $expression
+        returnByValue = $true
+        awaitPromise  = $false
+    }
+    $serializedState = [string]$evaluation.result.value
+    if ([string]::IsNullOrWhiteSpace($serializedState)) {
+        return $null
+    }
+
+    try {
+        $state = $serializedState | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        return $null
+    }
+
+    $providerCode = if ($state.sErrorCode) { [string]$state.sErrorCode } else { [string]$state.iErrorCode }
+    if ($providerCode -eq '0' -or $providerCode -notmatch '^(?i:AADSTS)?\d{5,8}$') {
+        return $null
+    }
+
+    return [pscustomobject][ordered]@{
+        sErrorCode    = $providerCode
+        correlationId = [string]$state.correlationId
+        traceId       = [string]$state.traceId
     }
 }
 
@@ -1093,6 +1169,7 @@ function Invoke-XdrBrowserAuthentication {
         $lastObservedTargetDescription = $null
         $lastObservedTargetTitle = $null
         $lastObservedTargetHost = $null
+        $lastObservedPageErrorState = $null
 
         do {
             Start-Sleep -Seconds 2
@@ -1117,10 +1194,23 @@ function Invoke-XdrBrowserAuthentication {
                     try { $lastObservedTargetHost = ([uri]$targetContext.Url).Host } catch { $lastObservedTargetHost = $null }
                     Write-Verbose "Observed browser page: $currentTargetDescription"
                 }
+            } catch {
+                Write-Verbose 'Browser target polling failed.'
+                continue
+            }
 
+            $pageErrorState = $null
+            try {
+                $pageErrorState = Get-XdrBrowserAuthenticationPageError -WebSocketUrl $targetContext.WebSocketUrl
+                $lastObservedPageErrorState = $pageErrorState
+            } catch {
+                Write-Verbose 'Browser page diagnostics were unavailable.'
+            }
+
+            try {
                 $cookies = @(Get-XdrBrowserCookieJar -WebSocketUrl $targetContext.WebSocketUrl)
             } catch {
-                Write-Verbose "Cookie polling failed: $($_.Exception.Message)"
+                Write-Verbose 'Browser cookie polling failed.'
                 continue
             }
 
@@ -1139,10 +1229,19 @@ function Invoke-XdrBrowserAuthentication {
         } while ((Get-Date) -lt $deadline)
 
         if (-not $selectedSccAuth -and -not $selectedEstsCookie) {
-            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod Browser -Stage BrowserSignIn -DefaultCode BrowserTimeout -SafeEvidence @{
-                PageTitle = $lastObservedTargetTitle
-                Host = $lastObservedTargetHost
+            $failureParams = @{
+                AuthenticationMethod = 'Browser'
+                Stage = 'BrowserSignIn'
+                DefaultCode = 'BrowserTimeout'
+                SafeEvidence = @{
+                    PageTitle = $lastObservedTargetTitle
+                    Host = $lastObservedTargetHost
+                }
             }
+            if ($lastObservedPageErrorState) {
+                $failureParams.AuthState = $lastObservedPageErrorState
+            }
+            $failure = Get-XdrAuthenticationFailure @failureParams
             throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 

--- a/XDRInternals/internal/functions/Invoke-XdrCredentialAuthentication.ps1
+++ b/XDRInternals/internal/functions/Invoke-XdrCredentialAuthentication.ps1
@@ -604,7 +604,8 @@ function Invoke-XdrCredentialAuthentication {
 
     if (-not $sessionInfo.urlPost) {
         if ($sessionInfo.sErrorCode) {
-            throw "Authentication failed with error $($sessionInfo.sErrorCode): $($sessionInfo.sErrTxt)"
+            $failure = Get-XdrAuthenticationFailure -AuthState $sessionInfo -AuthenticationMethod Credential -Stage Authorize
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
         throw "Unexpected response: no urlPost in login page configuration."
     }
@@ -652,18 +653,8 @@ function Invoke-XdrCredentialAuthentication {
 
     # Check for credential errors
     if ($authState.sErrorCode) {
-        $errorMessages = @{
-            '50126' = "Invalid username or password."
-            '50053' = "Account is locked. Too many failed sign-in attempts."
-            '50057' = "Account is disabled."
-            '50055' = "Password has expired."
-            '50056' = "Invalid or null password."
-            '53003' = "Blocked by Conditional Access policy."
-            '50034' = "User account not found."
-        }
-        $msg = $errorMessages[$authState.sErrorCode]
-        if (-not $msg) { $msg = $authState.sErrTxt }
-        throw "Authentication failed ($($authState.sErrorCode)): $msg"
+        $failure = Get-XdrAuthenticationFailure -AuthState $authState -AuthenticationMethod Credential -Stage Password
+        throw (New-XdrAuthenticationErrorRecord -Failure $failure)
     }
 
     Write-Verbose "Credential submission succeeded (pgid: $($authState.pgid))"
@@ -698,7 +689,7 @@ function Invoke-XdrCredentialAuthentication {
             'PhoneAppOTP' {
                 if ($TotpSecret) {
                     $verificationCode = Get-XdrTotpCode -Secret $TotpSecret
-                    Write-Verbose "Computed TOTP code: $verificationCode"
+                    Write-Verbose 'Computed a TOTP verification code.'
                 } else {
                     Write-Host "Enter the code from your authenticator app:"
                     $verificationCode = Read-Host "Code"
@@ -752,8 +743,8 @@ function Invoke-XdrCredentialAuthentication {
                 -WebSession $session -Verbose:$false
 
             if (-not (Test-XdrMfaAuthSucceeded -Response $endAuth)) {
-                $errDetail = if ($endAuth.Message) { $endAuth.Message } else { $endAuth.ResultValue }
-                throw "MFA verification failed: $errDetail"
+                $failure = Get-XdrAuthenticationFailure -SasResult $endAuth -AuthenticationMethod Credential -Stage Mfa -DefaultCode MfaDenied
+                throw (New-XdrAuthenticationErrorRecord -Failure $failure)
             }
 
             Write-Host "MFA verification succeeded."

--- a/XDRInternals/internal/functions/Invoke-XdrPasskeyAuthentication.ps1
+++ b/XDRInternals/internal/functions/Invoke-XdrPasskeyAuthentication.ps1
@@ -290,7 +290,7 @@ function Invoke-XdrPasskeyAuthentication {
     $credentialId = ($credentialId.TrimEnd('=') -replace '\+', '-' -replace '/', '_') | ForEach-Object { ConvertFrom-XdrUuidToBase64Url $_ }
 
     Write-Verbose "User: $targetUser | RP ID: $rpId | Origin: $origin"
-    Write-Verbose "Credential ID: $($credentialId.Substring(0, [Math]::Min(20, $credentialId.Length)))..."
+    Write-Verbose 'Loaded a passkey credential identifier.'
     #endregion
 
     #region Determine signing mode and prepare credentials
@@ -533,12 +533,9 @@ function Invoke-XdrPasskeyAuthentication {
     }
 
     if ($authFailed) {
-        $hint = if ($useKeyVault) {
-            "Key Vault signature validation failed. Verify Key Vault permissions (Crypto User / Sign), key name, and vault name."
-        } else {
-            "Passkey signature validation failed. Verify the credential ID and private key in the credential file."
-        }
-        throw "Authentication failed during passkey validation. $hint"
+        $failureCode = if ($useKeyVault) { 'KeyVaultAccessFailed' } else { 'PasskeyAssertionFailed' }
+        $failure = Get-XdrAuthenticationFailure -AuthenticationMethod SoftwarePasskey -Stage AssertionValidation -DefaultCode $failureCode
+        throw (New-XdrAuthenticationErrorRecord -Failure $failure)
     }
     #endregion
 
@@ -550,7 +547,8 @@ function Invoke-XdrPasskeyAuthentication {
 
     $estsCookies = $allCookies | Where-Object Name -Like "ESTS*"
     if (-not $estsCookies) {
-        throw "Authentication flow completed but no ESTS authentication cookie was obtained. The passkey credentials may be invalid or expired."
+        $failure = Get-XdrAuthenticationFailure -AuthenticationMethod SoftwarePasskey -Stage ArtifactCapture -DefaultCode NoAuthenticationArtifact
+        throw (New-XdrAuthenticationErrorRecord -Failure $failure)
     }
 
     # Pick the longest cookie (ESTSAUTHPERSISTENT is preferred when available)

--- a/XDRInternals/internal/functions/Invoke-XdrPhoneSignInAuthentication.ps1
+++ b/XDRInternals/internal/functions/Invoke-XdrPhoneSignInAuthentication.ps1
@@ -317,8 +317,8 @@ function Invoke-XdrPhoneSignInStartRemoteNgcChallenge {
     }
 
     if ([string]::IsNullOrWhiteSpace($sessionLookupKey)) {
-        $summary = $challengeResponse | ConvertTo-Json -Compress -Depth 10
-        throw "Phone sign-in challenge start did not return an active RemoteNGC session. Response: $summary"
+        $failure = Get-XdrAuthenticationFailure -AuthenticationMethod PhoneSignIn -Stage ChallengeStart -DefaultCode ProviderRejected -SafeEvidence @{ Status = [string]$challengeResponse.status }
+        throw (New-XdrAuthenticationErrorRecord -Failure $failure)
     }
 
     return [pscustomobject]@{
@@ -775,7 +775,8 @@ function Invoke-XdrPhoneSignInAuthentication {
         }
 
         if ($sasOutcome.Outcome.AuthState -and $sasOutcome.Outcome.AuthState.sErrorCode) {
-            throw "Phone sign-in failed with error $($sasOutcome.Outcome.AuthState.sErrorCode): $($sasOutcome.Outcome.AuthState.sErrTxt)"
+            $failure = Get-XdrAuthenticationFailure -AuthState $sasOutcome.Outcome.AuthState -AuthenticationMethod PhoneSignIn -Stage SasCompletion
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         throw 'Phone sign-in completed, but no ESTSAUTH cookie was captured.'
@@ -827,7 +828,8 @@ function Invoke-XdrPhoneSignInAuthentication {
         }
 
         if ($submitResult.AuthState -and $submitResult.AuthState.sErrorCode) {
-            throw "Phone sign-in login submission failed with error $($submitResult.AuthState.sErrorCode): $($submitResult.AuthState.sErrTxt)"
+            $failure = Get-XdrAuthenticationFailure -AuthState $submitResult.AuthState -AuthenticationMethod PhoneSignIn -Stage LoginSubmission
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         throw 'Phone sign-in completed and approved, but no ESTSAUTH cookie was captured.'
@@ -847,7 +849,8 @@ function Invoke-XdrPhoneSignInAuthentication {
         }
 
         if ($sasOutcome.Outcome.AuthState -and $sasOutcome.Outcome.AuthState.sErrorCode) {
-            throw "Phone sign-in failed with error $($sasOutcome.Outcome.AuthState.sErrorCode): $($sasOutcome.Outcome.AuthState.sErrTxt)"
+            $failure = Get-XdrAuthenticationFailure -AuthState $sasOutcome.Outcome.AuthState -AuthenticationMethod PhoneSignIn -Stage SasCompletion
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         throw 'Phone sign-in completed, but no ESTSAUTH cookie was captured.'
@@ -873,7 +876,8 @@ function Invoke-XdrPhoneSignInAuthentication {
         }
 
         if ($sasOutcome.Outcome.AuthState -and $sasOutcome.Outcome.AuthState.sErrorCode) {
-            throw "Phone sign-in failed with error $($sasOutcome.Outcome.AuthState.sErrorCode): $($sasOutcome.Outcome.AuthState.sErrTxt)"
+            $failure = Get-XdrAuthenticationFailure -AuthState $sasOutcome.Outcome.AuthState -AuthenticationMethod PhoneSignIn -Stage SasCompletion
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         throw 'Phone sign-in completed, but no ESTSAUTH cookie was captured.'

--- a/XDRInternals/internal/functions/Invoke-XdrSasAuthentication.ps1
+++ b/XDRInternals/internal/functions/Invoke-XdrSasAuthentication.ps1
@@ -97,7 +97,8 @@ function Invoke-XdrSasBeginAuth {
             $beginAuth.SessionId = $AuthState.sessionId
         }
     } elseif (-not $beginAuth.Success -and $beginAuth.ErrCode -ne 0) {
-        throw "$FailureLabel BeginAuth failed (ErrCode: $($beginAuth.ErrCode)): $($beginAuth.Message)"
+        $failure = Get-XdrAuthenticationFailure -SasResult $beginAuth -AuthenticationMethod $FailureLabel -Stage MfaBegin -DefaultCode ProviderRejected
+        throw (New-XdrAuthenticationErrorRecord -Failure $failure)
     }
 
     Write-Verbose "BeginAuth response: Success=$($beginAuth.Success), ResultValue=$($beginAuth.ResultValue)"
@@ -233,19 +234,23 @@ function Invoke-XdrSasPushNotificationPolling {
         }
 
         if ($pollResult.ResultValue -ne 'AuthenticationPending') {
-            throw "$FailureLabel denied or failed: $($pollResult.ResultValue) - $($pollResult.Message)"
+            $failure = Get-XdrAuthenticationFailure -SasResult $pollResult -AuthenticationMethod $FailureLabel -Stage MfaPolling -DefaultCode MfaDenied
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         if (-not $pollResult.Retry) {
-            throw "$FailureLabel timed out. Retry is false."
+            $failure = Get-XdrAuthenticationFailure -SasResult $pollResult -AuthenticationMethod $FailureLabel -Stage MfaPolling -DefaultCode MfaTimeout
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
     }
 
     if ($TimeoutMessage) {
-        throw ($TimeoutMessage -f ($pollCount * $PollingIntervalSeconds))
+        $failure = Get-XdrAuthenticationFailure -AuthenticationMethod $FailureLabel -Stage MfaPolling -DefaultCode MfaTimeout
+        throw (New-XdrAuthenticationErrorRecord -Failure $failure)
     }
 
-    throw "$FailureLabel did not complete before the timeout expired."
+    $failure = Get-XdrAuthenticationFailure -AuthenticationMethod $FailureLabel -Stage MfaPolling -DefaultCode MfaTimeout
+    throw (New-XdrAuthenticationErrorRecord -Failure $failure)
 }
 
 function Invoke-XdrSasProcessAuth {

--- a/XDRInternals/internal/functions/Invoke-XdrSsoAuthentication.ps1
+++ b/XDRInternals/internal/functions/Invoke-XdrSsoAuthentication.ps1
@@ -359,6 +359,7 @@ function Invoke-XdrSsoAuthentication {
         $lastObservedTargetDescription = $null
         $lastObservedTargetTitle = $null
         $lastObservedTargetHost = $null
+        $lastObservedPageErrorState = $null
 
         do {
             Start-Sleep -Seconds 2
@@ -383,10 +384,23 @@ function Invoke-XdrSsoAuthentication {
                     try { $lastObservedTargetHost = ([uri]$targetContext.Url).Host } catch { $lastObservedTargetHost = $null }
                     Write-Verbose "Observed browser page: $currentTargetDescription"
                 }
+            } catch {
+                Write-Verbose 'Browser target polling failed.'
+                continue
+            }
 
+            $pageErrorState = $null
+            try {
+                $pageErrorState = Get-XdrBrowserAuthenticationPageError -WebSocketUrl $targetContext.WebSocketUrl
+                $lastObservedPageErrorState = $pageErrorState
+            } catch {
+                Write-Verbose 'Browser page diagnostics were unavailable.'
+            }
+
+            try {
                 $cookies = @(Get-XdrBrowserCookieJar -WebSocketUrl $targetContext.WebSocketUrl)
             } catch {
-                Write-Verbose "Cookie polling failed: $($_.Exception.Message)"
+                Write-Verbose 'Browser cookie polling failed.'
                 continue
             }
 
@@ -407,10 +421,19 @@ function Invoke-XdrSsoAuthentication {
         } while ((Get-Date) -lt $deadline)
 
         if (-not $sccAuthCookieValue -and -not $estsAuthCookieValue) {
-            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod SSO -Stage BrowserSignIn -DefaultCode BrowserTimeout -SafeEvidence @{
-                PageTitle = $lastObservedTargetTitle
-                Host = $lastObservedTargetHost
+            $failureParams = @{
+                AuthenticationMethod = 'SSO'
+                Stage = 'BrowserSignIn'
+                DefaultCode = 'BrowserTimeout'
+                SafeEvidence = @{
+                    PageTitle = $lastObservedTargetTitle
+                    Host = $lastObservedTargetHost
+                }
             }
+            if ($lastObservedPageErrorState) {
+                $failureParams.AuthState = $lastObservedPageErrorState
+            }
+            $failure = Get-XdrAuthenticationFailure @failureParams
             throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 

--- a/XDRInternals/internal/functions/Invoke-XdrSsoAuthentication.ps1
+++ b/XDRInternals/internal/functions/Invoke-XdrSsoAuthentication.ps1
@@ -357,6 +357,8 @@ function Invoke-XdrSsoAuthentication {
         $xsrfToken = $null
         $firstEstsCookieObservedAt = $null
         $lastObservedTargetDescription = $null
+        $lastObservedTargetTitle = $null
+        $lastObservedTargetHost = $null
 
         do {
             Start-Sleep -Seconds 2
@@ -364,21 +366,11 @@ function Invoke-XdrSsoAuthentication {
             if ($browserProcess) {
                 $browserProcess.Refresh()
                 if ($browserProcess.HasExited) {
-                    if ($Visible) {
-                        $message = 'The browser window closed before SSO authentication completed.'
-                        if ($lastObservedTargetDescription) {
-                            $message += " Last observed browser page: $lastObservedTargetDescription"
-                        }
-
-                        throw $message
+                    $failure = Get-XdrAuthenticationFailure -AuthenticationMethod SSO -Stage BrowserSignIn -DefaultCode BrowserClosed -SafeEvidence @{
+                        PageTitle = $lastObservedTargetTitle
+                        Host = $lastObservedTargetHost
                     }
-
-                    $message = 'The browser exited before SSO authentication completed. Retry with -Visible to observe the flow on this device.'
-                    if ($lastObservedTargetDescription) {
-                        $message += " Last observed browser page: $lastObservedTargetDescription"
-                    }
-
-                    throw $message
+                    throw (New-XdrAuthenticationErrorRecord -Failure $failure)
                 }
             }
 
@@ -387,6 +379,8 @@ function Invoke-XdrSsoAuthentication {
                 $currentTargetDescription = Format-XdrBrowserTargetDescription -Url $targetContext.Url -Title $targetContext.Title
                 if ($currentTargetDescription -and $currentTargetDescription -ne $lastObservedTargetDescription) {
                     $lastObservedTargetDescription = $currentTargetDescription
+                    $lastObservedTargetTitle = [string]$targetContext.Title
+                    try { $lastObservedTargetHost = ([uri]$targetContext.Url).Host } catch { $lastObservedTargetHost = $null }
                     Write-Verbose "Observed browser page: $currentTargetDescription"
                 }
 
@@ -413,12 +407,11 @@ function Invoke-XdrSsoAuthentication {
         } while ((Get-Date) -lt $deadline)
 
         if (-not $sccAuthCookieValue -and -not $estsAuthCookieValue) {
-            $message = 'SSO authentication did not produce Defender portal or ESTS cookies before the timeout expired.'
-            if ($lastObservedTargetDescription) {
-                $message += " Last observed browser page: $lastObservedTargetDescription"
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod SSO -Stage BrowserSignIn -DefaultCode BrowserTimeout -SafeEvidence @{
+                PageTitle = $lastObservedTargetTitle
+                Host = $lastObservedTargetHost
             }
-
-            throw $message
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
         }
 
         $selectedTenant = $null

--- a/XDRInternals/internal/functions/Invoke-XdrTemporaryAccessPassAuthentication.ps1
+++ b/XDRInternals/internal/functions/Invoke-XdrTemporaryAccessPassAuthentication.ps1
@@ -145,7 +145,8 @@
             }
 
             if ($parsedState -and $parsedState.sErrorCode) {
-                throw "TAP authentication failed ($($parsedState.sErrorCode)): $($parsedState.sErrTxt)"
+                $failure = Get-XdrAuthenticationFailure -AuthState $parsedState -AuthenticationMethod TemporaryAccessPass -Stage PassSubmission
+                throw (New-XdrAuthenticationErrorRecord -Failure $failure)
             }
 
             break
@@ -168,7 +169,8 @@
             }
 
             if ($resolvedLocation -match 'error=') {
-                throw "TAP authentication failed: $resolvedLocation"
+                $failure = Get-XdrAuthenticationFailure -RedirectUri $resolvedLocation -AuthenticationMethod TemporaryAccessPass -Stage Redirect
+                throw (New-XdrAuthenticationErrorRecord -Failure $failure)
             }
 
             $currentUrl = $resolvedLocation
@@ -180,7 +182,8 @@
 
     $bestCookie = Get-XdrBestEstsCookieValue -Session $session
     if (-not $bestCookie) {
-        throw 'No ESTSAUTH cookie found after TAP authentication.'
+        $failure = Get-XdrAuthenticationFailure -AuthenticationMethod TemporaryAccessPass -Stage ArtifactCapture -DefaultCode NoAuthenticationArtifact
+        throw (New-XdrAuthenticationErrorRecord -Failure $failure)
     }
 
     Write-Verbose "Obtained ESTS cookie (length: $($bestCookie.Length))"

--- a/XDRInternals/internal/functions/New-XdrAuthenticationErrorRecord.ps1
+++ b/XDRInternals/internal/functions/New-XdrAuthenticationErrorRecord.ps1
@@ -1,0 +1,41 @@
+﻿function New-XdrAuthenticationErrorRecord {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Creates and returns an in-memory ErrorRecord without changing external state.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Failure,
+        [System.Management.Automation.ErrorRecord]$ErrorRecord,
+        [object]$TargetObject
+    )
+
+    if ($ErrorRecord -and $ErrorRecord.FullyQualifiedErrorId -like 'XdrAuthentication.*') {
+        return $ErrorRecord
+    }
+
+    $innerException = if ($ErrorRecord) { $ErrorRecord.Exception } else { $null }
+    $exception = [System.Security.Authentication.AuthenticationException]::new([string]$Failure.Message, $innerException)
+    $metadata = [pscustomobject][ordered]@{
+        Code                      = $Failure.Code
+        ProviderCode              = $Failure.ProviderCode
+        AuthenticationMethod      = $Failure.AuthenticationMethod
+        Stage                     = $Failure.Stage
+        StatusCode                = $Failure.StatusCode
+        Retryable                 = $Failure.Retryable
+        CorrelationId             = $Failure.CorrelationId
+        TraceId                   = $Failure.TraceId
+        RequestId                 = $Failure.RequestId
+        ConditionalAccessScenario = $Failure.ConditionalAccessScenario
+        SafeEvidence              = @($Failure.SafeEvidence)
+    }
+    $exception.Data['XdrAuthenticationFailure'] = $metadata
+
+    $result = [System.Management.Automation.ErrorRecord]::new(
+        $exception,
+        "XdrAuthentication.$($Failure.Code)",
+        $Failure.ErrorCategory,
+        $TargetObject
+    )
+    $result.ErrorDetails = [System.Management.Automation.ErrorDetails]::new([string]$Failure.Message)
+    $result.ErrorDetails.RecommendedAction = [string]$Failure.RecommendedAction
+    return $result
+}

--- a/XDRInternals/internal/functions/New-XdrAuthenticationErrorRecord.ps1
+++ b/XDRInternals/internal/functions/New-XdrAuthenticationErrorRecord.ps1
@@ -1,4 +1,30 @@
 ﻿function New-XdrAuthenticationErrorRecord {
+    <#
+    .SYNOPSIS
+        Creates a terminating PowerShell error from an XDR authentication failure.
+
+    .DESCRIPTION
+        Builds the stable error identifier, category, remediation, and secret-safe metadata for
+        an authentication failure while chaining the original exception when one is available.
+
+    .PARAMETER Failure
+        The normalized failure returned by Get-XdrAuthenticationFailure.
+
+    .PARAMETER ErrorRecord
+        The original PowerShell error to preserve, or an existing structured authentication error to return unchanged.
+
+    .PARAMETER TargetObject
+        An optional safe target object associated with the failure.
+
+    .EXAMPLE
+        New-XdrAuthenticationErrorRecord -Failure $failure -ErrorRecord $_
+
+        Creates a terminating record while preserving the caught exception.
+
+    .OUTPUTS
+        System.Management.Automation.ErrorRecord
+    #>
+    [OutputType([System.Management.Automation.ErrorRecord])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Creates and returns an in-memory ErrorRecord without changing external state.')]
     [CmdletBinding()]
     param(
@@ -8,7 +34,13 @@
         [object]$TargetObject
     )
 
-    if ($ErrorRecord -and $ErrorRecord.FullyQualifiedErrorId -like 'XdrAuthentication.*') {
+    $hasAuthenticationMetadata = (
+        $ErrorRecord -and
+        $ErrorRecord.Exception -and
+        $ErrorRecord.Exception.Data -and
+        $ErrorRecord.Exception.Data.Contains('XdrAuthenticationFailure')
+    )
+    if ($ErrorRecord -and ($ErrorRecord.FullyQualifiedErrorId -like 'XdrAuthentication.*' -or $hasAuthenticationMetadata)) {
         return $ErrorRecord
     }
 

--- a/tests/functions/AuthenticationError.Tests.ps1
+++ b/tests/functions/AuthenticationError.Tests.ps1
@@ -1,0 +1,196 @@
+﻿Describe 'Authentication error classification' {
+    InModuleScope XDRInternals {
+        It 'maps documented Entra code <ProviderCode> to <Code>' -ForEach @(
+            @{ ProviderCode = '50034'; Code = 'AccountNotFound' }
+            @{ ProviderCode = '50053'; Code = 'SignInBlocked' }
+            @{ ProviderCode = '50055'; Code = 'PasswordExpired' }
+            @{ ProviderCode = '50056'; Code = 'PasswordMissing' }
+            @{ ProviderCode = '50057'; Code = 'AccountDisabled' }
+            @{ ProviderCode = '50126'; Code = 'InvalidCredentials' }
+            @{ ProviderCode = '50058'; Code = 'SessionUnavailable' }
+            @{ ProviderCode = '50072'; Code = 'MfaEnrollmentRequired' }
+            @{ ProviderCode = '50079'; Code = 'MfaEnrollmentRequired' }
+            @{ ProviderCode = '50074'; Code = 'MfaRequired' }
+            @{ ProviderCode = '50076'; Code = 'MfaRequired' }
+            @{ ProviderCode = '50078'; Code = 'MfaTimeout' }
+            @{ ProviderCode = '50087'; Code = 'MfaTemporarilyUnavailable' }
+            @{ ProviderCode = '50088'; Code = 'MfaTemporarilyUnavailable' }
+            @{ ProviderCode = '50089'; Code = 'FlowExpired' }
+            @{ ProviderCode = '50105'; Code = 'AppAssignmentRequired' }
+            @{ ProviderCode = '65001'; Code = 'ConsentRequired' }
+            @{ ProviderCode = '90008'; Code = 'ConsentRequired' }
+            @{ ProviderCode = '90094'; Code = 'ConsentRequired' }
+            @{ ProviderCode = '90095'; Code = 'ConsentRequired' }
+            @{ ProviderCode = '90002'; Code = 'InvalidTenant' }
+            @{ ProviderCode = '53000'; Code = 'ConditionalAccess' }
+            @{ ProviderCode = '53001'; Code = 'ConditionalAccess' }
+            @{ ProviderCode = '53002'; Code = 'ConditionalAccess' }
+            @{ ProviderCode = '53003'; Code = 'ConditionalAccess' }
+            @{ ProviderCode = '53004'; Code = 'ConditionalAccess' }
+            @{ ProviderCode = '53009'; Code = 'ConditionalAccess' }
+            @{ ProviderCode = '90006'; Code = 'ProviderUnavailable' }
+            @{ ProviderCode = '90024'; Code = 'ProviderUnavailable' }
+            @{ ProviderCode = '90033'; Code = 'ProviderUnavailable' }
+        ) {
+            $failure = Get-XdrAuthenticationFailure -AuthState ([pscustomobject]@{ sErrorCode = $ProviderCode })
+            $failure.Code | Should -Be $Code
+            $failure.ProviderCode | Should -Be $ProviderCode
+        }
+
+        It 'does not describe AADSTS50053 as a definite account lockout' {
+            $failure = Get-XdrAuthenticationFailure -AuthState ([pscustomobject]@{ sErrorCode = 'AADSTS50053' })
+
+            $failure.Code | Should -Be 'SignInBlocked'
+            $failure.Message | Should -Not -Match '(?i)account is locked'
+            $failure.RecommendedAction | Should -Match '(?i)sign-in logs'
+            $failure.RecommendedAction | Should -Match '(?i)blocked IP'
+        }
+
+        It 'maps OAuth errors from query and fragment redirects' -ForEach @(
+            @{ Uri = 'https://localhost/callback?error=interaction_required&error_description=do-not-retain'; Code = 'MfaRequired' }
+            @{ Uri = 'https://localhost/callback#error=user_denied&code=secret-code'; Code = 'MfaDenied' }
+            @{ Uri = 'https://localhost/callback#error=temporarily_unavailable'; Code = 'ProviderUnavailable' }
+            @{ Uri = 'https://localhost/callback#error=consent_required'; Code = 'ConsentRequired' }
+            @{ Uri = 'https://localhost/callback#error=unexpected_provider_value'; Code = 'ProviderRejected' }
+        ) {
+            $failure = Get-XdrAuthenticationFailure -RedirectUri $Uri
+
+            $failure.Code | Should -Be $Code
+            ($failure | ConvertTo-Json -Depth 8) | Should -Not -Match 'do-not-retain|secret-code'
+        }
+
+        It 'maps SAS outcomes without retaining continuation state' -ForEach @(
+            @{ ResultValue = 'AuthenticationDenied'; Retry = $false; Code = 'MfaDenied' }
+            @{ ResultValue = 'AuthenticationPending'; Retry = $true; Code = 'MfaRequired' }
+            @{ ResultValue = 'AuthenticationPending'; Retry = $false; Code = 'MfaTimeout' }
+            @{ ResultValue = 'AuthenticationExpired'; Retry = $false; Code = 'MfaTimeout' }
+        ) {
+            $sas = [pscustomobject]@{ ResultValue = $ResultValue; Retry = $Retry; FlowToken = 'sas-flow-secret'; Ctx = 'sas-context-secret' }
+            $failure = Get-XdrAuthenticationFailure -SasResult $sas
+
+            $failure.Code | Should -Be $Code
+            ($failure | ConvertTo-Json -Depth 8) | Should -Not -Match 'sas-flow-secret|sas-context-secret'
+        }
+
+        It 'maps HTTP status <StatusCode> to <Code>' -ForEach @(
+            @{ StatusCode = 400; Code = 'RequestInvalid' }
+            @{ StatusCode = 401; Code = 'ProviderRejected' }
+            @{ StatusCode = 403; Code = 'ProviderRejected' }
+            @{ StatusCode = 429; Code = 'Throttled' }
+            @{ StatusCode = 502; Code = 'ProviderUnavailable' }
+            @{ StatusCode = 503; Code = 'ProviderUnavailable' }
+            @{ StatusCode = 504; Code = 'ProviderUnavailable' }
+        ) {
+            $failure = Get-XdrAuthenticationFailure -Response ([pscustomobject]@{ StatusCode = $StatusCode })
+            $failure.Code | Should -Be $Code
+            $failure.StatusCode | Should -Be $StatusCode
+        }
+
+        It 'parses JSON error details and preserves safe diagnostic identifiers' {
+            $exception = [System.Exception]::new('HTTP request failed')
+            $record = [System.Management.Automation.ErrorRecord]::new($exception, 'NativeFailure', 'ConnectionError', $null)
+            $record.ErrorDetails = [System.Management.Automation.ErrorDetails]::new('{"error":{"code":"AADSTS50126"},"correlation_id":"11111111-1111-1111-1111-111111111111","trace_id":"trace-123","access_token":"must-not-appear"}')
+
+            $failure = Get-XdrAuthenticationFailure -ErrorRecord $record -AuthenticationMethod Credential -Stage Password
+
+            $failure.Code | Should -Be 'InvalidCredentials'
+            $failure.CorrelationId | Should -Be '11111111-1111-1111-1111-111111111111'
+            $failure.TraceId | Should -Be 'trace-123'
+            ($failure | ConvertTo-Json -Depth 8) | Should -Not -Match 'must-not-appear'
+        }
+
+        It 'gives exact provider codes precedence over caller defaults, OAuth, and HTTP status' {
+            $failure = Get-XdrAuthenticationFailure -AuthState ([pscustomobject]@{ sErrorCode = '50057' }) -RedirectUri 'https://localhost/#error=interaction_required' -Response ([pscustomobject]@{ StatusCode = 503 }) -DefaultCode BrowserTimeout
+            $failure.Code | Should -Be 'AccountDisabled'
+        }
+
+        It 'uses the requested local classification when no structured provider signal exists' -ForEach @(
+            'CredentialFileInvalid', 'PasskeyUnavailable', 'PasskeyAssertionFailed', 'KeyVaultAccessFailed',
+            'BrowserClosed', 'BrowserTimeout', 'BrowserStartupFailed', 'TenantSelectionFailed',
+            'NoAuthenticationArtifact', 'BootstrapFailed', 'UnknownFailure'
+        ) {
+            $failure = Get-XdrAuthenticationFailure -DefaultCode $_
+            $failure.Code | Should -Be $_
+            $failure.Message | Should -Not -BeNullOrEmpty
+            $failure.RecommendedAction | Should -Not -BeNullOrEmpty
+        }
+
+        It 'sets retryability according to whether a fresh attempt can succeed without configuration changes' -ForEach @(
+            @{ Code = 'MfaTimeout'; Retryable = $true }
+            @{ Code = 'FlowExpired'; Retryable = $true }
+            @{ Code = 'Throttled'; Retryable = $true }
+            @{ Code = 'ConditionalAccess'; Retryable = $false }
+            @{ Code = 'AppAssignmentRequired'; Retryable = $false }
+            @{ Code = 'ConsentRequired'; Retryable = $false }
+            @{ Code = 'InvalidCredentials'; Retryable = $false }
+        ) {
+            (Get-XdrAuthenticationFailure -DefaultCode $Code).Retryable | Should -Be $Retryable
+        }
+
+        It 'adds only allowlisted and bounded safe evidence' {
+            $failure = Get-XdrAuthenticationFailure -SafeEvidence ([ordered]@{
+                    Attempt = 'ESTS'
+                    Host = 'https://login.microsoftonline.com/path?code=secret-code'
+                    Unsafe = 'must-not-appear'
+                    Status = 'password=secret-password'
+                    PageTitle = ('x' * 300)
+                })
+
+            $failure.SafeEvidence.Name | Should -Contain 'Attempt'
+            $failure.SafeEvidence.Name | Should -Contain 'Host'
+            $failure.SafeEvidence.Name | Should -Contain 'PageTitle'
+            $failure.SafeEvidence.Name | Should -Not -Contain 'Unsafe'
+            $failure.SafeEvidence.Name | Should -Not -Contain 'Status'
+            ($failure.SafeEvidence | Where-Object Name -EQ 'Host').Value | Should -Be 'login.microsoftonline.com'
+            ($failure.SafeEvidence | Where-Object Name -EQ 'PageTitle').Value.Length | Should -Be 256
+            ($failure | ConvertTo-Json -Depth 8) | Should -Not -Match 'secret-code|secret-password|must-not-appear'
+        }
+    }
+}
+
+Describe 'Authentication error record contract' {
+    InModuleScope XDRInternals {
+        It 'creates a stable terminating record and preserves the original exception as the inner exception' {
+            $original = [System.InvalidOperationException]::new('native failure')
+            $nativeRecord = [System.Management.Automation.ErrorRecord]::new($original, 'NativeFailure', 'InvalidOperation', $null)
+            $failure = Get-XdrAuthenticationFailure -AuthState ([pscustomobject]@{
+                    sErrorCode = '53003'
+                    correlationId = '11111111-1111-1111-1111-111111111111'
+                }) -AuthenticationMethod Browser -Stage Authorize
+
+            $record = New-XdrAuthenticationErrorRecord -Failure $failure -ErrorRecord $nativeRecord
+
+            $record.FullyQualifiedErrorId | Should -Be 'XdrAuthentication.ConditionalAccess'
+            $record.CategoryInfo.Category | Should -Be 'PermissionDenied'
+            $record.ErrorDetails.Message | Should -Match 'Conditional Access'
+            $record.ErrorDetails.RecommendedAction | Should -Match 'sign-in logs'
+            [object]::ReferenceEquals($record.Exception.InnerException, $original) | Should -BeTrue
+            $record.Exception.Data['XdrAuthenticationFailure'].Code | Should -Be 'ConditionalAccess'
+            $record.Exception.Data['XdrAuthenticationFailure'].ConditionalAccessScenario | Should -Be 'PolicyBlocked'
+        }
+
+        It 'does not double-wrap an existing structured authentication error' {
+            $firstFailure = Get-XdrAuthenticationFailure -DefaultCode BrowserTimeout
+            $firstRecord = New-XdrAuthenticationErrorRecord -Failure $firstFailure
+            $secondFailure = Get-XdrAuthenticationFailure -ErrorRecord $firstRecord
+
+            $secondRecord = New-XdrAuthenticationErrorRecord -Failure $secondFailure -ErrorRecord $firstRecord
+
+            [object]::ReferenceEquals($secondRecord, $firstRecord) | Should -BeTrue
+        }
+
+        It 'keeps secrets out of displayed details, remediation, and metadata' {
+            $original = [System.Exception]::new('redirect https://localhost/?code=secret-code&session_id=secret-session')
+            $nativeRecord = [System.Management.Automation.ErrorRecord]::new($original, 'NativeFailure', 'AuthenticationError', $null)
+            $failure = Get-XdrAuthenticationFailure -RedirectUri 'https://localhost/?error=access_denied&code=secret-code' -SafeEvidence @{ Status = 'cookie=secret-cookie' }
+            $record = New-XdrAuthenticationErrorRecord -Failure $failure -ErrorRecord $nativeRecord
+
+            $exposed = @(
+                $record.ErrorDetails.Message
+                $record.ErrorDetails.RecommendedAction
+                ($record.Exception.Data['XdrAuthenticationFailure'] | ConvertTo-Json -Depth 8)
+            ) -join "`n"
+            $exposed | Should -Not -Match 'secret-code|secret-session|secret-cookie'
+        }
+    }
+}

--- a/tests/functions/AuthenticationError.Tests.ps1
+++ b/tests/functions/AuthenticationError.Tests.ps1
@@ -32,6 +32,8 @@
             @{ ProviderCode = '90006'; Code = 'ProviderUnavailable' }
             @{ ProviderCode = '90024'; Code = 'ProviderUnavailable' }
             @{ ProviderCode = '90033'; Code = 'ProviderUnavailable' }
+            @{ ProviderCode = '130503'; Code = 'InvalidCredentials' }
+            @{ ProviderCode = '701013'; Code = 'MfaTemporarilyUnavailable' }
         ) {
             $failure = Get-XdrAuthenticationFailure -AuthState ([pscustomobject]@{ sErrorCode = $ProviderCode })
             $failure.Code | Should -Be $Code
@@ -45,6 +47,32 @@
             $failure.Message | Should -Not -Match '(?i)account is locked'
             $failure.RecommendedAction | Should -Match '(?i)sign-in logs'
             $failure.RecommendedAction | Should -Match '(?i)blocked IP'
+        }
+
+        It 'provides method-specific remediation for a rejected Temporary Access Pass' {
+            $failure = Get-XdrAuthenticationFailure -AuthState ([pscustomobject]@{ sErrorCode = '130503' }) -AuthenticationMethod TemporaryAccessPass -Stage PassSubmission
+
+            $failure.Code | Should -Be 'InvalidCredentials'
+            $failure.Message | Should -Match 'Temporary Access Pass'
+            $failure.Message | Should -Not -Match '(?i)password'
+            $failure.RecommendedAction | Should -Match '(?i)new Temporary Access Pass'
+            $failure.Retryable | Should -BeFalse
+        }
+
+        It 'uses authentication-method-specific timeout classifications' -ForEach @(
+            @{ Method = 'PhoneSignIn'; Code = 'MfaTimeout' }
+            @{ Method = 'Browser'; Code = 'BrowserTimeout' }
+            @{ Method = 'SSO'; Code = 'BrowserTimeout' }
+            @{ Method = 'TemporaryAccessPass'; Code = 'UnknownFailure' }
+        ) {
+            $record = [System.Management.Automation.ErrorRecord]::new(
+                [System.TimeoutException]::new('Authentication timed out.'),
+                'NativeTimeout',
+                'OperationTimeout',
+                $null
+            )
+
+            (Get-XdrAuthenticationFailure -ErrorRecord $record -AuthenticationMethod $Method).Code | Should -Be $Code
         }
 
         It 'calls out a compliant-device Conditional Access requirement' {

--- a/tests/functions/AuthenticationError.Tests.ps1
+++ b/tests/functions/AuthenticationError.Tests.ps1
@@ -2,6 +2,7 @@
     InModuleScope XDRInternals {
         It 'maps documented Entra code <ProviderCode> to <Code>' -ForEach @(
             @{ ProviderCode = '16000'; Code = 'AccountNotFound' }
+            @{ ProviderCode = '50005'; Code = 'ConditionalAccess' }
             @{ ProviderCode = '50034'; Code = 'AccountNotFound' }
             @{ ProviderCode = '50053'; Code = 'SignInBlocked' }
             @{ ProviderCode = '50055'; Code = 'PasswordExpired' }
@@ -18,6 +19,8 @@
             @{ ProviderCode = '50088'; Code = 'MfaTemporarilyUnavailable' }
             @{ ProviderCode = '50089'; Code = 'FlowExpired' }
             @{ ProviderCode = '50105'; Code = 'AppAssignmentRequired' }
+            @{ ProviderCode = '50131'; Code = 'ConditionalAccess' }
+            @{ ProviderCode = '50142'; Code = 'PasswordExpired' }
             @{ ProviderCode = '65001'; Code = 'ConsentRequired' }
             @{ ProviderCode = '90008'; Code = 'ConsentRequired' }
             @{ ProviderCode = '90094'; Code = 'ConsentRequired' }
@@ -29,6 +32,10 @@
             @{ ProviderCode = '53003'; Code = 'ConditionalAccess' }
             @{ ProviderCode = '53004'; Code = 'ConditionalAccess' }
             @{ ProviderCode = '53009'; Code = 'ConditionalAccess' }
+            @{ ProviderCode = '53010'; Code = 'ConditionalAccess' }
+            @{ ProviderCode = '530035'; Code = 'SignInBlocked' }
+            @{ ProviderCode = '53011'; Code = 'SignInBlocked' }
+            @{ ProviderCode = '530034'; Code = 'SignInBlocked' }
             @{ ProviderCode = '90006'; Code = 'ProviderUnavailable' }
             @{ ProviderCode = '90024'; Code = 'ProviderUnavailable' }
             @{ ProviderCode = '90033'; Code = 'ProviderUnavailable' }
@@ -91,6 +98,39 @@
             $failure.ConditionalAccessScenario | Should -Be 'PolicyBlocked'
             $failure.Message | Should -Be 'A Conditional Access policy blocked this sign-in.'
             $failure.RecommendedAction | Should -Match '(?i)reported Conditional Access requirements'
+        }
+
+        It 'provides scenario-specific Conditional Access remediation for <ProviderCode>' -ForEach @(
+            @{ ProviderCode = '50005'; Scenario = 'UnsupportedDevicePlatform'; Message = 'does not support the device platform'; Action = 'device-platform condition' }
+            @{ ProviderCode = '50131'; Scenario = 'PolicyEvaluationFailed'; Message = 'Conditional Access evaluation failed'; Action = 'exact policy decision' }
+            @{ ProviderCode = '50142'; Scenario = 'PasswordChangeRequired'; Message = 'requires the account password to be changed'; Action = 'Change the password' }
+            @{ ProviderCode = '53001'; Scenario = 'DeviceNotDomainJoined'; Message = 'hybrid joined device'; Action = 'hybrid-join grant control' }
+            @{ ProviderCode = '53002'; Scenario = 'ApplicationBlocked'; Message = 'approved client application'; Action = 'approved-client-app grant control' }
+            @{ ProviderCode = '53004'; Scenario = 'ProofUpRequired'; Message = 'multifactor authentication registration'; Action = 'security-info registration' }
+            @{ ProviderCode = '53009'; Scenario = 'ApplicationRequiresProtectionPolicy'; Message = 'Intune app protection policy'; Action = 'app-protection grant control' }
+            @{ ProviderCode = '53010'; Scenario = 'SecurityInfoRegistrationRestricted'; Message = 'specific locations or devices'; Action = 'security-info registration policy' }
+            @{ ProviderCode = '530035'; Scenario = 'SecurityDefaultsBlocked'; Message = 'security defaults'; Action = 'modern authentication flow' }
+            @{ ProviderCode = '53011'; Scenario = 'HomeTenantRisk'; Message = 'risk detected in its home tenant'; Action = 'risky sign-in or risky user' }
+            @{ ProviderCode = '530034'; Scenario = 'DelegatedAdminRisk'; Message = 'delegated administrator'; Action = 'home tenant' }
+        ) {
+            $failure = Get-XdrAuthenticationFailure -AuthState ([pscustomobject]@{ sErrorCode = "AADSTS$ProviderCode" })
+
+            $failure.ConditionalAccessScenario | Should -Be $Scenario
+            $failure.Message | Should -Match ([regex]::Escape($Message))
+            $failure.RecommendedAction | Should -Match ([regex]::Escape($Action))
+            $failure.Retryable | Should -BeFalse
+        }
+
+        It 'identifies a Conditional Access App Control reverse-proxy redirect' {
+            $failure = Get-XdrAuthenticationFailure -DefaultCode ConditionalAccess -SafeEvidence @{ Host = 'contoso-com.access.mcas.ms' }
+
+            $failure.Code | Should -Be 'ConditionalAccess'
+            $failure.ConditionalAccessScenario | Should -Be 'AppControlProxy'
+            $failure.Message | Should -Match '(?i)Conditional Access App Control'
+            $failure.RecommendedAction | Should -Match '(?i)policy-supported browser session'
+            $failure.RecommendedAction | Should -Match '(?i)XDRInternals cannot continue'
+            $failure.RecommendedAction | Should -Match '(?i)reverse proxy'
+            ($failure.SafeEvidence | Where-Object Name -EQ Host).Value | Should -Be 'contoso-com.access.mcas.ms'
         }
 
         It 'maps OAuth errors from query and fragment redirects' -ForEach @(

--- a/tests/functions/AuthenticationError.Tests.ps1
+++ b/tests/functions/AuthenticationError.Tests.ps1
@@ -47,6 +47,24 @@
             $failure.RecommendedAction | Should -Match '(?i)blocked IP'
         }
 
+        It 'calls out a compliant-device Conditional Access requirement' {
+            $failure = Get-XdrAuthenticationFailure -AuthState ([pscustomobject]@{ sErrorCode = 'AADSTS53000' })
+
+            $failure.Code | Should -Be 'ConditionalAccess'
+            $failure.ConditionalAccessScenario | Should -Be 'DeviceNotCompliant'
+            $failure.Message | Should -Match '(?i)requires a compliant device'
+            $failure.RecommendedAction | Should -Match '(?i)device marked compliant'
+            $failure.RecommendedAction | Should -Match '(?i)sign-in logs'
+        }
+
+        It 'keeps generic Conditional Access remediation for policy blocks without an exact scenario' {
+            $failure = Get-XdrAuthenticationFailure -AuthState ([pscustomobject]@{ sErrorCode = 'AADSTS53003' })
+
+            $failure.ConditionalAccessScenario | Should -Be 'PolicyBlocked'
+            $failure.Message | Should -Be 'A Conditional Access policy blocked this sign-in.'
+            $failure.RecommendedAction | Should -Match '(?i)reported Conditional Access requirements'
+        }
+
         It 'maps OAuth errors from query and fragment redirects' -ForEach @(
             @{ Uri = 'https://localhost/callback?error=interaction_required&error_description=do-not-retain'; Code = 'MfaRequired' }
             @{ Uri = 'https://localhost/callback#error=user_denied&code=secret-code'; Code = 'MfaDenied' }

--- a/tests/functions/AuthenticationError.Tests.ps1
+++ b/tests/functions/AuthenticationError.Tests.ps1
@@ -1,6 +1,7 @@
 ﻿Describe 'Authentication error classification' {
     InModuleScope XDRInternals {
         It 'maps documented Entra code <ProviderCode> to <Code>' -ForEach @(
+            @{ ProviderCode = '16000'; Code = 'AccountNotFound' }
             @{ ProviderCode = '50034'; Code = 'AccountNotFound' }
             @{ ProviderCode = '50053'; Code = 'SignInBlocked' }
             @{ ProviderCode = '50055'; Code = 'PasswordExpired' }

--- a/tests/functions/Connect.Tests.ps1
+++ b/tests/functions/Connect.Tests.ps1
@@ -665,6 +665,50 @@ InModuleScope XDRInternals {
             $result | Should -Be 'Microsoft Defender [https://security.microsoft.com/]'
         }
 
+        It 'removes query and fragment values from browser target descriptions' {
+            $result = Format-XdrBrowserTargetDescription -Title 'Sign in' -Url 'https://login.microsoftonline.com/common/oauth2/authorize?login_hint=user%40contoso.com&nonce=secret-nonce#code=secret-code'
+
+            $result | Should -Be 'Sign in [https://login.microsoftonline.com/common/oauth2/authorize]'
+            $result | Should -Not -Match 'user|nonce|code|secret'
+        }
+
+        It 'reads only allowlisted authentication error fields through CDP' {
+            Mock Invoke-XdrBrowserCdpCommand {
+                [pscustomobject]@{
+                    result = [pscustomobject]@{
+                        value = '{"sErrorCode":"53003","correlationId":"11111111-1111-1111-1111-111111111111","traceId":"trace-123"}'
+                    }
+                }
+            } -ModuleName XDRInternals
+
+            $result = Get-XdrBrowserAuthenticationPageError -WebSocketUrl 'ws://login-target'
+
+            $result.sErrorCode | Should -Be '53003'
+            $result.correlationId | Should -Be '11111111-1111-1111-1111-111111111111'
+            $result.traceId | Should -Be 'trace-123'
+            Should -Invoke Invoke-XdrBrowserCdpCommand -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'Runtime.evaluate' -and
+                $Params.returnByValue -eq $true -and
+                $Params.expression -match '\$Config' -and
+                $Params.expression -notmatch '(?i)sFT|sCtx|canary|sessionId|innerHTML|document\.|outerHTML|textContent'
+            }
+        }
+
+        It 'ignores browser page state without an exact numeric provider error' -ForEach @(
+            @{ SerializedState = $null }
+            @{ SerializedState = '{}' }
+            @{ SerializedState = '{"sErrorCode":"0"}' }
+            @{ SerializedState = '{"sErrorCode":"access_denied"}' }
+            @{ SerializedState = 'not-json' }
+        ) {
+            $script:serializedBrowserState = $SerializedState
+            Mock Invoke-XdrBrowserCdpCommand {
+                [pscustomobject]@{ result = [pscustomobject]@{ value = $script:serializedBrowserState } }
+            } -ModuleName XDRInternals
+
+            Get-XdrBrowserAuthenticationPageError -WebSocketUrl 'ws://login-target' | Should -BeNullOrEmpty
+        }
+
         It 'returns the macOS SSO default profile path' {
             if (-not $IsMacOS) {
                 Set-ItResult -Skipped -Because 'macOS-specific path assertion.'

--- a/tests/functions/Connect.Tests.ps1
+++ b/tests/functions/Connect.Tests.ps1
@@ -40,7 +40,7 @@
 
         {
             Connect-XdrByTemporaryAccessPass -Username 'user@contoso.com' -TemporaryAccessPass $tap -TenantId '8612f621-73ca-4c12-973c-0da732bc44c2'
-        } | Should -Throw '*no ESTS cookie*'
+        } | Should -Throw '*without a usable session artifact*'
     }
 
     It 'resolves the tenant ID from the username when TenantId is omitted' {
@@ -89,7 +89,7 @@ Describe 'Connect-XdrByPhoneSignIn' {
 
         {
             Connect-XdrByPhoneSignIn -Username 'user@contoso.com'
-        } | Should -Throw '*no ESTS cookie*'
+        } | Should -Throw '*without a usable session artifact*'
     }
 }
 
@@ -152,7 +152,7 @@ Describe 'Connect-XdrByBrowser' {
     It 'rejects combining explicit profile and private session mode' {
         {
             Connect-XdrByBrowser -Username 'user@contoso.com' -ProfilePath 'C:\Temp\XdrBrowserProfile' -PrivateSession
-        } | Should -Throw '*Do not combine -PrivateSession with -ProfilePath*'
+        } | Should -Throw '*invalid request*'
     }
 
     It 'prefers ESTS cookie bootstrap when browser auth returns both ESTS and portal cookies' {
@@ -223,7 +223,7 @@ Describe 'Connect-XdrByBrowser' {
 
         {
             Connect-XdrByBrowser -Username 'user@contoso.com'
-        } | Should -Throw '*no authentication cookies*'
+        } | Should -Throw '*without a usable session artifact*'
     }
 }
 
@@ -344,7 +344,7 @@ Describe 'Connect-XdrBySSO' {
 
         {
             Connect-XdrBySSO
-        } | Should -Throw '*no authentication cookies*'
+        } | Should -Throw '*without a usable session artifact*'
     }
 }
 

--- a/tests/functions/ConnectAuthenticationErrors.Tests.ps1
+++ b/tests/functions/ConnectAuthenticationErrors.Tests.ps1
@@ -121,6 +121,40 @@
         $caught.Exception.Data['XdrAuthenticationFailure'].Stage | Should -Be 'PassSubmission'
     }
 
+    It 'reports an exact rejected-TAP response with TAP-specific remediation' {
+        Mock Invoke-XdrTemporaryAccessPassAuthentication {
+            $record = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new('Authentication provider rejected the pass.'),
+                'NativeTapFailure',
+                'AuthenticationError',
+                $null
+            )
+            $record.ErrorDetails = [System.Management.Automation.ErrorDetails]::new('{"sErrorCode":"130503","sFT":"secret-flow-state"}')
+            throw $record
+        } -ModuleName XDRInternals
+
+        $caught = try {
+            Connect-XdrByTemporaryAccessPass -Username 'user@contoso.com' -TemporaryAccessPass (New-AuthenticationTestSecureString) -TenantId 'tenant-id'
+        } catch { $_ }
+
+        $caught.FullyQualifiedErrorId | Should -BeLike 'XdrAuthentication.InvalidCredentials*'
+        $caught.ErrorDetails.Message | Should -Match 'Temporary Access Pass'
+        $caught.ErrorDetails.RecommendedAction | Should -Match 'new Temporary Access Pass'
+        $caught.Exception.Data['XdrAuthenticationFailure'].ProviderCode | Should -Be '130503'
+        (($caught.ErrorDetails | Out-String), ($caught.Exception.Data['XdrAuthenticationFailure'] | ConvertTo-Json -Depth 8)) -join "`n" | Should -Not -Match 'secret-flow-state'
+    }
+
+    It 'reports a native phone polling timeout as an MFA timeout' {
+        Mock Invoke-XdrPhoneSignInAuthentication { throw [System.TimeoutException]::new('Phone sign-in did not complete before the timeout expired.') } -ModuleName XDRInternals
+
+        $caught = try { Connect-XdrByPhoneSignIn -Username 'user@contoso.com' } catch { $_ }
+
+        $caught.FullyQualifiedErrorId | Should -BeLike 'XdrAuthentication.MfaTimeout*'
+        $caught.ErrorDetails.Message | Should -Match '(?i)multifactor authentication request.*timed out'
+        $caught.ErrorDetails.Message | Should -Not -Match '(?i)browser'
+        $caught.Exception.Data['XdrAuthenticationFailure'].AuthenticationMethod | Should -Be 'PhoneSignIn'
+    }
+
     It 'passes through structured Phone, Browser, and SSO failures' -ForEach @(
         @{ Command = 'Connect-XdrByPhoneSignIn'; Helper = 'Invoke-XdrPhoneSignInAuthentication'; Arguments = @{ Username = 'user@contoso.com' } }
         @{ Command = 'Connect-XdrByBrowser'; Helper = 'Invoke-XdrBrowserAuthentication'; Arguments = @{} }

--- a/tests/functions/ConnectAuthenticationErrors.Tests.ps1
+++ b/tests/functions/ConnectAuthenticationErrors.Tests.ps1
@@ -1,0 +1,221 @@
+﻿Describe 'Connect authentication error integration' {
+    BeforeAll {
+        function New-AuthenticationTestSecureString {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'Uses fixed placeholder values in unit tests only.')]
+            param([string]$Value = 'placeholder-secret')
+            ConvertTo-SecureString $Value -AsPlainText -Force
+        }
+    }
+
+    BeforeEach {
+        Mock Write-Host {} -ModuleName XDRInternals
+    }
+
+    It 'normalizes a structured credential rejection at the public boundary' {
+        Mock Invoke-XdrCredentialAuthentication {
+            $nativeException = [System.Exception]::new('HTTP request failed')
+            $nativeRecord = [System.Management.Automation.ErrorRecord]::new($nativeException, 'NativeFailure', 'AuthenticationError', $null)
+            $nativeRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new('{"error":{"code":"AADSTS50126"},"correlation_id":"11111111-1111-1111-1111-111111111111","access_token":"secret-token"}')
+            throw $nativeRecord
+        } -ModuleName XDRInternals
+
+        $credential = [PSCredential]::new('user@contoso.com', (New-AuthenticationTestSecureString))
+        $caught = try { Connect-XdrByCredential -Credential $credential } catch { $_ }
+
+        $caught.FullyQualifiedErrorId | Should -BeLike 'XdrAuthentication.InvalidCredentials*'
+        $metadata = $caught.Exception.Data['XdrAuthenticationFailure']
+        $metadata.AuthenticationMethod | Should -Be 'Credential'
+        $metadata.Stage | Should -Be 'SignIn'
+        $metadata.CorrelationId | Should -Be '11111111-1111-1111-1111-111111111111'
+        (($caught.ErrorDetails.Message, $caught.ErrorDetails.RecommendedAction, ($metadata | ConvertTo-Json -Depth 8)) -join "`n") | Should -Not -Match 'secret-token'
+    }
+
+    It 'classifies an invalid software passkey credential file without exposing its path' {
+        Mock Invoke-XdrPasskeyAuthentication { throw 'Credential file not found: /private/credentials/admin-passkey.json' } -ModuleName XDRInternals
+
+        $caught = try { Connect-XdrBySoftwarePasskey -KeyFilePath '/private/credentials/admin-passkey.json' } catch { $_ }
+
+        $caught.FullyQualifiedErrorId | Should -BeLike 'XdrAuthentication.CredentialFileInvalid*'
+        $caught.ErrorDetails.Message | Should -Not -Match 'admin-passkey|/private/'
+        $caught.Exception.Data['XdrAuthenticationFailure'].AuthenticationMethod | Should -Be 'SoftwarePasskey'
+    }
+
+    It 'classifies an ESTS session rejection from exact provider state' {
+        Mock Clear-XdrCache {} -ModuleName XDRInternals
+        Mock Invoke-WebRequest {
+            if ($Uri -eq 'https://login.microsoftonline.com/error') {
+                return [pscustomobject]@{}
+            }
+
+            return [pscustomobject]@{
+                InputFields = @()
+                Content = '<script>$Config={"sErrorCode":"50058","sErrTxt":"unsafe provider text","sFT":"secret-flow-token","sCtx":"secret-context"};</script>'
+                StatusCode = 200
+            }
+        } -ModuleName XDRInternals
+
+        $caught = try { Connect-XdrByEstsCookie -EstsAuthCookieValue 'secret-cookie-value' -Verbose 4>&1 } catch { $_ }
+
+        $caught.FullyQualifiedErrorId | Should -BeLike 'XdrAuthentication.SessionUnavailable*'
+        $exposed = @(
+            $caught.ErrorDetails.Message
+            $caught.ErrorDetails.RecommendedAction
+            ($caught.Exception.Data['XdrAuthenticationFailure'] | ConvertTo-Json -Depth 8)
+        ) -join "`n"
+        $exposed | Should -Not -Match 'secret-cookie-value|secret-flow-token|secret-context|unsafe provider text'
+    }
+
+    It 'keeps the successful ESTS-cookie bootstrap behavior unchanged' {
+        Mock Clear-XdrCache {} -ModuleName XDRInternals
+        Mock Set-XdrConnectionSettings { 'connected' } -ModuleName XDRInternals
+        Mock Invoke-WebRequest {
+            if ($Uri -eq 'https://login.microsoftonline.com/error') {
+                return [pscustomobject]@{}
+            }
+
+            if ($Method -eq 'Get') {
+                return [pscustomobject]@{
+                    InputFields = @(
+                        [pscustomobject]@{ name = 'code'; value = 'authorization-code' }
+                        [pscustomobject]@{ name = 'id_token'; value = 'identity-token' }
+                        [pscustomobject]@{ name = 'state'; value = 'state-value' }
+                        [pscustomobject]@{ name = 'session_state'; value = 'session-state' }
+                        [pscustomobject]@{ name = 'correlation_id'; value = '11111111-1111-1111-1111-111111111111' }
+                    )
+                    Content = ''
+                    StatusCode = 200
+                }
+            }
+
+            return [pscustomobject]@{ StatusCode = 200 }
+        } -ModuleName XDRInternals
+
+        $output = @(Connect-XdrByEstsCookie -EstsAuthCookieValue 'secret-cookie-value' -Verbose 4>&1)
+
+        $output[-1] | Should -Be 'connected'
+        ($output | Out-String) | Should -Not -Match 'secret-cookie-value|authorization-code|identity-token|state-value|session-state'
+        Should -Invoke Invoke-WebRequest -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'Post' -and $Body.code -eq 'authorization-code'
+        }
+        Should -Invoke Set-XdrConnectionSettings -ModuleName XDRInternals -Times 1 -Exactly
+    }
+
+    It 'does not wrap an already-structured TAP error again' {
+        Mock Invoke-XdrTemporaryAccessPassAuthentication {
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod TemporaryAccessPass -Stage PassSubmission -DefaultCode InvalidCredentials
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
+        } -ModuleName XDRInternals
+        Mock Connect-XdrByEstsCookie { 'connected' } -ModuleName XDRInternals
+
+        $caught = try {
+            Connect-XdrByTemporaryAccessPass -Username 'user@contoso.com' -TemporaryAccessPass (New-AuthenticationTestSecureString) -TenantId 'tenant-id'
+        } catch { $_ }
+
+        $caught.FullyQualifiedErrorId | Should -BeLike 'XdrAuthentication.InvalidCredentials*'
+        $caught.Exception.InnerException | Should -BeNullOrEmpty
+        $caught.Exception.Data['XdrAuthenticationFailure'].Stage | Should -Be 'PassSubmission'
+    }
+
+    It 'passes through structured Phone, Browser, and SSO failures' -ForEach @(
+        @{ Command = 'Connect-XdrByPhoneSignIn'; Helper = 'Invoke-XdrPhoneSignInAuthentication'; Arguments = @{ Username = 'user@contoso.com' }; Method = 'PhoneSignIn' }
+        @{ Command = 'Connect-XdrByBrowser'; Helper = 'Invoke-XdrBrowserAuthentication'; Arguments = @{}; Method = 'Browser' }
+        @{ Command = 'Connect-XdrBySSO'; Helper = 'Invoke-XdrSsoAuthentication'; Arguments = @{}; Method = 'SSO' }
+    ) {
+        Mock $Helper {
+            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod $Method -Stage BrowserSignIn -DefaultCode BrowserTimeout
+            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
+        } -ModuleName XDRInternals
+
+        $caught = try { & $Command @Arguments } catch { $_ }
+
+        $caught.FullyQualifiedErrorId | Should -BeLike 'XdrAuthentication.BrowserTimeout*'
+        $caught.Exception.Data['XdrAuthenticationFailure'].AuthenticationMethod | Should -Be $Method
+        $caught.Exception.InnerException | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Authentication artifact fallback diagnostics' {
+    InModuleScope XDRInternals {
+        BeforeEach {
+            Mock Connect-XdrByEstsCookie { throw 'ESTS native failure with cookie=secret-cookie' }
+            Mock Set-XdrConnectionSettings { throw 'Portal native failure with token=secret-token' }
+        }
+
+        It 'retains safe classifications for both failed bootstrap attempts' {
+            $caught = try {
+                Connect-XdrAuthArtifactSet -EstsAuthCookieValue 'secret-cookie' -SccAuthCookieValue 'secret-portal-cookie' -XsrfToken 'secret-xsrf' -ConnectionPreference PreferEsts -FallbackToPortalOnEstsBootstrapFailure -FailureLabel 'Browser'
+            } catch { $_ }
+
+            $caught.FullyQualifiedErrorId | Should -BeLike 'XdrAuthentication.BootstrapFailed*'
+            $metadata = $caught.Exception.Data['XdrAuthenticationFailure']
+            ($metadata.SafeEvidence | Where-Object Name -EQ Attempt).Value | Should -Be 'ESTS:BootstrapFailed; Portal:BootstrapFailed'
+            (($caught.ErrorDetails.Message, $caught.ErrorDetails.RecommendedAction, ($metadata | ConvertTo-Json -Depth 8)) -join "`n") | Should -Not -Match 'secret-cookie|secret-token|secret-xsrf|secret-portal-cookie'
+        }
+    }
+}
+
+Describe 'Browser authentication failure boundaries' {
+    InModuleScope XDRInternals {
+        BeforeEach {
+            Mock Write-Host {}
+            Mock Resolve-XdrBrowserPath { [pscustomobject]@{ Name = 'Test Browser'; Path = '/test/browser' } }
+            Mock Get-XdrBrowserFreeTcpPort { 9222 }
+            Mock Resolve-XdrBrowserProfileConfiguration {
+                [pscustomobject]@{ ProfilePath = '/test/profile'; UsePrivateSession = $false; CleanupProfileOnExit = $false }
+            }
+            Mock Get-XdrBrowserInteractiveStartUrl { 'https://login.microsoftonline.com/' }
+            Mock Get-XdrBrowserLaunchArgumentList { @('--test') }
+            Mock Test-XdrBrowserProcessOutputSuppression { $true }
+            Mock Get-XdrBrowserCdpVersion { [pscustomobject]@{ webSocketDebuggerUrl = 'ws://localhost/test' } }
+            Mock Start-Sleep {}
+            Mock Stop-XdrBrowserProcess {}
+            Mock Remove-XdrBrowserProcessRedirectFiles {}
+        }
+
+        It 'returns BrowserClosed when the launched browser exits' {
+            Mock Start-XdrBrowserProcess {
+                $process = [pscustomobject]@{ HasExited = $true }
+                $process | Add-Member -MemberType ScriptMethod -Name Refresh -Value {}
+                return $process
+            }
+
+            $caught = try { Invoke-XdrBrowserAuthentication -TimeoutSeconds 30 } catch { $_ }
+
+            $caught.FullyQualifiedErrorId | Should -BeLike 'XdrAuthentication.BrowserClosed*'
+            $caught.Exception.Data['XdrAuthenticationFailure'].Retryable | Should -BeTrue
+        }
+
+        It 'returns BrowserTimeout with allowlisted page evidence when cookies never appear' {
+            Mock Start-XdrBrowserProcess {
+                $process = [pscustomobject]@{ HasExited = $false }
+                $process | Add-Member -MemberType ScriptMethod -Name Refresh -Value {}
+                return $process
+            }
+            Mock Get-Date {
+                if (-not $script:browserDateCall) { $script:browserDateCall = 0 }
+                $script:browserDateCall++
+                if ($script:browserDateCall -eq 1) { return [datetime]'2026-01-01T00:00:00Z' }
+                return [datetime]'2026-01-01T00:01:00Z'
+            }
+            Mock Get-XdrBrowserPreferredTargetContext {
+                [pscustomobject]@{
+                    Url = 'https://login.microsoftonline.com/common/oauth2/authorize?code=secret-code'
+                    Title = 'Sign in to your account'
+                    WebSocketUrl = 'ws://localhost/page'
+                }
+            }
+            Mock Format-XdrBrowserTargetDescription { 'Sign in to your account [login.microsoftonline.com]' }
+            Mock Get-XdrBrowserCookieJar { @() }
+            Mock Get-XdrBestBrowserEstsCookie { $null }
+            Mock Get-XdrBrowserCookieValue { $null }
+
+            $caught = try { Invoke-XdrBrowserAuthentication -TimeoutSeconds 30 } catch { $_ }
+
+            $caught.FullyQualifiedErrorId | Should -BeLike 'XdrAuthentication.BrowserTimeout*'
+            $metadata = $caught.Exception.Data['XdrAuthenticationFailure']
+            ($metadata.SafeEvidence | Where-Object Name -EQ Host).Value | Should -Be 'login.microsoftonline.com'
+            ($metadata.SafeEvidence | Where-Object Name -EQ PageTitle).Value | Should -Be 'Sign in to your account'
+            ($metadata | ConvertTo-Json -Depth 8) | Should -Not -Match 'secret-code|oauth2/authorize'
+        }
+    }
+}

--- a/tests/functions/ConnectAuthenticationErrors.Tests.ps1
+++ b/tests/functions/ConnectAuthenticationErrors.Tests.ps1
@@ -216,6 +216,7 @@ Describe 'Browser authentication failure boundaries' {
             }
             Mock Format-XdrBrowserTargetDescription { 'Sign in to your account [login.microsoftonline.com]' }
             Mock Get-XdrBrowserCookieJar { @() }
+            Mock Get-XdrBrowserAuthenticationPageError { $null }
             Mock Get-XdrBestBrowserEstsCookie { $null }
             Mock Get-XdrBrowserCookieValue { $null }
 
@@ -226,6 +227,47 @@ Describe 'Browser authentication failure boundaries' {
             ($metadata.SafeEvidence | Where-Object Name -EQ Host).Value | Should -Be 'login.microsoftonline.com'
             ($metadata.SafeEvidence | Where-Object Name -EQ PageTitle).Value | Should -Be 'Sign in to your account'
             ($metadata | ConvertTo-Json -Depth 8) | Should -Not -Match 'secret-code|oauth2/authorize'
+        }
+
+        It 'uses exact page error state when browser polling reaches its timeout' {
+            Mock Start-XdrBrowserProcess {
+                $process = [pscustomobject]@{ HasExited = $false }
+                $process | Add-Member -MemberType ScriptMethod -Name Refresh -Value {}
+                return $process
+            }
+            Mock Get-XdrBrowserPreferredTargetContext {
+                [pscustomobject]@{
+                    Url = 'https://login.microsoftonline.com/common/login'
+                    Title = 'Sign in blocked'
+                    WebSocketUrl = 'ws://localhost/page'
+                }
+            }
+            Mock Format-XdrBrowserTargetDescription { 'Sign in blocked [login.microsoftonline.com]' }
+            Mock Get-Date {
+                if (-not $script:browserErrorDateCall) { $script:browserErrorDateCall = 0 }
+                $script:browserErrorDateCall++
+                if ($script:browserErrorDateCall -eq 1) { return [datetime]'2026-01-01T00:00:00Z' }
+                return [datetime]'2026-01-01T00:01:00Z'
+            }
+            Mock Get-XdrBrowserAuthenticationPageError {
+                [pscustomobject]@{
+                    sErrorCode = '53003'
+                    correlationId = '11111111-1111-1111-1111-111111111111'
+                    traceId = 'trace-123'
+                }
+            }
+            Mock Get-XdrBrowserCookieJar { @() }
+            Mock Get-XdrBestBrowserEstsCookie { $null }
+            Mock Get-XdrBrowserCookieValue { $null }
+
+            $caught = try { Invoke-XdrBrowserAuthentication -TimeoutSeconds 30 } catch { $_ }
+
+            $caught.FullyQualifiedErrorId | Should -BeLike 'XdrAuthentication.ConditionalAccess*'
+            $metadata = $caught.Exception.Data['XdrAuthenticationFailure']
+            $metadata.ProviderCode | Should -Be '53003'
+            $metadata.CorrelationId | Should -Be '11111111-1111-1111-1111-111111111111'
+            ($metadata.SafeEvidence | Where-Object Name -EQ Host).Value | Should -Be 'login.microsoftonline.com'
+            Should -Invoke Get-XdrBrowserCookieJar -Times 1 -Exactly
         }
     }
 }

--- a/tests/functions/ConnectAuthenticationErrors.Tests.ps1
+++ b/tests/functions/ConnectAuthenticationErrors.Tests.ps1
@@ -65,6 +65,32 @@
         $exposed | Should -Not -Match 'secret-cookie-value|secret-flow-token|secret-context|unsafe provider text'
     }
 
+    It 'reports a Conditional Access App Control redirect instead of a generic provider rejection' {
+        Mock Clear-XdrCache {} -ModuleName XDRInternals
+        Mock Invoke-WebRequest {
+            if ($Uri -eq 'https://login.microsoftonline.com/error') {
+                return [pscustomobject]@{}
+            }
+
+            return [pscustomobject]@{
+                InputFields = @([pscustomobject]@{ name = 'id_token'; value = 'secret-identity-token' })
+                Content = '<script>window.location.replace("https://contoso-com.access.mcas.ms/path?code=secret-code")</script>'
+                StatusCode = 200
+            }
+        } -ModuleName XDRInternals
+
+        $caught = try { Connect-XdrByEstsCookie -EstsAuthCookieValue 'secret-cookie-value' } catch { $_ }
+
+        $caught.FullyQualifiedErrorId | Should -BeLike 'XdrAuthentication.ConditionalAccess*'
+        $metadata = $caught.Exception.Data['XdrAuthenticationFailure']
+        $metadata.ConditionalAccessScenario | Should -Be 'AppControlProxy'
+        ($metadata.SafeEvidence | Where-Object Name -EQ Host).Value | Should -Be 'contoso-com.access.mcas.ms'
+        $caught.ErrorDetails.Message | Should -Match '(?i)Conditional Access App Control'
+        $caught.ErrorDetails.RecommendedAction | Should -Match '(?i)policy-supported browser session'
+        $caught.ErrorDetails.RecommendedAction | Should -Match '(?i)XDRInternals cannot continue'
+        (($caught.ErrorDetails | Out-String), ($metadata | ConvertTo-Json -Depth 8)) -join "`n" | Should -Not -Match 'secret-cookie-value|secret-identity-token|secret-code'
+    }
+
     It 'keeps the successful ESTS-cookie bootstrap behavior unchanged' {
         Mock Clear-XdrCache {} -ModuleName XDRInternals
         Mock Set-XdrConnectionSettings { 'connected' } -ModuleName XDRInternals

--- a/tests/functions/ConnectAuthenticationErrors.Tests.ps1
+++ b/tests/functions/ConnectAuthenticationErrors.Tests.ps1
@@ -102,8 +102,13 @@
 
     It 'does not wrap an already-structured TAP error again' {
         Mock Invoke-XdrTemporaryAccessPassAuthentication {
-            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod TemporaryAccessPass -Stage PassSubmission -DefaultCode InvalidCredentials
-            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
+            $exception = [System.Security.Authentication.AuthenticationException]::new('The username or password was not accepted.')
+            $exception.Data['XdrAuthenticationFailure'] = [pscustomobject]@{
+                Code = 'InvalidCredentials'; AuthenticationMethod = 'TemporaryAccessPass'; Stage = 'PassSubmission'
+            }
+            $record = [System.Management.Automation.ErrorRecord]::new($exception, 'XdrAuthentication.InvalidCredentials', 'AuthenticationError', $null)
+            $record.ErrorDetails = [System.Management.Automation.ErrorDetails]::new('The username or password was not accepted.')
+            throw $record
         } -ModuleName XDRInternals
         Mock Connect-XdrByEstsCookie { 'connected' } -ModuleName XDRInternals
 
@@ -117,19 +122,24 @@
     }
 
     It 'passes through structured Phone, Browser, and SSO failures' -ForEach @(
-        @{ Command = 'Connect-XdrByPhoneSignIn'; Helper = 'Invoke-XdrPhoneSignInAuthentication'; Arguments = @{ Username = 'user@contoso.com' }; Method = 'PhoneSignIn' }
-        @{ Command = 'Connect-XdrByBrowser'; Helper = 'Invoke-XdrBrowserAuthentication'; Arguments = @{}; Method = 'Browser' }
-        @{ Command = 'Connect-XdrBySSO'; Helper = 'Invoke-XdrSsoAuthentication'; Arguments = @{}; Method = 'SSO' }
+        @{ Command = 'Connect-XdrByPhoneSignIn'; Helper = 'Invoke-XdrPhoneSignInAuthentication'; Arguments = @{ Username = 'user@contoso.com' } }
+        @{ Command = 'Connect-XdrByBrowser'; Helper = 'Invoke-XdrBrowserAuthentication'; Arguments = @{} }
+        @{ Command = 'Connect-XdrBySSO'; Helper = 'Invoke-XdrSsoAuthentication'; Arguments = @{} }
     ) {
         Mock $Helper {
-            $failure = Get-XdrAuthenticationFailure -AuthenticationMethod $Method -Stage BrowserSignIn -DefaultCode BrowserTimeout
-            throw (New-XdrAuthenticationErrorRecord -Failure $failure)
+            $exception = [System.Security.Authentication.AuthenticationException]::new('Browser authentication did not complete before the timeout.')
+            $exception.Data['XdrAuthenticationFailure'] = [pscustomobject]@{
+                Code = 'BrowserTimeout'; AuthenticationMethod = 'StructuredMock'; Stage = 'BrowserSignIn'
+            }
+            $record = [System.Management.Automation.ErrorRecord]::new($exception, 'XdrAuthentication.BrowserTimeout', 'OperationTimeout', $null)
+            $record.ErrorDetails = [System.Management.Automation.ErrorDetails]::new('Browser authentication did not complete before the timeout.')
+            throw $record
         } -ModuleName XDRInternals
 
         $caught = try { & $Command @Arguments } catch { $_ }
 
         $caught.FullyQualifiedErrorId | Should -BeLike 'XdrAuthentication.BrowserTimeout*'
-        $caught.Exception.Data['XdrAuthenticationFailure'].AuthenticationMethod | Should -Be $Method
+        $caught.Exception.Data['XdrAuthenticationFailure'].AuthenticationMethod | Should -Be 'StructuredMock'
         $caught.Exception.InnerException | Should -BeNullOrEmpty
     }
 }


### PR DESCRIPTION
## Summary

Add a shared, structured authentication error contract across the authentication-focused `Connect-Xdr*` cmdlets.

Authentication failures now provide stable `XdrAuthentication.<Code>` identifiers, appropriate PowerShell error categories, concise user-facing messages, recommended actions, retryability, safe diagnostic identifiers, and bounded metadata while preserving original exceptions.

## What changed

- Added shared authentication failure normalization and error-record construction.
- Integrated structured terminating errors with Credential, Temporary Access Pass, Phone Sign-In, Software Passkey, Browser, SSO, ESTS-cookie, and shared artifact-bootstrap flows.
- Added exact Entra, OAuth, SAS, and HTTP classifications with precedence tests.
- Added scenario-specific Conditional Access remediation for device compliance and join state, approved clients, app protection, security-info registration, security defaults, password change, and risk-based blocks.
- Detects Conditional Access App Control redirects through the Defender for Cloud Apps reverse proxy and reports the safe proxy host without retaining page content.
- Added allowlisted browser page diagnostics through the existing CDP path.
- Added method-specific handling for rejected TAPs, phone MFA timeouts, and temporary remote-auth-session failures.
- Preserved safe summaries when both ESTS and portal fallback attempts fail.
- Prevented secrets, authorization artifacts, redirect state, cookies, assertions, and browser page content from entering diagnostics.

## User impact

Successful authentication behavior and public command surfaces remain unchanged. Failed authentication now explains what failed, whether retrying is useful, and what corrective action to take without exposing authentication material.

For RemoteNGC phone sign-in, an explicit denial is classified when Entra reports a terminal denial state. When the service continues to expose only a pending state after the user denies the prompt, the observable result is reported as `MfaTimeout` rather than incorrectly as a browser timeout.

## Validation

- Full repository validation during final review: 20,119 tests passed with zero failures.
- After the final exact-code additions: 12,300 analyzer tests and 115 focused authentication tests passed with zero failures.
- Documentation synchronization completed with no generated changes.
- Live proofs covered:
  - successful browser authentication
  - browser closure and timeout handling
  - invalid tenant and session failures
  - TAP authentication reaching Conditional Access evaluation
  - compliant-device Conditional Access rejection
  - software-passkey authentication reaching a Conditional Access App Control reverse-proxy redirect
  - rejected/revoked TAP handling
  - phone-sign-in denial behavior and timeout normalization
- Live and automated secret-safety checks confirmed that authentication material is not retained in displayed errors, metadata, verbose diagnostics, or fallback evidence.

