### PR TITLE
fix: preserve Defender user agent across worker requests

### DIFF
--- a/XDRInternals/functions/Connect-XdrEndpointDeviceLiveResponse.ps1
+++ b/XDRInternals/functions/Connect-XdrEndpointDeviceLiveResponse.ps1
@@ -840,6 +840,9 @@
             $knownCommands = @($SharedParameters.KnownCommands)
 
             $webSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            if (-not [string]::IsNullOrWhiteSpace([string]$SharedParameters.UserAgent)) {
+                $webSession.UserAgent = [string]$SharedParameters.UserAgent
+            }
             foreach ($cookieInfo in $SharedParameters.CookieData) {
                 $cookie = [System.Net.Cookie]::new($cookieInfo.Name, $cookieInfo.Value, $cookieInfo.Path, $cookieInfo.Domain)
                 $webSession.Cookies.Add($cookie)
@@ -1063,6 +1066,7 @@
             BaseUrl       = $requestContext.BaseUrl
             CookieData    = $requestContext.CookieData
             HeadersData   = $requestContext.HeadersData
+            UserAgent     = $requestContext.UserAgent
             KnownCommands = $knownCommands
         } -BatchStartedScript {
             param($BatchNumber, $TotalBatches, $Items)

--- a/XDRInternals/functions/Invoke-XdrEndpointDeviceLiveResponseCommand.ps1
+++ b/XDRInternals/functions/Invoke-XdrEndpointDeviceLiveResponseCommand.ps1
@@ -614,6 +614,9 @@
             $webSession = $SharedParameters.WebSession
             if (-not $webSession) {
                 $webSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+                if (-not [string]::IsNullOrWhiteSpace([string]$SharedParameters.UserAgent)) {
+                    $webSession.UserAgent = [string]$SharedParameters.UserAgent
+                }
                 foreach ($cookieInfo in $SharedParameters.CookieData) {
                     $cookie = [System.Net.Cookie]::new($cookieInfo.Name, $cookieInfo.Value, $cookieInfo.Path, $cookieInfo.Domain)
                     $webSession.Cookies.Add($cookie)
@@ -977,6 +980,7 @@
             BaseUrl     = $requestContext.BaseUrl
             CookieData  = $requestContext.CookieData
             HeadersData = $requestContext.HeadersData
+            UserAgent   = $requestContext.UserAgent
         }
 
         foreach ($batchResult in @($batchResults | Sort-Object @{ Expression = { if ([string]::IsNullOrWhiteSpace($_.Item.DeviceName)) { '~' } else { $_.Item.DeviceName } } }, @{ Expression = { $_.Item.SessionId } })) {

--- a/XDRInternals/functions/Set-XdrConnectionSettings.ps1
+++ b/XDRInternals/functions/Set-XdrConnectionSettings.ps1
@@ -77,6 +77,7 @@
         }
         # Create session and cookies
         $script:session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $script:session.UserAgent = Get-XdrDefaultUserAgent
         $script:session.Cookies.Add((New-Object System.Net.Cookie("sccauth", $SccAuthValue, "/", "security.microsoft.com")))
 
         if ($PSBoundParameters.ContainsKey('Xsrf')) {
@@ -116,12 +117,14 @@
     if ($PSBoundParameters.ContainsKey('ResetWebSession')) {
         # Set tenant id
         $TenantId = $script:headers["x-tid"]
+        $userAgent = [string]$script:session.UserAgent
         # Reset the existing WebSession by creating a new one
         Write-Verbose "Resetting existing WebSession to remove old headers and cookies"
         $SccAuthValue = $script:session.cookies.GetCookies("https://security.microsoft.com")['sccauth'].Value
         $XsrfValue = $script:session.cookies.GetCookies("https://security.microsoft.com")['xsrf-token'].Value
         # Create session and cookies
         $script:session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $script:session.UserAgent = if ([string]::IsNullOrWhiteSpace($userAgent)) { Get-XdrDefaultUserAgent } else { $userAgent }
         $script:session.Cookies.Add((New-Object System.Net.Cookie("sccauth", $SccAuthValue, "/", "security.microsoft.com")))
         $script:session.Cookies.Add((New-Object System.Net.Cookie("XSRF-TOKEN", $XsrfValue, "/", "security.microsoft.com")))
     }

--- a/XDRInternals/internal/functions/Get-XdrRequestContextSnapshot.ps1
+++ b/XDRInternals/internal/functions/Get-XdrRequestContextSnapshot.ps1
@@ -13,7 +13,7 @@
 
     .OUTPUTS
         PSCustomObject
-        Returns an object with BaseUrl, CookieData, and HeadersData properties.
+        Returns an object with BaseUrl, CookieData, HeadersData, and UserAgent properties.
     #>
     [CmdletBinding()]
     param ()
@@ -52,5 +52,6 @@
         BaseUrl     = $baseUrl
         CookieData  = @($cookieData)
         HeadersData = $headersData
+        UserAgent   = [string]$script:session.UserAgent
     }
 }

--- a/tests/functions/LiveResponse.Tests.ps1
+++ b/tests/functions/LiveResponse.Tests.ps1
@@ -73,6 +73,7 @@
                     BaseUrl     = 'https://security.microsoft.com'
                     CookieData  = @()
                     HeadersData = @{}
+                    UserAgent   = 'XDRInternals-Test-Browser/1.0'
                 }
             } -ModuleName XDRInternals
         }
@@ -123,7 +124,8 @@
                 $Items.Count -eq 27 -and
                 $Items[0].DeviceName -eq 'device1' -and
                 $Items[0].LastSeen -eq '2026-03-25T12:34:56Z' -and
-                $Items[0].OsPlatform -eq 'Windows10'
+                $Items[0].OsPlatform -eq 'Windows10' -and
+                $SharedParameters.UserAgent -eq 'XDRInternals-Test-Browser/1.0'
             }
         }
 
@@ -247,6 +249,7 @@
                     BaseUrl     = 'https://security.microsoft.com'
                     CookieData  = @()
                     HeadersData = @{}
+                    UserAgent   = 'XDRInternals-Test-Browser/1.0'
                 }
             } -ModuleName XDRInternals
         }
@@ -601,7 +604,8 @@
                 $Items.Count -eq 2 -and
                 (@($Items | Where-Object { @($_.CommandDefinitions).Count -ne 1 }).Count -eq 0) -and
                 (@($Items | Where-Object { $_.CommandDefinitions[0] -is [System.Array] }).Count -eq 0) -and
-                (@($Items | Where-Object { $_.CommandDefinitions[0].command_definition_id -ne 'processes' }).Count -eq 0)
+                (@($Items | Where-Object { $_.CommandDefinitions[0].command_definition_id -ne 'processes' }).Count -eq 0) -and
+                $SharedParameters.UserAgent -eq 'XDRInternals-Test-Browser/1.0'
             }
         }
 

--- a/tests/functions/RequestContext.Tests.ps1
+++ b/tests/functions/RequestContext.Tests.ps1
@@ -1,8 +1,8 @@
-InModuleScope XDRInternals {
+﻿InModuleScope XDRInternals {
     Describe 'Defender request context preservation' {
         AfterEach {
-            Remove-Variable -Name session -Scope Script -ErrorAction SilentlyContinue
-            Remove-Variable -Name headers -Scope Script -ErrorAction SilentlyContinue
+            $script:session = $null
+            $script:headers = $null
         }
 
         It 'includes the authenticated browser user-agent in worker snapshots' {
@@ -30,6 +30,26 @@ InModuleScope XDRInternals {
             Set-XdrConnectionSettings -SccAuth 'cookie-value' -Xsrf 'xsrf-value' -TenantId 'tenant-id'
 
             $script:session.UserAgent | Should -Be (Get-XdrDefaultUserAgent)
+            $script:headers['X-XSRF-TOKEN'] | Should -Be 'xsrf-value'
+            $script:headers['x-tid'] | Should -Be 'tenant-id'
+            $script:headers['tenant-id'] | Should -Be 'tenant-id'
+        }
+
+        It 'preserves a custom user-agent when resetting the portal session' {
+            Mock Set-XdrCache {} -ModuleName XDRInternals
+            Mock Write-Host {} -ModuleName XDRInternals
+
+            $script:session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            $script:session.UserAgent = 'XDRInternals-Custom-Browser/1.0'
+            $script:session.Cookies.Add([System.Net.Cookie]::new('sccauth', 'cookie-value', '/', 'security.microsoft.com'))
+            $script:session.Cookies.Add([System.Net.Cookie]::new('XSRF-TOKEN', 'xsrf-value', '/', 'security.microsoft.com'))
+            $script:headers = @{
+                'x-tid' = 'tenant-id'
+            }
+
+            Set-XdrConnectionSettings -ResetWebSession
+
+            $script:session.UserAgent | Should -Be 'XDRInternals-Custom-Browser/1.0'
             $script:headers['X-XSRF-TOKEN'] | Should -Be 'xsrf-value'
             $script:headers['x-tid'] | Should -Be 'tenant-id'
             $script:headers['tenant-id'] | Should -Be 'tenant-id'

--- a/tests/functions/RequestContext.Tests.ps1
+++ b/tests/functions/RequestContext.Tests.ps1
@@ -1,0 +1,38 @@
+InModuleScope XDRInternals {
+    Describe 'Defender request context preservation' {
+        AfterEach {
+            Remove-Variable -Name session -Scope Script -ErrorAction SilentlyContinue
+            Remove-Variable -Name headers -Scope Script -ErrorAction SilentlyContinue
+        }
+
+        It 'includes the authenticated browser user-agent in worker snapshots' {
+            $script:session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            $script:session.UserAgent = 'XDRInternals-Test-Browser/1.0'
+            $script:session.Cookies.Add([System.Net.Cookie]::new('sccauth', 'cookie-value', '/', 'security.microsoft.com'))
+            $script:headers = @{
+                'X-XSRF-TOKEN' = 'xsrf-value'
+                'x-tid' = 'tenant-id'
+                'tenant-id' = 'tenant-id'
+            }
+
+            $snapshot = Get-XdrRequestContextSnapshot
+
+            $snapshot.UserAgent | Should -Be 'XDRInternals-Test-Browser/1.0'
+            $snapshot.HeadersData['x-tid'] | Should -Be 'tenant-id'
+            $snapshot.HeadersData['tenant-id'] | Should -Be 'tenant-id'
+            $snapshot.CookieData.Name | Should -Contain 'sccauth'
+        }
+
+        It 'uses the browser-compatible user-agent for a manually constructed portal session' {
+            Mock Set-XdrCache {} -ModuleName XDRInternals
+            Mock Write-Host {} -ModuleName XDRInternals
+
+            Set-XdrConnectionSettings -SccAuth 'cookie-value' -Xsrf 'xsrf-value' -TenantId 'tenant-id'
+
+            $script:session.UserAgent | Should -Be (Get-XdrDefaultUserAgent)
+            $script:headers['X-XSRF-TOKEN'] | Should -Be 'xsrf-value'
+            $script:headers['x-tid'] | Should -Be 'tenant-id'
+            $script:headers['tenant-id'] | Should -Be 'tenant-id'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Preserves the authenticated Defender portal user agent whenever request context is reconstructed or transferred to live-response workers.

- Store the default browser-compatible user agent when manual connection settings create a new session.
- Preserve a custom user agent when resetting an existing session.
- Include the user agent in request-context snapshots.
- Restore it in both live-response worker session paths before issuing Defender requests.
- Cover snapshot creation, manual and reset session behavior, and both batching handoffs with focused Pester tests.

## Why

The shared request-context boundary retained cookies and headers across worker runspaces, but omitted the session user agent. Reconstructed `WebRequestSession` instances could therefore fall back to PowerShell's default user agent even when authentication used a browser-compatible value, potentially changing request behavior across the worker boundary.

This keeps the fix at the shared request-context boundary. It does not copy volatile browser telemetry headers or add endpoint-specific headers to unrelated cmdlets.

## Review notes

This supersedes #126, which was opened from the wrong account.

During review, the original implementation was kept unchanged. Test coverage was strengthened for both worker handoffs and custom user-agent preservation during `ResetWebSession`. The new test file was also brought into compliance with the repository's UTF-8 BOM and integrity rules.

## Validation

- `./build/vsts-validate.ps1`
- 19,748 passed, 0 failed, 3 expected platform/configuration skips
