### PR TITLE
fix: preserve Defender user agent across worker requests

### DIFF
--- a/XDRInternals/functions/Connect-XdrEndpointDeviceLiveResponse.ps1
+++ b/XDRInternals/functions/Connect-XdrEndpointDeviceLiveResponse.ps1
@@ -840,6 +840,9 @@
             $knownCommands = @($SharedParameters.KnownCommands)
 
             $webSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            if (-not [string]::IsNullOrWhiteSpace([string]$SharedParameters.UserAgent)) {
+                $webSession.UserAgent = [string]$SharedParameters.UserAgent
+            }
             foreach ($cookieInfo in $SharedParameters.CookieData) {
                 $cookie = [System.Net.Cookie]::new($cookieInfo.Name, $cookieInfo.Value, $cookieInfo.Path, $cookieInfo.Domain)
                 $webSession.Cookies.Add($cookie)
@@ -1063,6 +1066,7 @@
             BaseUrl       = $requestContext.BaseUrl
             CookieData    = $requestContext.CookieData
             HeadersData   = $requestContext.HeadersData
+            UserAgent     = $requestContext.UserAgent
             KnownCommands = $knownCommands
         } -BatchStartedScript {
             param($BatchNumber, $TotalBatches, $Items)

--- a/XDRInternals/functions/Invoke-XdrEndpointDeviceLiveResponseCommand.ps1
+++ b/XDRInternals/functions/Invoke-XdrEndpointDeviceLiveResponseCommand.ps1
@@ -614,6 +614,9 @@
             $webSession = $SharedParameters.WebSession
             if (-not $webSession) {
                 $webSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+                if (-not [string]::IsNullOrWhiteSpace([string]$SharedParameters.UserAgent)) {
+                    $webSession.UserAgent = [string]$SharedParameters.UserAgent
+                }
                 foreach ($cookieInfo in $SharedParameters.CookieData) {
                     $cookie = [System.Net.Cookie]::new($cookieInfo.Name, $cookieInfo.Value, $cookieInfo.Path, $cookieInfo.Domain)
                     $webSession.Cookies.Add($cookie)
@@ -977,6 +980,7 @@
             BaseUrl     = $requestContext.BaseUrl
             CookieData  = $requestContext.CookieData
             HeadersData = $requestContext.HeadersData
+            UserAgent   = $requestContext.UserAgent
         }
 
         foreach ($batchResult in @($batchResults | Sort-Object @{ Expression = { if ([string]::IsNullOrWhiteSpace($_.Item.DeviceName)) { '~' } else { $_.Item.DeviceName } } }, @{ Expression = { $_.Item.SessionId } })) {

--- a/XDRInternals/functions/Set-XdrConnectionSettings.ps1
+++ b/XDRInternals/functions/Set-XdrConnectionSettings.ps1
@@ -77,6 +77,7 @@
         }
         # Create session and cookies
         $script:session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $script:session.UserAgent = Get-XdrDefaultUserAgent
         $script:session.Cookies.Add((New-Object System.Net.Cookie("sccauth", $SccAuthValue, "/", "security.microsoft.com")))
 
         if ($PSBoundParameters.ContainsKey('Xsrf')) {
@@ -116,12 +117,14 @@
     if ($PSBoundParameters.ContainsKey('ResetWebSession')) {
         # Set tenant id
         $TenantId = $script:headers["x-tid"]
+        $userAgent = [string]$script:session.UserAgent
         # Reset the existing WebSession by creating a new one
         Write-Verbose "Resetting existing WebSession to remove old headers and cookies"
         $SccAuthValue = $script:session.cookies.GetCookies("https://security.microsoft.com")['sccauth'].Value
         $XsrfValue = $script:session.cookies.GetCookies("https://security.microsoft.com")['xsrf-token'].Value
         # Create session and cookies
         $script:session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $script:session.UserAgent = if ([string]::IsNullOrWhiteSpace($userAgent)) { Get-XdrDefaultUserAgent } else { $userAgent }
         $script:session.Cookies.Add((New-Object System.Net.Cookie("sccauth", $SccAuthValue, "/", "security.microsoft.com")))
         $script:session.Cookies.Add((New-Object System.Net.Cookie("XSRF-TOKEN", $XsrfValue, "/", "security.microsoft.com")))
     }

--- a/XDRInternals/internal/functions/Get-XdrRequestContextSnapshot.ps1
+++ b/XDRInternals/internal/functions/Get-XdrRequestContextSnapshot.ps1
@@ -13,7 +13,7 @@
 
     .OUTPUTS
         PSCustomObject
-        Returns an object with BaseUrl, CookieData, and HeadersData properties.
+        Returns an object with BaseUrl, CookieData, HeadersData, and UserAgent properties.
     #>
     [CmdletBinding()]
     param ()
@@ -52,5 +52,6 @@
         BaseUrl     = $baseUrl
         CookieData  = @($cookieData)
         HeadersData = $headersData
+        UserAgent   = [string]$script:session.UserAgent
     }
 }

--- a/tests/functions/RequestContext.Tests.ps1
+++ b/tests/functions/RequestContext.Tests.ps1
@@ -1,0 +1,38 @@
+InModuleScope XDRInternals {
+    Describe 'Defender request context preservation' {
+        AfterEach {
+            Remove-Variable -Name session -Scope Script -ErrorAction SilentlyContinue
+            Remove-Variable -Name headers -Scope Script -ErrorAction SilentlyContinue
+        }
+
+        It 'includes the authenticated browser user-agent in worker snapshots' {
+            $script:session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            $script:session.UserAgent = 'XDRInternals-Test-Browser/1.0'
+            $script:session.Cookies.Add([System.Net.Cookie]::new('sccauth', 'cookie-value', '/', 'security.microsoft.com'))
+            $script:headers = @{
+                'X-XSRF-TOKEN' = 'xsrf-value'
+                'x-tid' = 'tenant-id'
+                'tenant-id' = 'tenant-id'
+            }
+
+            $snapshot = Get-XdrRequestContextSnapshot
+
+            $snapshot.UserAgent | Should -Be 'XDRInternals-Test-Browser/1.0'
+            $snapshot.HeadersData['x-tid'] | Should -Be 'tenant-id'
+            $snapshot.HeadersData['tenant-id'] | Should -Be 'tenant-id'
+            $snapshot.CookieData.Name | Should -Contain 'sccauth'
+        }
+
+        It 'uses the browser-compatible user-agent for a manually constructed portal session' {
+            Mock Set-XdrCache {} -ModuleName XDRInternals
+            Mock Write-Host {} -ModuleName XDRInternals
+
+            Set-XdrConnectionSettings -SccAuth 'cookie-value' -Xsrf 'xsrf-value' -TenantId 'tenant-id'
+
+            $script:session.UserAgent | Should -Be (Get-XdrDefaultUserAgent)
+            $script:headers['X-XSRF-TOKEN'] | Should -Be 'xsrf-value'
+            $script:headers['x-tid'] | Should -Be 'tenant-id'
+            $script:headers['tenant-id'] | Should -Be 'tenant-id'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Preserves the authenticated Defender portal user agent wherever request context is reconstructed or transferred to live-response workers.

- Store the default browser-compatible user agent when manual connection settings create a new session.
- Include the user agent in request-context snapshots.
- Restore it in live-response worker sessions before issuing Defender requests.
- Cover both the snapshot and manual-session paths with focused Pester tests.

## Why

The endpoint-contract review for another project found that XDRInternals retained cookies and headers across worker boundaries but not the session user agent. A reconstructed `WebRequestSession` could therefore fall back to PowerShell's default user agent even though the authenticated browser-style session used a browser-compatible value.

This PR keeps the change at the shared request-context boundary. It does not copy volatile browser telemetry headers, and it does not add Defender Cloud Apps endpoint-specific headers to cmdlets that do not call those endpoints.

## Validation

- Rebased onto current `MSCloudInternals/XDRInternals` `main` (`20895ab`).
- `tests/functions/RequestContext.Tests.ps1`: 2 passed / 0 failed.
