### PR TITLE
Add resumable identity timeline export

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Get-XdrTenantContext -Force
 | Disconnect-XdrEndpointDeviceLiveResponse                        | Closes an active Live Response session in Microsoft Defender XDR. |
 | Export-XdrAzureDataExplorer                                     | Exports pipeline data to Azure Data Explorer using queued ingestion. |
 | Export-XdrEndpointDeviceTimeline                                | Exports a Microsoft Defender XDR device timeline to NDJSON. |
-| Export-XdrIdentityUserTimeline                                  | Exports a Microsoft Defender for Identity user timeline to resumable NDJSON. |
+| Export-XdrIdentityUserTimeline                                  | Exports a Microsoft Defender for Identity user timeline to NDJSON. |
 | Export-XdrToSentinel                                            | Exports XDR data to a Microsoft Sentinel (Log Analytics) custom table. |
 | Get-XdrActionsCenterHistory                                     | Retrieves historical actions from the Microsoft Defender XDR Action Center. |
 | Get-XdrActionsCenterPending                                     | Retrieves pending actions from the Microsoft Defender XDR Action Center. |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Get-XdrTenantContext -Force
 | Disconnect-XdrEndpointDeviceLiveResponse                        | Closes an active Live Response session in Microsoft Defender XDR. |
 | Export-XdrAzureDataExplorer                                     | Exports pipeline data to Azure Data Explorer using queued ingestion. |
 | Export-XdrEndpointDeviceTimeline                                | Exports a Microsoft Defender XDR device timeline to NDJSON. |
+| Export-XdrIdentityUserTimeline                                  | Exports a Microsoft Defender for Identity user timeline to resumable NDJSON. |
 | Export-XdrToSentinel                                            | Exports XDR data to a Microsoft Sentinel (Log Analytics) custom table. |
 | Get-XdrActionsCenterHistory                                     | Retrieves historical actions from the Microsoft Defender XDR Action Center. |
 | Get-XdrActionsCenterPending                                     | Retrieves pending actions from the Microsoft Defender XDR Action Center. |
@@ -375,6 +376,70 @@ The 4-hour/four-worker balance is therefore the initial release default: it comp
 90-day export without retries or restarts while remaining competitive on elapsed time and
 memory. These defaults can be revisited as more devices, tenants, and time ranges are
 available for testing.
+
+#### Large identity timeline exports
+
+Use `Export-XdrIdentityUserTimeline` for a full, disk-backed Defender for Identity user
+timeline. The identity API has different pagination and boundary rules from the device
+timeline, so this command uses a separate worker while preserving the same resumable
+NDJSON contract:
+
+```powershell
+$from = (Get-Date).ToUniversalTime().AddDays(-90)
+$to = (Get-Date).ToUniversalTime()
+
+Export-XdrIdentityUserTimeline `
+    -Upn 'user@contoso.com' `
+    -FromDate $from `
+    -ToDate $to `
+    -Path '.\identity-timeline-90d.ndjson'
+```
+
+The command accepts `-Upn`, `-AadId`, `-Sid`, or `-RadiusUserId`, exports one identity
+per invocation, and uses fixed internal 24-hour windows with eight workers. Completed
+parts are length- and SHA-256-validated before resume. An existing final file remains in
+place during a `-Force` replacement and is atomically replaced only after the new export
+has been fully validated.
+
+Identity Sentinel anomalies are not included in this initial exporter. The current
+identity Sentinel route is a separate API and requires additional completeness and
+pagination validation before it can be used for incident-response export. A live entity
+resolved by AadId and SID exposed an `armId`; its ARM timeline accepted 7-, 30-, and
+31-day requests but rejected 60-, 89-, and 90-day requests with HTTP 400. Values above
+six for `numberOfBucket` were also rejected. The successful responses contained no
+anomalies, so result limits and pagination under load remain unvalidated.
+
+Live validation found that offset pages are not stable enough for high-fidelity export.
+On a dense six-hour range, adjacent offset pages repeated 13 EventIds while page
+membership and `Description` values changed between identical requests. Deduplicating
+those pages yielded fewer logical events than timestamp-keyset retrieval.
+
+The exporter therefore always requests `skip = 0`. After a full page, it withholds the
+oldest timestamp group and repeats the request with that second as the new upper bound.
+Two delayed, fresh-context 30-day probes for a dense test identity each produced the
+same 23,490-event logical set across 36 requests; the largest tied boundary contained
+723 events in one second. Two probes for a lower-volume identity likewise produced the
+same logical set. Duplicate
+representations are counted, the first raw object is retained unchanged, and the export
+fails if one second fills all 1,000 rows because completeness cannot then be proven.
+
+Repeated corrected-strategy benchmarks favored the 24-hour/eight-worker default. On a
+fixed 7-day range its median was 14.1 seconds versus 19.5 seconds for 48 hours/four
+workers; on a fixed 30-day range it was 54.1 seconds versus 87.5 seconds. A 90-day run
+completed in 192.3 seconds versus 316.9 seconds for 24 hours/four workers. Event sets
+were identical for directly comparable runs, no candidate run retried or restarted, and
+peak process working set remained below 756 MiB. The settings remain private because
+this is tenant-specific evidence, not a service guarantee.
+
+Independent validation also confirmed line count, half-open range, global ordering,
+byte length, SHA-256, interruption/resume, and adjacent-window set equality. On a fixed
+six-hour range, the public `Get-` and `Export-` commands returned identical 1,845-event
+stable sets. Repeated raw-file hashes are not expected to match: the service changed
+only `Id`, `RowNumber`, and `Description` on otherwise identical logical events during
+the delayed 30-day comparison. The service also added one 44-day-old event without an
+`EventId` between delayed 90-day snapshots. Treat an export as a point-in-time service
+snapshot and preserve its manifest timestamps; rerun important historical ranges when
+late backend enrichment matters.
 
 #### Azure Data Explorer export
 

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Export-XdrIdentityUserTimeline `
 ```
 
 The command accepts `-Upn`, `-AadId`, `-Sid`, or `-RadiusUserId`, exports one identity
-per invocation, and uses fixed internal 24-hour windows with eight workers. Completed
+per invocation, and uses fixed internal 12-hour windows with eight workers. Completed
 parts are length- and SHA-256-validated before resume. An existing final file remains in
 place during a `-Force` replacement and is atomically replaced only after the new export
 has been fully validated.
@@ -423,16 +423,31 @@ same logical set. Duplicate
 representations are counted, the first raw object is retained unchanged, and the export
 fails if one second fills all 1,000 rows because completeness cannot then be proven.
 
-Repeated corrected-strategy benchmarks favored the 24-hour/eight-worker default. On a
-fixed 7-day range its median was 14.1 seconds versus 19.5 seconds for 48 hours/four
-workers; on a fixed 30-day range it was 54.1 seconds versus 87.5 seconds. A 90-day run
-completed in 192.3 seconds versus 316.9 seconds for 24 hours/four workers. Event sets
-were identical for directly comparable runs, no candidate run retried or restarted, and
-peak process working set remained below 756 MiB. The settings remain private because
-this is tenant-specific evidence, not a service guarantee.
+Follow-up testing kept the 1,000-row page size. On a dense 30-day range, both 250- and
+500-row pages failed closed because two API seconds each filled an entire page; the
+1,000-row run completed with 23,502 events and a maximum of 723 events in one second.
+A separate low-volume 30-day range returned the same 335-event canonical set with page
+sizes 250, 500, and 1,000, supporting the short-page terminal assumption where the page
+can represent a complete second.
+
+The same follow-up compared 6-, 12-, and 24-hour windows with 4, 8, and 16 workers on a
+dense fixed seven-day range. All nine aligned runs produced the same 10,070-event
+canonical set. The 12-hour/eight-worker candidate was then interleaved with the prior
+24-hour/eight-worker default over 30 days: 12-hour runs completed in 56.2 and 61.0
+seconds versus 70.8 and 68.2 seconds for 24 hours. All four returned the same 23,502
+events with no retries or restarts; peak working set ranged from 573 to 700 MiB for 12
+hours and 658 to 678 MiB for 24 hours. The repeatable improvement earned the 12-hour
+default, while worker count and page size remain unchanged and private.
+
+A midnight-aligned stress range also exposed a service boundary violation: the API
+repeatedly returned a 23:59:59 event outside its exclusive lower bound. Every tested
+window size rejected that response after fresh-window restarts instead of publishing
+overlapping output.
 
 Independent validation also confirmed line count, half-open range, global ordering,
-byte length, SHA-256, interruption/resume, and adjacent-window set equality. On a fixed
+byte length, SHA-256, interruption/resume, and adjacent-window set equality. A live
+12-hour-window export resumed 18 of 60 hash-validated parts after interruption and
+completed 23,502 rows with matching length and SHA-256. On a fixed
 six-hour range, the public `Get-` and `Export-` commands returned identical 1,845-event
 stable sets. Repeated raw-file hashes are not expected to match: the service changed
 only `Id`, `RowNumber`, and `Description` on otherwise identical logical events during

--- a/XDRInternals/XDRInternals.psd1
+++ b/XDRInternals/XDRInternals.psd1
@@ -74,6 +74,7 @@
         "Disconnect-XdrEndpointDeviceLiveResponse",
         "Export-XdrAzureDataExplorer",
         "Export-XdrEndpointDeviceTimeline",
+        "Export-XdrIdentityUserTimeline",
         "Export-XdrToSentinel",
         "Get-XdrActionsCenterHistory",
         "Get-XdrActionsCenterPending",

--- a/XDRInternals/functions/Export-XdrIdentityUserTimeline.ps1
+++ b/XDRInternals/functions/Export-XdrIdentityUserTimeline.ps1
@@ -1,0 +1,571 @@
+﻿function Export-XdrIdentityUserTimeline {
+    <#
+    .SYNOPSIS
+        Exports a Microsoft Defender for Identity user timeline to NDJSON.
+
+    .DESCRIPTION
+        Exports a bounded identity timeline through the Defender XDR portal API. The
+        requested range is divided into fixed, newest-first intervals and written to
+        resumable, hash-validated NDJSON parts. The final path is published only after
+        every interval succeeds and the complete byte stream is independently verified.
+
+        This cmdlet is intended for large incident-response collections. Use
+        Get-XdrIdentityUserTimeline for smaller in-memory retrieval.
+
+    .PARAMETER AadId
+        The Entra object ID of the user.
+
+    .PARAMETER Upn
+        The user principal name of the user.
+
+    .PARAMETER Sid
+        The security identifier of the user.
+
+    .PARAMETER RadiusUserId
+        The Defender for Identity RADIUS user identifier.
+
+    .PARAMETER FromDate
+        Inclusive beginning of the export range. The value is converted to UTC.
+
+    .PARAMETER ToDate
+        Exclusive end of the export range. The value is converted to UTC.
+
+    .PARAMETER Path
+        Destination NDJSON file. The path must end in .ndjson.
+
+    .PARAMETER Force
+        Starts a replacement export when Path or incompatible resumable state exists.
+        An existing final file remains available until the replacement is complete.
+
+    .EXAMPLE
+        Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $from -ToDate $to -Path '.\identity.ndjson'
+        Exports the requested identity timeline and returns a compact summary.
+    #>
+    [OutputType([PSCustomObject])]
+    [CmdletBinding(DefaultParameterSetName = 'ByUpn')]
+    param (
+        [Parameter(Mandatory, ParameterSetName = 'ByAadId')]
+        [Alias('aad', 'ObjectId')]
+        [string]$AadId,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByUpn')]
+        [Alias('UserPrincipalName', 'Email')]
+        [string]$Upn,
+
+        [Parameter(Mandatory, ParameterSetName = 'BySid')]
+        [string]$Sid,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByRadiusUserId')]
+        [string]$RadiusUserId,
+
+        [Parameter(Mandatory)]
+        [datetime]$FromDate,
+
+        [Parameter(Mandatory)]
+        [datetime]$ToDate,
+
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter()]
+        [switch]$Force
+    )
+
+    begin {
+        if ($PSVersionTable.PSVersion.Major -lt 7) {
+            throw 'Export-XdrIdentityUserTimeline requires PowerShell 7 or later.'
+        }
+        Update-XdrConnectionSettings
+    }
+
+    process {
+        $operationStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $rangeStart = $FromDate.ToUniversalTime()
+        $rangeEnd = $ToDate.ToUniversalTime()
+        if ($rangeStart -ge $rangeEnd) {
+            throw 'FromDate must be before ToDate.'
+        }
+        if (($rangeEnd - $rangeStart).TotalDays -gt 180) {
+            throw 'The time range between FromDate and ToDate cannot exceed 180 days.'
+        }
+
+        $selectorName = $PSCmdlet.ParameterSetName.Substring(2)
+        $selectorValue = switch ($selectorName) {
+            'AadId' { $AadId }
+            'Upn' { $Upn }
+            'Sid' { $Sid }
+            'RadiusUserId' { $RadiusUserId }
+        }
+        try {
+            $resolveParameters = @{ ErrorAction = 'Stop' }
+            $resolveParameters[$selectorName] = $selectorValue
+            $resolvedUser = Get-XdrIdentityUser @resolveParameters | Select-Object -First 1
+        }
+        catch {
+            $selectorHint = if ($selectorName -eq 'Upn') {
+                ' If the Defender user URL contains aad or sid values, retry with -AadId or -Sid; sending an unresolved UPN directly can return an empty timeline.'
+            } else { '' }
+            throw "Failed to resolve identity by $selectorName '$selectorValue': $($_.Exception.Message)$selectorHint"
+        }
+        if ($null -eq $resolvedUser) {
+            throw "Could not resolve identity by $selectorName '$selectorValue'."
+        }
+
+        $userIdentifiers = ConvertTo-XdrIdentityUserIdentifiers -ResolvedUser $resolvedUser
+        if ($null -eq $userIdentifiers -or $userIdentifiers.Count -eq 0) {
+            throw 'The resolved identity did not contain identifiers usable by the timeline API.'
+        }
+
+        $canonicalize = {
+            param($Value)
+
+            if ($Value -is [System.Collections.IDictionary]) {
+                $ordered = [ordered]@{}
+                foreach ($key in @($Value.Keys | Sort-Object)) {
+                    $ordered[[string]$key] = & $canonicalize $Value[$key]
+                }
+                return $ordered
+            }
+            if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
+                return @($Value | ForEach-Object { & $canonicalize $_ })
+            }
+            return $Value
+        }
+        $canonicalIdentifiers = & $canonicalize $userIdentifiers
+        $identityJson = $canonicalIdentifiers | ConvertTo-Json -Depth 20 -Compress
+        $identityFingerprint = [Convert]::ToHexString(
+            [System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($identityJson))
+        ).ToLowerInvariant()
+
+        $outputPath = [System.IO.Path]::GetFullPath($Path)
+        if ([System.IO.Path]::GetExtension($outputPath) -ine '.ndjson') {
+            throw "Path '$Path' must use the .ndjson extension."
+        }
+        if (Test-Path -LiteralPath $outputPath -PathType Container) {
+            throw "Path '$Path' resolves to a directory."
+        }
+        $outputDirectory = Split-Path -Parent $outputPath
+        if (-not (Test-Path -LiteralPath $outputDirectory)) {
+            New-Item -Path $outputDirectory -ItemType Directory -Force -ErrorAction Stop | Out-Null
+        }
+
+        $manifestPath = "$outputPath.manifest.json"
+        $manifestPartialPath = "$manifestPath.partial"
+        $partsPath = "$outputPath.parts"
+        $outputPartialPath = "$outputPath.partial"
+        $writeManifest = {
+            param($Manifest)
+
+            $Manifest.UpdatedUtc = [datetime]::UtcNow.ToString('o')
+            [System.IO.File]::WriteAllText(
+                $manifestPartialPath,
+                ($Manifest | ConvertTo-Json -Depth 20),
+                [System.Text.UTF8Encoding]::new($false)
+            )
+            [System.IO.File]::Move($manifestPartialPath, $manifestPath, $true)
+        }
+
+        $chunkHours = 24
+        $pageSize = 1000
+        $paginationStrategy = 'TimestampKeysetV2'
+        $throttleLimit = 8
+        $requestTimeoutSeconds = 120
+        $maxRetries = 5
+        $maxChunkRestarts = 2
+        $baseUrl = 'https://security.microsoft.com'
+        $manifest = $null
+        $resumedChunkCount = 0
+        $existingOutputAtStart = Test-Path -LiteralPath $outputPath -PathType Leaf
+
+        if ($Force) {
+            foreach ($staleFile in @($manifestPath, $manifestPartialPath, $outputPartialPath)) {
+                if (Test-Path -LiteralPath $staleFile) {
+                    Remove-Item -LiteralPath $staleFile -Force -ErrorAction Stop
+                }
+            }
+            if (Test-Path -LiteralPath $partsPath) {
+                Remove-Item -LiteralPath $partsPath -Recurse -Force -ErrorAction Stop
+            }
+        }
+        elseif (Test-Path -LiteralPath $manifestPath) {
+            try {
+                $manifest = Get-Content -LiteralPath $manifestPath -Raw -ErrorAction Stop |
+                    ConvertFrom-Json -AsHashtable -Depth 20 -ErrorAction Stop
+            }
+            catch {
+                throw "Manifest '$manifestPath' could not be read. Use -Force to start a new export. $($_.Exception.Message)"
+            }
+        }
+        elseif ($existingOutputAtStart) {
+            throw "Path '$outputPath' already exists without resumable state. Use -Force to replace it."
+        }
+
+        $compatible = $false
+        if ($manifest) {
+            $compatible =
+                [int]$manifest.SchemaVersion -eq 2 -and
+                [string]$manifest.IdentityFingerprint -eq $identityFingerprint -and
+                ([datetime]$manifest.FromDateUtc).ToUniversalTime().Ticks -eq $rangeStart.Ticks -and
+                ([datetime]$manifest.ToDateUtc).ToUniversalTime().Ticks -eq $rangeEnd.Ticks -and
+                [int]$manifest.ChunkHours -eq $chunkHours -and
+                [int]$manifest.PageSize -eq $pageSize -and
+                [string]$manifest.PaginationStrategy -eq $paginationStrategy
+            if (-not $compatible) {
+                throw "Manifest '$manifestPath' does not match this request. Use -Force to discard it or choose another Path."
+            }
+        }
+
+        if ($manifest -and [string]$manifest.State -in @('Publishing', 'Complete')) {
+            $expectedBytes = [long]$manifest.Summary.FileBytes
+            $expectedHash = [string]$manifest.Summary.FileSha256
+            $validOutput = $false
+            if (Test-Path -LiteralPath $outputPath -PathType Leaf) {
+                $validOutput = (Get-Item -LiteralPath $outputPath).Length -eq $expectedBytes
+                if ($validOutput) {
+                    $validOutput = (Get-FileHash -LiteralPath $outputPath -Algorithm SHA256).Hash.ToLowerInvariant() -eq $expectedHash
+                }
+            }
+
+            if (-not $validOutput -and [string]$manifest.State -eq 'Publishing' -and
+                (Test-Path -LiteralPath $outputPartialPath -PathType Leaf)) {
+                $validPartial = (Get-Item -LiteralPath $outputPartialPath).Length -eq $expectedBytes
+                if ($validPartial) {
+                    $validPartial = (Get-FileHash -LiteralPath $outputPartialPath -Algorithm SHA256).Hash.ToLowerInvariant() -eq $expectedHash
+                }
+                if ($validPartial) {
+                    [System.IO.File]::Move($outputPartialPath, $outputPath, $true)
+                    $validOutput = $true
+                }
+            }
+
+            if ($validOutput) {
+                $partsRetained = $false
+                if (Test-Path -LiteralPath $partsPath) {
+                    try { Remove-Item -LiteralPath $partsPath -Recurse -Force -ErrorAction Stop }
+                    catch { $partsRetained = $true }
+                }
+                $manifest.State = 'Complete'
+                $manifest.Summary.PartsRetained = $partsRetained
+                & $writeManifest $manifest
+                return [PSCustomObject]@{
+                    OutputPath = $outputPath; ManifestPath = $manifestPath
+                    TotalEvents = [long]$manifest.Summary.EventCount; TotalPages = [long]$manifest.Summary.PageCount
+                    TotalRetries = [long]$manifest.Summary.RetryCount; TotalChunkRestarts = [long]$manifest.Summary.ChunkRestartCount
+                    TotalPaginationRewinds = [long]$manifest.Summary.PaginationRewindCount
+                    TotalChunks = @($manifest.Chunks).Count; ResumedChunks = @($manifest.Chunks).Count
+                    FileBytes = $expectedBytes; FileSha256 = $expectedHash
+                    MissingTimestampCount = [long]$manifest.Summary.MissingTimestampCount
+                    BoundaryTimestampCount = [long]$manifest.Summary.BoundaryTimestampCount
+                    DuplicateRepresentationCount = [long]$manifest.Summary.DuplicateRepresentationCount
+                    MergeSeconds = [double]$manifest.Summary.MergeSeconds
+                    ElapsedSeconds = [double]$manifest.Summary.ElapsedSeconds
+                    TemporaryPartsRetained = $partsRetained
+                }
+            }
+            if ([string]$manifest.State -eq 'Complete') {
+                throw "Completed export '$outputPath' failed validation. Use -Force to replace it."
+            }
+            $manifest.State = 'InProgress'
+            if (Test-Path -LiteralPath $outputPartialPath) {
+                Remove-Item -LiteralPath $outputPartialPath -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        if (-not $manifest) {
+            $chunks = [System.Collections.Generic.List[object]]::new()
+            $chunkEnd = $rangeEnd
+            $index = 0
+            while ($chunkEnd -gt $rangeStart) {
+                $chunkStart = $chunkEnd.AddHours(-$chunkHours)
+                if ($chunkStart -lt $rangeStart) { $chunkStart = $rangeStart }
+                $chunks.Add([PSCustomObject]@{
+                        Index = $index; FromDate = $chunkStart; ToDate = $chunkEnd
+                        DurationTicks = ($chunkEnd - $chunkStart).Ticks
+                        FileName = ('chunk_{0:D4}_{1:yyyyMMddTHHmmssfffZ}_{2:yyyyMMddTHHmmssfffZ}.ndjson' -f $index, $chunkStart, $chunkEnd)
+                    })
+                $index++
+                $chunkEnd = $chunkStart
+            }
+
+            $manifestChunks = @(
+                foreach ($plannedChunk in $chunks) {
+                    [ordered]@{
+                        Index = $plannedChunk.Index; FromDateUtc = $plannedChunk.FromDate.ToString('o')
+                        ToDateUtc = $plannedChunk.ToDate.ToString('o'); DurationTicks = $plannedChunk.DurationTicks
+                        FileName = $plannedChunk.FileName; Status = 'Pending'; EventCount = 0L; PageCount = 0
+                        RetryCount = 0; RewindCount = 0; AttemptCount = 0; FileBytes = 0L; FileSha256 = $null
+                        MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.0; Error = $null
+                        DuplicateRepresentationCount = 0L
+                    }
+                }
+            )
+            $manifest = [ordered]@{
+                SchemaVersion = 2; State = 'InProgress'; IdentityFingerprint = $identityFingerprint
+                IdentitySelector = $selectorName; FromDateUtc = $rangeStart.ToString('o'); ToDateUtc = $rangeEnd.ToString('o')
+                ChunkHours = $chunkHours; PageSize = $pageSize; PaginationStrategy = $paginationStrategy
+                Ordering = 'NewestTimeWindowFirst;ApiTimestampDescending'; ReplaceExisting = $existingOutputAtStart
+                CreatedUtc = [datetime]::UtcNow.ToString('o'); UpdatedUtc = [datetime]::UtcNow.ToString('o')
+                Chunks = $manifestChunks; Summary = $null
+            }
+        }
+
+        New-Item -Path $partsPath -ItemType Directory -Force -ErrorAction Stop | Out-Null
+        foreach ($manifestChunk in @($manifest.Chunks)) {
+            if ([string]$manifestChunk.Status -eq 'Completed') {
+                $partPath = Join-Path $partsPath ([string]$manifestChunk.FileName)
+                $validPart = Test-Path -LiteralPath $partPath -PathType Leaf
+                if ($validPart) { $validPart = (Get-Item -LiteralPath $partPath).Length -eq [long]$manifestChunk.FileBytes }
+                if ($validPart) {
+                    $validPart = (Get-FileHash -LiteralPath $partPath -Algorithm SHA256).Hash.ToLowerInvariant() -eq [string]$manifestChunk.FileSha256
+                }
+                if ($validPart) {
+                    $resumedChunkCount++
+                    continue
+                }
+                if (Test-Path -LiteralPath $partPath) { Remove-Item -LiteralPath $partPath -Force -ErrorAction SilentlyContinue }
+            }
+
+            $manifestChunk.Status = 'Pending'; $manifestChunk.EventCount = 0L; $manifestChunk.PageCount = 0
+            $manifestChunk.RetryCount = 0; $manifestChunk.RewindCount = 0; $manifestChunk.AttemptCount = 0
+            $manifestChunk.FileBytes = 0L; $manifestChunk.FileSha256 = $null; $manifestChunk.MissingTimestampCount = 0L
+            $manifestChunk.BoundaryTimestampCount = 0L; $manifestChunk.ElapsedSeconds = 0.0; $manifestChunk.Error = $null
+            $manifestChunk.DuplicateRepresentationCount = 0L
+        }
+        $manifest.State = 'InProgress'
+        & $writeManifest $manifest
+
+        $cookieData = @(
+            foreach ($cookie in $script:session.Cookies.GetCookies([uri]$baseUrl)) {
+                [PSCustomObject]@{ Name = $cookie.Name; Value = $cookie.Value; Domain = $cookie.Domain; Path = $cookie.Path }
+            }
+        )
+        $identityHeaders = Get-XdrIdentityHeaders
+        $headersData = @{}
+        foreach ($headerName in $identityHeaders.Keys) { $headersData[$headerName] = $identityHeaders[$headerName] }
+
+        $sharedParameters = @{
+            BaseUrl = $baseUrl; UserIdentifiers = $userIdentifiers; PageSize = $pageSize
+            MaxRetries = $maxRetries; RequestTimeoutSeconds = $requestTimeoutSeconds; PartsPath = $partsPath
+            CookieData = $cookieData; HeadersData = $headersData
+        }
+        $pendingChunks = @(
+            foreach ($manifestChunk in @($manifest.Chunks | Where-Object Status -eq 'Pending' | Sort-Object { [int]$_.Index })) {
+                [PSCustomObject]@{
+                    Index = [int]$manifestChunk.Index; FromDate = [datetime]$manifestChunk.FromDateUtc
+                    ToDate = [datetime]$manifestChunk.ToDateUtc; DurationTicks = [long]$manifestChunk.DurationTicks
+                    FileName = [string]$manifestChunk.FileName; Attempt = [int]$manifestChunk.AttemptCount
+                }
+            }
+        )
+
+        $totalChunkCount = @($manifest.Chunks).Count
+        $totalDurationTicks = [long](($manifest.Chunks | ForEach-Object { [long]$_.DurationTicks } | Measure-Object -Sum).Sum)
+        $initialCompletedTicks = [long](($manifest.Chunks | Where-Object Status -eq 'Completed' | ForEach-Object { [long]$_.DurationTicks } | Measure-Object -Sum).Sum)
+        Write-Information "Identity timeline export: $totalChunkCount $chunkHours-hour window(s), $resumedChunkCount resumed, throttle=$throttleLimit, output='$outputPath'." -InformationAction Continue
+
+        $workerScriptText = (New-XdrIdentityTimelineExportWorker).ToString()
+        $statusMap = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+        $chunkQueue = [System.Collections.Generic.Queue[object]]::new()
+        foreach ($pendingChunk in $pendingChunks) { $chunkQueue.Enqueue($pendingChunk) }
+        $runspacePool = [runspacefactory]::CreateRunspacePool(1, $throttleLimit)
+        $activeJobs = [System.Collections.Generic.List[object]]::new()
+        $failureResults = [System.Collections.Generic.List[object]]::new()
+        $completedDuringRunTicks = 0L
+        $lastProgressUpdate = [datetime]::MinValue
+        $lastHeartbeat = [datetime]::UtcNow
+        $stopScheduling = $false
+        $capturedError = $null
+
+        $startChunkJob = {
+            param($Chunk)
+            $powerShell = [powershell]::Create()
+            $powerShell.RunspacePool = $runspacePool
+            [void]$powerShell.AddScript($workerScriptText)
+            [void]$powerShell.AddParameter('chunk', $Chunk)
+            [void]$powerShell.AddParameter('sharedParameters', $sharedParameters)
+            [void]$powerShell.AddParameter('statusMap', $statusMap)
+            [PSCustomObject]@{ PowerShell = $powerShell; Handle = $powerShell.BeginInvoke(); Chunk = $Chunk }
+        }
+
+        try {
+            $runspacePool.Open()
+            while ($chunkQueue.Count -gt 0 -and $activeJobs.Count -lt $throttleLimit) {
+                $activeJobs.Add((& $startChunkJob $chunkQueue.Dequeue()))
+            }
+            while ($activeJobs.Count -gt 0) {
+                $completedJobs = @($activeJobs | Where-Object { $_.Handle.IsCompleted })
+                foreach ($job in $completedJobs) {
+                    try {
+                        $jobOutput = @($job.PowerShell.EndInvoke($job.Handle))
+                        $result = $jobOutput | Select-Object -Last 1
+                        if (-not $result) { throw "Chunk $($job.Chunk.Index) returned no result." }
+                    }
+                    catch {
+                        $result = [PSCustomObject]@{
+                            Success = $false; ChunkIndex = [int]$job.Chunk.Index; EventCount = 0L; PageCount = 0
+                            RetryCount = 0; RewindCount = 0; FileBytes = 0L; FileSha256 = $null
+                            MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.0
+                            DuplicateRepresentationCount = 0L
+                            Error = $_.ToString(); FailureClass = 'WorkerFailure'
+                        }
+                    }
+                    finally {
+                        $job.PowerShell.Dispose()
+                        [void]$activeJobs.Remove($job)
+                    }
+
+                    $manifestChunk = @($manifest.Chunks | Where-Object { [int]$_.Index -eq [int]$result.ChunkIndex })[0]
+                    $manifestChunk.RetryCount = [int]$manifestChunk.RetryCount + [int]$result.RetryCount
+                    $manifestChunk.RewindCount = [int]$manifestChunk.RewindCount + [int]$result.RewindCount
+                    $manifestChunk.DuplicateRepresentationCount = [long]$manifestChunk.DuplicateRepresentationCount + [long]$result.DuplicateRepresentationCount
+                    $manifestChunk.AttemptCount = [int]$job.Chunk.Attempt
+                    $manifestChunk.ElapsedSeconds = [double]$manifestChunk.ElapsedSeconds + [double]$result.ElapsedSeconds
+
+                    if ($result.Success) {
+                        $manifestChunk.Status = 'Completed'; $manifestChunk.EventCount = [long]$result.EventCount
+                        $manifestChunk.PageCount = [int]$result.PageCount; $manifestChunk.FileBytes = [long]$result.FileBytes
+                        $manifestChunk.FileSha256 = [string]$result.FileSha256
+                        $manifestChunk.MissingTimestampCount = [long]$result.MissingTimestampCount
+                        $manifestChunk.BoundaryTimestampCount = [long]$result.BoundaryTimestampCount
+                        $manifestChunk.Error = $null
+                        $completedDuringRunTicks += [long]$manifestChunk.DurationTicks
+                    }
+                    elseif ([string]$result.FailureClass -in @('PartialResponse', 'TransientHttp', 'Transport', 'Protocol') -and
+                        [int]$job.Chunk.Attempt -lt $maxChunkRestarts) {
+                        $nextAttempt = [int]$job.Chunk.Attempt + 1
+                        $manifestChunk.Status = 'Pending'; $manifestChunk.AttemptCount = $nextAttempt
+                        $manifestChunk.EventCount = 0L; $manifestChunk.PageCount = 0; $manifestChunk.FileBytes = 0L
+                        $manifestChunk.FileSha256 = $null; $manifestChunk.MissingTimestampCount = 0L
+                        $manifestChunk.BoundaryTimestampCount = 0L; $manifestChunk.Error = $result.Error
+                        $manifestChunk.DuplicateRepresentationCount = 0L
+                        $chunkQueue.Enqueue([PSCustomObject]@{
+                                Index = [int]$manifestChunk.Index; FromDate = [datetime]$manifestChunk.FromDateUtc
+                                ToDate = [datetime]$manifestChunk.ToDateUtc; DurationTicks = [long]$manifestChunk.DurationTicks
+                                FileName = [string]$manifestChunk.FileName; Attempt = $nextAttempt
+                            })
+                        Write-Information "Restarting identity timeline window $($manifestChunk.Index) with a fresh request context after $($result.FailureClass)." -InformationAction Continue
+                    }
+                    else {
+                        $manifestChunk.Status = 'Failed'; $manifestChunk.Error = $result.Error
+                        $failureResults.Add($result); $stopScheduling = $true
+                    }
+                    & $writeManifest $manifest
+
+                    while (-not $stopScheduling -and $chunkQueue.Count -gt 0 -and $activeJobs.Count -lt $throttleLimit) {
+                        $activeJobs.Add((& $startChunkJob $chunkQueue.Dequeue()))
+                    }
+                }
+
+                $now = [datetime]::UtcNow
+                if (($now - $lastProgressUpdate).TotalSeconds -ge 2) {
+                    $completedTicks = $initialCompletedTicks + $completedDuringRunTicks
+                    $percent = if ($totalDurationTicks -gt 0) { [math]::Min(100, [math]::Round(100 * $completedTicks / $totalDurationTicks, 1)) } else { 100 }
+                    $completedCount = @($manifest.Chunks | Where-Object Status -eq 'Completed').Count
+                    $activeEvents = [long](($statusMap.Values | ForEach-Object { [long]$_.Events } | Measure-Object -Sum).Sum)
+                    Write-Progress -Activity 'Exporting XDR identity user timeline' -Status "Completed $completedCount/$totalChunkCount windows; active events $activeEvents" -PercentComplete $percent
+                    $lastProgressUpdate = $now
+                }
+                if (($now - $lastHeartbeat).TotalSeconds -ge 30) {
+                    $completedCount = @($manifest.Chunks | Where-Object Status -eq 'Completed').Count
+                    Write-Information "Identity timeline heartbeat: windows $completedCount/$totalChunkCount; active $($activeJobs.Count); queued $($chunkQueue.Count); elapsed $($operationStopwatch.Elapsed.ToString('c'))." -InformationAction Continue
+                    $lastHeartbeat = $now
+                }
+                if ($completedJobs.Count -eq 0) { Start-Sleep -Milliseconds 200 }
+            }
+        }
+        catch { $capturedError = $_ }
+        finally {
+            foreach ($job in @($activeJobs)) {
+                try { $job.PowerShell.Stop() } catch { Write-Verbose "Could not stop chunk $($job.Chunk.Index): $_" }
+                $job.PowerShell.Dispose()
+            }
+            $activeJobs.Clear(); $runspacePool.Close(); $runspacePool.Dispose()
+            Write-Progress -Activity 'Exporting XDR identity user timeline' -Completed
+        }
+
+        if ($capturedError) {
+            $manifest.State = 'Failed'; $manifest.Summary = [ordered]@{ Error = $capturedError.ToString() }
+            & $writeManifest $manifest
+            throw $capturedError
+        }
+        if ($failureResults.Count -gt 0 -or $chunkQueue.Count -gt 0) {
+            $manifest.State = 'Failed'
+            $manifest.Summary = [ordered]@{
+                FailedChunkCount = $failureResults.Count
+                Errors = @($failureResults | ForEach-Object { "chunk $($_.ChunkIndex): $($_.Error)" })
+            }
+            & $writeManifest $manifest
+            throw "Identity timeline export failed. Completed parts were preserved for resume. $($manifest.Summary.Errors -join '; ')"
+        }
+        if (@($manifest.Chunks | Where-Object Status -ne 'Completed').Count -gt 0) {
+            throw 'Identity timeline export has incomplete windows; the final file was not published.'
+        }
+
+        $orderedParts = @(
+            foreach ($manifestChunk in @($manifest.Chunks | Sort-Object { [int]$_.Index })) {
+                [PSCustomObject]@{
+                    FilePath = Join-Path $partsPath ([string]$manifestChunk.FileName)
+                    FileSha256 = [string]$manifestChunk.FileSha256; EventCount = [long]$manifestChunk.EventCount
+                }
+            }
+        )
+        $totalPartBytes = [long](($manifest.Chunks | ForEach-Object { [long]$_.FileBytes } | Measure-Object -Sum).Sum)
+        $requiredMergeBytes = $totalPartBytes + [long][math]::Max([long]64MB, [long][math]::Ceiling($totalPartBytes * 0.05))
+        $outputDrive = [System.IO.DriveInfo]::new([System.IO.Path]::GetPathRoot($outputPath))
+        if ($outputDrive.AvailableFreeSpace -lt $requiredMergeBytes) {
+            $manifest.State = 'Failed'; $manifest.Summary = [ordered]@{ Error = 'Insufficient disk space to finalize the identity timeline export.' }
+            & $writeManifest $manifest
+            throw "Finalizing the identity timeline requires at least $([math]::Round($requiredMergeBytes / 1GB, 2)) GiB free. Completed parts were preserved for resume."
+        }
+
+        if (Test-Path -LiteralPath $outputPartialPath) { Remove-Item -LiteralPath $outputPartialPath -Force }
+        $mergeStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $mergeResult = Merge-XdrTimelineNdjsonPart -Part $orderedParts -DestinationPath $outputPartialPath
+        $mergeStopwatch.Stop()
+
+        $totalPages = [long](($manifest.Chunks | ForEach-Object { [long]$_.PageCount } | Measure-Object -Sum).Sum)
+        $totalRetries = [long](($manifest.Chunks | ForEach-Object { [long]$_.RetryCount } | Measure-Object -Sum).Sum)
+        $totalRewinds = [long](($manifest.Chunks | ForEach-Object { [long]$_.RewindCount } | Measure-Object -Sum).Sum)
+        $totalRestarts = [long](($manifest.Chunks | ForEach-Object { [long]$_.AttemptCount } | Measure-Object -Sum).Sum)
+        $missingTimestampCount = [long](($manifest.Chunks | ForEach-Object { [long]$_.MissingTimestampCount } | Measure-Object -Sum).Sum)
+        $boundaryTimestampCount = [long](($manifest.Chunks | ForEach-Object { [long]$_.BoundaryTimestampCount } | Measure-Object -Sum).Sum)
+        $duplicateRepresentationCount = [long](($manifest.Chunks | ForEach-Object { [long]$_.DuplicateRepresentationCount } | Measure-Object -Sum).Sum)
+        $operationStopwatch.Stop()
+        $manifest.State = 'Publishing'
+        $manifest.Summary = [ordered]@{
+            OutputPath = $outputPath; EventCount = [long]$mergeResult.EventCount; PageCount = $totalPages
+            RetryCount = $totalRetries; ChunkRestartCount = $totalRestarts; PaginationRewindCount = $totalRewinds
+            FileBytes = [long]$mergeResult.FileBytes; FileSha256 = [string]$mergeResult.FileSha256
+            MissingTimestampCount = $missingTimestampCount; BoundaryTimestampCount = $boundaryTimestampCount
+            DuplicateRepresentationCount = $duplicateRepresentationCount
+            ResumedChunkCount = $resumedChunkCount; PartsRetained = $true
+            MergeSeconds = [math]::Round($mergeStopwatch.Elapsed.TotalSeconds, 3)
+            ElapsedSeconds = [math]::Round($operationStopwatch.Elapsed.TotalSeconds, 3)
+            CompletedUtc = [datetime]::UtcNow.ToString('o')
+        }
+        & $writeManifest $manifest
+        [System.IO.File]::Move($outputPartialPath, $outputPath, $true)
+
+        $partsRetained = $false
+        try { Remove-Item -LiteralPath $partsPath -Recurse -Force -ErrorAction Stop }
+        catch {
+            $partsRetained = $true
+            Write-Warning "The export completed, but temporary parts could not be removed from '$partsPath': $($_.Exception.Message)"
+        }
+        $manifest.State = 'Complete'; $manifest.Summary.PartsRetained = $partsRetained
+        & $writeManifest $manifest
+
+        Write-Information "Identity timeline export complete: $($mergeResult.EventCount) events, $totalChunkCount windows, $([math]::Round($mergeResult.FileBytes / 1MB, 2)) MiB." -InformationAction Continue
+        [PSCustomObject]@{
+            OutputPath = $outputPath; ManifestPath = $manifestPath; TotalEvents = [long]$mergeResult.EventCount
+            TotalPages = $totalPages; TotalRetries = $totalRetries; TotalChunkRestarts = $totalRestarts
+            TotalPaginationRewinds = $totalRewinds; TotalChunks = $totalChunkCount; ResumedChunks = $resumedChunkCount
+            FileBytes = [long]$mergeResult.FileBytes; FileSha256 = [string]$mergeResult.FileSha256
+            MissingTimestampCount = $missingTimestampCount; BoundaryTimestampCount = $boundaryTimestampCount
+            DuplicateRepresentationCount = $duplicateRepresentationCount
+            MergeSeconds = [math]::Round($mergeStopwatch.Elapsed.TotalSeconds, 3)
+            ElapsedSeconds = [math]::Round($operationStopwatch.Elapsed.TotalSeconds, 3)
+            TemporaryPartsRetained = $partsRetained
+        }
+    }
+}

--- a/XDRInternals/functions/Export-XdrIdentityUserTimeline.ps1
+++ b/XDRInternals/functions/Export-XdrIdentityUserTimeline.ps1
@@ -165,7 +165,7 @@
             [System.IO.File]::Move($manifestPartialPath, $manifestPath, $true)
         }
 
-        $chunkHours = 24
+        $chunkHours = 12
         $pageSize = 1000
         $paginationStrategy = 'TimestampKeysetV2'
         $throttleLimit = 8

--- a/XDRInternals/functions/Get-XdrIdentityUserTimeline.ps1
+++ b/XDRInternals/functions/Get-XdrIdentityUserTimeline.ps1
@@ -90,6 +90,10 @@
     .PARAMETER KeepTempFiles
         If specified, keeps the temporary JSON files after merging.
 
+    .PARAMETER AllowPartial
+        Returns completed chunks when one or more chunks fail. By default, the cmdlet
+        fails rather than returning an incomplete identity timeline.
+
     .PARAMETER ExportPath
         Optional. Export results directly to a JSON file at the specified path.
 
@@ -253,6 +257,9 @@
         [switch]$KeepTempFiles,
 
         [Parameter()]
+        [switch]$AllowPartial,
+
+        [Parameter()]
         [ValidateScript({
             if ([string]::IsNullOrWhiteSpace($_)) { return $true }
             $parentDir = Split-Path -Path $_ -Parent
@@ -268,10 +275,8 @@
         Update-XdrConnectionSettings
 
         # Constants - centralized for maintainability (function-local scope)
-        $UnixEpoch = [datetime]'1970-01-01'
         $StallTimeoutSeconds = 120           # Stall detection: no progress for this duration kills the job
         $RecentProgressSeconds = 30          # Progress files updated within this window reset stall timer
-        $IdentityMaxSkip = 9000            # Identity API skip values above 9000 are rejected
 
         # Build headers required for MDI identity APIs
         $mdiHeaders = Get-XdrIdentityHeaders
@@ -322,9 +327,12 @@
             $isNotFound = $fqid -like 'XdrIdentityUserNotFound*' -or $fqid -like '*XdrIdentityUserNotFound*'
 
             if ($isNotFound) {
+                $selectorHint = if ($IdentifierLabel -eq 'UPN') {
+                    ' If the Defender user URL contains aad or sid values, retry with -AadId or -Sid.'
+                } else { '' }
                 $PSCmdlet.ThrowTerminatingError(
                     [System.Management.Automation.ErrorRecord]::new(
-                        [System.ArgumentException]::new("Could not resolve user with ${IdentifierLabel}: $IdentifierValue"),
+                        [System.ArgumentException]::new("Could not resolve user with ${IdentifierLabel}: $IdentifierValue.$selectorHint"),
                         'UserNotFound',
                         [System.Management.Automation.ErrorCategory]::ObjectNotFound,
                         $IdentifierValue
@@ -569,7 +577,6 @@
             RetryDelaySeconds = $RetryDelaySeconds
             EventType         = if ($PSBoundParameters.ContainsKey('EventType')) { $EventType } else { $null }
             RequestTimeoutSec = $RequestTimeoutSeconds
-            MaxSkip           = $IdentityMaxSkip
         }
 
         # Generate date chunks.
@@ -667,24 +674,73 @@
                 $chunkToDate = $chunk.ToDate
                 $chunkIndex = $chunk.Index
 
-                # Recreate web session with cookies (required for isolated execution context)
-                $webSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
-                foreach ($c in $cookieInfo) {
-                    $cookie = [System.Net.Cookie]::new($c.Name, $c.Value, $c.Path, $c.Domain)
-                    $webSession.Cookies.Add($cookie)
-                }
-
                 # Convert dates to Unix timestamps (seconds)
-                $unixEpoch = [datetime]'1970-01-01'
-                $fromUnix = [int]($chunkFromDate.ToUniversalTime() - $unixEpoch).TotalSeconds
-                $toUnix = [int]($chunkToDate.ToUniversalTime() - $unixEpoch).TotalSeconds
+                # The identity API treats both Unix-second bounds as exclusive. Expand
+                # the lower bound by one second so the logical interval remains
+                # [chunkFromDate, chunkToDate), including subsecond caller ranges.
+                $chunkFromUtc = $chunkFromDate.ToUniversalTime()
+                $chunkToUtc = $chunkToDate.ToUniversalTime()
+                $fromOffset = [datetimeoffset]::new($chunkFromUtc)
+                $toOffset = [datetimeoffset]::new($chunkToUtc)
+                $fromUnix = $fromOffset.ToUnixTimeSeconds()
+                if (($chunkFromUtc.Ticks % [timespan]::TicksPerSecond) -ne 0) { $fromUnix++ }
+                $fromUnix--
+                $toUnix = $toOffset.ToUnixTimeSeconds()
+                if (($chunkToUtc.Ticks % [timespan]::TicksPerSecond) -ne 0) { $toUnix++ }
 
                 $Uri = "$baseUrl/apiproxy/mdi/identity/userapiservice/timeline/mtp"
                 $maxRetries = $baseParams.MaxRetries
                 $baseDelay = $baseParams.RetryDelaySeconds
                 $requestTimeout = $baseParams.RequestTimeoutSec
-                $maxSkip = $baseParams.MaxSkip
                 $pageSize = $baseParams.PageSize
+
+                $canonicalizePayload = {
+                    param($Value)
+
+                    if ($Value -is [System.Collections.IDictionary]) {
+                        $ordered = [ordered]@{}
+                        foreach ($name in @($Value.Keys | Sort-Object)) {
+                            $ordered[[string]$name] = & $canonicalizePayload $Value[$name]
+                        }
+                        return $ordered
+                    }
+                    if ($Value -is [System.Management.Automation.PSCustomObject]) {
+                        $ordered = [ordered]@{}
+                        foreach ($property in @($Value.PSObject.Properties | Sort-Object Name)) {
+                            $ordered[$property.Name] = & $canonicalizePayload $property.Value
+                        }
+                        return $ordered
+                    }
+                    if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
+                        return @($Value | ForEach-Object { & $canonicalizePayload $_ })
+                    }
+                    return $Value
+                }
+                $getEventKey = {
+                    param($EventItem, [datetime]$Timestamp)
+
+                    $stablePayload = [ordered]@{}
+                    foreach ($property in @($EventItem.PSObject.Properties | Sort-Object Name)) {
+                        if ($property.Name -notin @('Id', 'RowNumber', 'Description')) {
+                            $stablePayload[$property.Name] = & $canonicalizePayload $property.Value
+                        }
+                    }
+                    $stableJson = $stablePayload | ConvertTo-Json -Depth 20 -Compress
+                    $hasher = [System.Security.Cryptography.SHA256]::Create()
+                    try {
+                        $hash = $hasher.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($stableJson))
+                        $idPrefix = if ($EventItem.PSObject.Properties['EventId'] -and
+                            -not [string]::IsNullOrWhiteSpace([string]$EventItem.EventId)) {
+                            "EventId:$([string]$EventItem.EventId)"
+                        } else {
+                            'NoEventId'
+                        }
+                        return "$($Timestamp.ToString('o'))|$idPrefix|Payload:$([System.BitConverter]::ToString($hash).Replace('-', ''))"
+                    }
+                    finally {
+                        $hasher.Dispose()
+                    }
+                }
 
                 # Chunk-level retry loop
                 $chunkAttempt = 0
@@ -693,24 +749,28 @@
 
                 while (-not $chunkSuccess -and $chunkAttempt -lt $maxRetries) {
                     $chunkAttempt++
+                    # A failed attempt may poison this undocumented API's request
+                    # context. Recreate the cookie-backed session before replaying
+                    # the complete logical chunk.
+                    $webSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+                    foreach ($c in $cookieInfo) {
+                        $cookie = [System.Net.Cookie]::new($c.Name, $c.Value, $c.Path, $c.Domain)
+                        $webSession.Cookies.Add($cookie)
+                    }
                     $chunkEvents = [System.Collections.Generic.List[object]]::new()
-                    $skip = 0
                     $currentToUnix = $toUnix
-                    $previousBoundaryTimestamp = $null
                     $progressFile = Join-Path $tempPath "progress_$chunkIndex.txt"
                     $lastProgressWriteUtc = [datetime]::MinValue
+                    $chunkFailureIsRetryable = $true
 
                     try {
                         $chunkStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
                         $pagesRetrieved = 0
-                        $boundaryTimestamp = $null
-                        $boundaryCount = 0
-
-                        do {
+                        while ($true) {
                             # Build request body
                             $requestBody = @{
                                 count           = $pageSize
-                                skip            = $skip
+                                skip            = 0
                                 userIdentifiers = $userIds
                                 filters         = @{
                                     Timeframe = @{
@@ -753,108 +813,117 @@
                                     # Check if it's a timeout
                                     $isTimeout = $_.Exception.Message -like "*timeout*" -or $_.Exception.Message -like "*timed out*"
 
-                                    if ($statusCode -eq 429 -or $statusCode -eq 403) {
+                                    if ($statusCode -in @(401, 403)) {
+                                        $chunkFailureIsRetryable = $false
+                                        throw "Chunk $chunkIndex : Authentication failed with HTTP $statusCode"
+                                    } elseif ($attempt -ge $maxRetries) {
+                                        throw "Chunk $chunkIndex : Failed after $maxRetries attempts (HTTP $statusCode)"
+                                    } elseif ($statusCode -eq 429) {
                                         $delay = $baseDelay * [Math]::Pow(2, $attempt - 1) + (Get-Random -Minimum 1 -Maximum 10)
                                         $delay = [Math]::Min($delay, 300)
                                         Start-Sleep -Seconds $delay
-                                    } elseif ($isTimeout -and $attempt -lt $maxRetries) {
+                                    } elseif ($isTimeout) {
                                         Start-Sleep -Seconds (Get-Random -Minimum 2 -Maximum 5)
-                                    } elseif ($attempt -lt $maxRetries) {
+                                    } elseif ($null -eq $statusCode -or $statusCode -in @(408, 500, 502, 503, 504)) {
                                         $delay = Get-Random -Minimum 5 -Maximum 15
                                         Start-Sleep -Seconds $delay
                                     } else {
-                                        throw "Chunk $chunkIndex : Failed after $maxRetries attempts. Last error: $_"
+                                        $chunkFailureIsRetryable = $false
+                                        throw "Chunk $chunkIndex : Timeline request failed with HTTP $statusCode"
                                     }
                                 }
                             }
 
-                            $responseData = if ($response -and $response.data) { @($response.data) } else { @() }
-                            if ($responseData.Count -eq 0) {
-                                break
+                            foreach ($requiredProperty in @('count', 'data', 'errors')) {
+                                if (-not $response.PSObject.Properties[$requiredProperty]) {
+                                    throw "Chunk $chunkIndex : Timeline response did not contain '$requiredProperty'"
+                                }
                             }
-
+                            $responseData = if ($null -eq $response.data) { @() } else { @($response.data) }
+                            $responseErrorPropertyCount = if ($null -eq $response.errors) {
+                                0
+                            } else {
+                                @($response.errors.PSObject.Properties).Count
+                            }
+                            if ($responseErrorPropertyCount -gt 0) {
+                                throw "Chunk $chunkIndex : Timeline response contained service errors"
+                            }
+                            if ([int]$response.count -ne $responseData.Count) {
+                                throw "Chunk $chunkIndex : Timeline response count=$($response.count) but data contained $($responseData.Count) event(s)"
+                            }
+                            $requestFromDate = [datetimeoffset]::FromUnixTimeSeconds($fromUnix).UtcDateTime
+                            $requestToDate = [datetimeoffset]::FromUnixTimeSeconds($currentToUnix).UtcDateTime
+                            $previousTimestamp = $null
+                            $pageNewestTimestamp = $null
+                            $pageOldestTimestamp = $null
+                            $pageNewestUnixSecond = $null
+                            $pageOldestUnixSecond = $null
+                            $pageEvents = [System.Collections.Generic.List[object]]::new()
+                            $pageKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
                             foreach ($timelineEvent in $responseData) {
-                                $chunkEvents.Add($timelineEvent)
-
-                                # Track the oldest timestamp and count events at that boundary.
-                                if ($timelineEvent.PSObject.Properties['Timestamp'] -and $timelineEvent.Timestamp) {
-                                    try {
-                                        $eventTimestamp = [datetime]::Parse($timelineEvent.Timestamp).ToUniversalTime()
-                                        if ($null -eq $boundaryTimestamp -or $eventTimestamp -lt $boundaryTimestamp) {
-                                            $boundaryTimestamp = $eventTimestamp
-                                            $boundaryCount = 1
-                                        } elseif ($eventTimestamp -eq $boundaryTimestamp) {
-                                            $boundaryCount++
-                                        }
-                                    } catch {
-                                        Write-Verbose "Ignoring timestamp parse errors for boundary tracking."
-                                    }
+                                if (-not $timelineEvent.PSObject.Properties['Timestamp'] -or
+                                    [string]::IsNullOrWhiteSpace([string]$timelineEvent.Timestamp)) {
+                                    throw "Chunk $chunkIndex : Timeline event did not contain a Timestamp"
                                 }
-                            }
-
-                            if ($responseData.Count -lt $pageSize) {
-                                break
-                            }
-
-                            $nextSkip = $skip + $responseData.Count
-                            if ($nextSkip -gt $maxSkip) {
-                                if ($null -eq $boundaryTimestamp) {
-                                    throw "Chunk $chunkIndex : Hit skip limit but no boundary timestamp was available"
+                                $parsedTimestamp = [datetimeoffset]::MinValue
+                                $parseStyles = [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+                                if (-not [datetimeoffset]::TryParse(
+                                        [string]$timelineEvent.Timestamp,
+                                        [System.Globalization.CultureInfo]::InvariantCulture,
+                                        $parseStyles,
+                                        [ref]$parsedTimestamp
+                                    )) {
+                                    throw "Chunk $chunkIndex : Timeline event Timestamp could not be parsed"
                                 }
+                                $eventTimestamp = $parsedTimestamp.UtcDateTime
+                                if ($eventTimestamp -le $requestFromDate -or $eventTimestamp -ge $requestToDate) {
+                                    throw "Chunk $chunkIndex : Timeline event fell outside the API's exclusive interval"
+                                }
+                                if ($eventTimestamp -lt $chunkFromUtc -or $eventTimestamp -ge $chunkToUtc) {
+                                    throw "Chunk $chunkIndex : Timeline event fell outside the logical interval"
+                                }
+                                if ($null -ne $previousTimestamp -and $eventTimestamp -gt $previousTimestamp) {
+                                    throw "Chunk $chunkIndex : Timeline response was not in descending timestamp order"
+                                }
+                                $previousTimestamp = $eventTimestamp
+                                $eventUnixSecond = [datetimeoffset]::new($eventTimestamp).ToUnixTimeSeconds()
+                                if ($null -eq $pageNewestTimestamp) {
+                                    $pageNewestTimestamp = $eventTimestamp
+                                    $pageNewestUnixSecond = $eventUnixSecond
+                                }
+                                $pageOldestTimestamp = $eventTimestamp
+                                $pageOldestUnixSecond = $eventUnixSecond
 
-                                # Pathological case: too many events in one second (> maxSkip + pageSize).
-                                if ($null -ne $previousBoundaryTimestamp -and $boundaryTimestamp -eq $previousBoundaryTimestamp) {
-                                    # API cannot page past this second. Drop all events for this second so output is deterministic.
-                                    $keptEvents = [System.Collections.Generic.List[object]]::new()
-                                    $droppedCount = 0
-                                    foreach ($existingEvent in $chunkEvents) {
-                                        $isBoundaryEvent = $false
-                                        if ($existingEvent.PSObject.Properties['Timestamp'] -and $existingEvent.Timestamp) {
-                                            try {
-                                                $existingTs = [datetime]::Parse($existingEvent.Timestamp).ToUniversalTime()
-                                                $isBoundaryEvent = ($existingTs -eq $boundaryTimestamp)
-                                            } catch {
-                                                Write-Verbose "Ignoring timestamp parse errors; treat event as non-boundary."
-                                            }
-                                        }
-
-                                        if ($isBoundaryEvent) {
-                                            $droppedCount++
-                                        } else {
-                                            $keptEvents.Add($existingEvent)
-                                        }
-                                    }
-                                    $chunkEvents = $keptEvents
-
-                                    Write-Warning "Chunk $chunkIndex : More than $($maxSkip + $pageSize) events at timestamp $($boundaryTimestamp.ToString('o')); dropped $droppedCount events at this second due to API pagination limits"
-
-                                    # Move to older data and skip this second entirely.
-                                    $currentToUnix = [int]($boundaryTimestamp.AddSeconds(-1) - $unixEpoch).TotalSeconds
-                                    if ($currentToUnix -lt $fromUnix) {
-                                        break
-                                    }
-
-                                    $skip = 0
-                                    $previousBoundaryTimestamp = $null
-                                    $boundaryTimestamp = $null
-                                    $boundaryCount = 0
+                                $eventKey = & $getEventKey $timelineEvent $eventTimestamp
+                                if (-not $pageKeys.Add($eventKey)) {
                                     continue
                                 }
-                                # Remove the incomplete boundary second and restart at that boundary.
-                                if ($boundaryCount -gt 0 -and $boundaryCount -le $chunkEvents.Count) {
-                                    $chunkEvents.RemoveRange($chunkEvents.Count - $boundaryCount, $boundaryCount)
-                                }
-
-                                $previousBoundaryTimestamp = $boundaryTimestamp
-                                $currentToUnix = [int]($boundaryTimestamp.AddSeconds(1) - $unixEpoch).TotalSeconds
-                                $skip = 0
-                                $boundaryTimestamp = $null
-                                $boundaryCount = 0
-                                continue
+                                $pageEvents.Add([PSCustomObject]@{
+                                        Event = $timelineEvent
+                                        Timestamp = $eventTimestamp
+                                        UnixSecond = $eventUnixSecond
+                                    })
                             }
 
-                            $skip = $nextSkip
-                        } while ($true)
+                            $pageIsFull = $responseData.Count -eq $pageSize
+                            if ($pageIsFull -and $pageNewestUnixSecond -eq $pageOldestUnixSecond) {
+                                throw "Chunk $chunkIndex : UnpageableBoundary - one API timestamp second filled a complete $pageSize-row page at $($pageOldestTimestamp.ToString('o'))"
+                            }
+                            foreach ($pageEvent in $pageEvents) {
+                                if (-not $pageIsFull -or $pageEvent.UnixSecond -gt $pageOldestUnixSecond) {
+                                    $chunkEvents.Add($pageEvent.Event)
+                                }
+                            }
+
+                            if (-not $pageIsFull) {
+                                break
+                            }
+                            $nextToUnix = $pageOldestUnixSecond + 1L
+                            if ($nextToUnix -ge $currentToUnix) {
+                                throw "Chunk $chunkIndex : UnpageableBoundary - cannot advance beyond timestamp $($pageOldestTimestamp.ToString('o'))"
+                            }
+                            $currentToUnix = $nextToUnix
+                        }
 
                         $chunkStopwatch.Stop()
                         $chunkSuccess = $true
@@ -891,8 +960,11 @@
                         if ($chunkStopwatch) { $chunkStopwatch.Stop() }
                         $lastChunkError = $_.ToString()
 
-                        # Non-retryable error or max retries reached
-                        if ($chunkAttempt -ge $maxRetries) {
+                        # Authentication, permanent HTTP failures, and an
+                        # unpageable API second cannot improve on replay.
+                        $nonRetryableChunkFailure = -not $chunkFailureIsRetryable -or
+                            $lastChunkError -like '*UnpageableBoundary*'
+                        if ($nonRetryableChunkFailure -or $chunkAttempt -ge $maxRetries) {
                             @{
                                 ChunkIndex     = $chunkIndex
                                 Success        = $false
@@ -1113,17 +1185,20 @@
             Write-Progress -Activity "Retrieving User Timeline for $userDisplayName" -Completed -Id 1
 
             # Check for failures
-            $failures = $results | Where-Object { -not $_.Success }
-            if ($failures) {
+            $failures = @($results | Where-Object { -not $_.Success })
+            if ($failures.Count -gt 0) {
                 Write-Warning "Some chunks failed to retrieve: $($failures.Count) failures"
                 foreach ($fail in $failures) {
                     Write-Warning "  Chunk $($fail.ChunkIndex) ($($fail.FromDate) - $($fail.ToDate)): $($fail.Error)"
+                }
+                if (-not $AllowPartial) {
+                    throw "Identity timeline retrieval failed for $($failures.Count) chunk(s). Use -AllowPartial to return only completed chunks."
                 }
             }
 
             # Output timing information for each chunk
             Write-Information "`n=== Chunk Download Statistics ===" -InformationAction Continue
-            $successfulResults = $results | Where-Object { $_.Success }
+            $successfulResults = @($results | Where-Object { $_.Success })
             $totalElapsed = 0
             $totalSizeKB = 0
             foreach ($result in ($successfulResults | Sort-Object ChunkIndex)) {
@@ -1158,6 +1233,29 @@
             $toUtcExclusive = $ToDate.ToUniversalTime()
             $sha256 = [System.Security.Cryptography.SHA256]::Create()
             $chunkFiles = Get-ChildItem -Path $runTempPath -Filter "chunk_*.json" -ErrorAction SilentlyContinue | Sort-Object Name
+
+            $canonicalizePayload = {
+                param($Value)
+
+                if ($Value -is [System.Collections.IDictionary]) {
+                    $ordered = [ordered]@{}
+                    foreach ($name in @($Value.Keys | Sort-Object)) {
+                        $ordered[[string]$name] = & $canonicalizePayload $Value[$name]
+                    }
+                    return $ordered
+                }
+                if ($Value -is [System.Management.Automation.PSCustomObject]) {
+                    $ordered = [ordered]@{}
+                    foreach ($property in @($Value.PSObject.Properties | Sort-Object Name)) {
+                        $ordered[$property.Name] = & $canonicalizePayload $property.Value
+                    }
+                    return $ordered
+                }
+                if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
+                    return @($Value | ForEach-Object { & $canonicalizePayload $_ })
+                }
+                return $Value
+            }
 
             $addDedupedEvent = {
                 param([PSObject]$eventObject)
@@ -1195,17 +1293,21 @@
                     return
                 }
 
-                $unstableProperties = @('Id', 'RowNumber', 'EventId', 'ReportId')
                 $stablePayload = [ordered]@{}
                 foreach ($property in ($eventObject.PSObject.Properties | Sort-Object Name)) {
-                    if ($unstableProperties -notcontains $property.Name) {
-                        $stablePayload[$property.Name] = $property.Value
+                    if ($property.Name -notin @('Id', 'RowNumber', 'Description')) {
+                        $stablePayload[$property.Name] = & $canonicalizePayload $property.Value
                     }
                 }
-
                 $stableJson = $stablePayload | ConvertTo-Json -Depth 20 -Compress
                 $stableHashBytes = $sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($stableJson))
-                $stableKey = [System.BitConverter]::ToString($stableHashBytes).Replace('-', '')
+                $idPrefix = if ($eventObject.PSObject.Properties['EventId'] -and
+                    -not [string]::IsNullOrWhiteSpace([string]$eventObject.EventId)) {
+                    "EventId:$([string]$eventObject.EventId)"
+                } else {
+                    'NoEventId'
+                }
+                $stableKey = "$($eventTimestampUtc.ToString('o'))|$idPrefix|Payload:$([System.BitConverter]::ToString($stableHashBytes).Replace('-', ''))"
                 $mergeCounters['TotalCandidates']++
 
                 if ($stableEventKeys.Add($stableKey)) {
@@ -1289,6 +1391,10 @@
 
             $sha256.Dispose()
             Write-Verbose "Merge stats: candidates=$($mergeCounters.TotalCandidates), duplicates=$($mergeCounters.Duplicates), outOfRange=$($mergeCounters.OutOfRange), missingTimestamp=$($mergeCounters.MissingTimestamp), timestampParseErrors=$($mergeCounters.TimestampParseErrors)"
+            if (-not $AllowPartial -and
+                ([int]$mergeCounters.MissingTimestamp -gt 0 -or [int]$mergeCounters.TimestampParseErrors -gt 0)) {
+                throw "Identity timeline retrieval encountered $($mergeCounters.MissingTimestamp) missing timestamp(s) and $($mergeCounters.TimestampParseErrors) timestamp parse error(s). Use -AllowPartial to omit invalid events."
+            }
 
             # Sort events by timestamp (newest first) with deterministic tie-breaker
             $sortedEvents = $eventRows |
@@ -1297,8 +1403,8 @@
 
             $operationStartTime.Stop()
             $totalEvents = $sortedEvents.Count
-            $successCount = ($results | Where-Object { $_.Success }).Count
-            $failCount = ($results | Where-Object { -not $_.Success }).Count
+            $successCount = @($results | Where-Object { $_.Success }).Count
+            $failCount = @($results | Where-Object { -not $_.Success }).Count
             $wallClockSeconds = $operationStartTime.Elapsed.TotalSeconds
             $totalSizeMB = [math]::Round($totalSizeKB / 1024, 1)
             $effectiveRate = if ($wallClockSeconds -gt 0) { [math]::Round($totalEvents / $wallClockSeconds, 1) } else { 0 }
@@ -1329,17 +1435,14 @@
             return $sortedEvents
 
         } catch {
-            Write-Error -Exception $_.Exception -Message "Failed to retrieve user timeline: $($_.Exception.Message)"
+            $capturedError = $_
             Write-Verbose "Full error: $($_.Exception.ToString())"
 
             # Cleanup on error
             if (-not $KeepTempFiles -and (Test-Path $runTempPath)) {
                 Remove-Item -Path $runTempPath -Recurse -Force -ErrorAction SilentlyContinue
             }
+            throw $capturedError
         }
     }
 }
-
-
-
-

--- a/XDRInternals/internal/functions/Merge-XdrEndpointTimelineNdjsonPart.ps1
+++ b/XDRInternals/internal/functions/Merge-XdrEndpointTimelineNdjsonPart.ps1
@@ -1,7 +1,7 @@
-﻿function Merge-XdrEndpointTimelineNdjsonPart {
+﻿function Merge-XdrTimelineNdjsonPart {
     <#
     .SYNOPSIS
-        Concatenates validated endpoint timeline NDJSON part files.
+        Concatenates validated timeline NDJSON part files.
 
     .DESCRIPTION
         Copies part files into one destination without parsing JSON. Each part hash is
@@ -14,7 +14,7 @@
         Path to create. The destination must not already exist.
 
     .EXAMPLE
-        Merge-XdrEndpointTimelineNdjsonPart -Part $parts -DestinationPath $partialPath
+        Merge-XdrTimelineNdjsonPart -Part $parts -DestinationPath $partialPath
         Creates and hashes the combined NDJSON file.
     #>
     [OutputType([PSCustomObject])]
@@ -83,7 +83,7 @@
             $actualPartHash = [Convert]::ToHexString($partHasher.Hash).ToLowerInvariant()
             $partHasher.Dispose()
             if ($actualPartHash -ne [string]$partItem.FileSha256) {
-                throw "Endpoint timeline part '$($partItem.FilePath)' failed SHA-256 validation."
+                throw "Timeline part '$($partItem.FilePath)' failed SHA-256 validation."
             }
 
             $totalEvents += [long]$partItem.EventCount
@@ -108,4 +108,36 @@
         if ($outputHasher) { $outputHasher.Dispose() }
         if ($destination) { $destination.Dispose() }
     }
+}
+
+function Merge-XdrEndpointTimelineNdjsonPart {
+    <#
+    .SYNOPSIS
+        Preserves the endpoint-specific private helper name.
+
+    .DESCRIPTION
+        Calls the workload-neutral timeline merger so the endpoint exporter keeps
+        its original private helper contract.
+
+    .PARAMETER Part
+        Ordered endpoint timeline part metadata to validate and concatenate.
+
+    .PARAMETER DestinationPath
+        Path to the new combined NDJSON file.
+
+    .EXAMPLE
+        Merge-XdrEndpointTimelineNdjsonPart -Part $parts -DestinationPath $partialPath
+        Validates and merges endpoint timeline parts.
+    #>
+    [OutputType([PSCustomObject])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [object[]]$Part,
+
+        [Parameter(Mandatory)]
+        [string]$DestinationPath
+    )
+
+    Merge-XdrTimelineNdjsonPart -Part $Part -DestinationPath $DestinationPath
 }

--- a/XDRInternals/internal/functions/New-XdrIdentityTimelineExportWorker.ps1
+++ b/XDRInternals/internal/functions/New-XdrIdentityTimelineExportWorker.ps1
@@ -1,0 +1,366 @@
+﻿function New-XdrIdentityTimelineExportWorker {
+    <#
+    .SYNOPSIS
+        Creates the self-contained identity timeline export worker.
+
+    .DESCRIPTION
+        Returns a scriptblock that downloads one bounded identity timeline interval,
+        validates timestamp-keyset pages, advances safely across tied API-second groups,
+        and writes UTF-8 NDJSON without retaining the complete interval in memory.
+
+    .EXAMPLE
+        $worker = New-XdrIdentityTimelineExportWorker
+        Creates the worker used by Export-XdrIdentityUserTimeline.
+    #>
+    [OutputType([scriptblock])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Private factory that only returns a worker scriptblock.')]
+    [CmdletBinding()]
+    param ()
+
+    return {
+        param($chunk, $sharedParameters, $statusMap)
+
+        $chunkIndex = [int]$chunk.Index
+        $chunkFromDate = ([datetime]$chunk.FromDate).ToUniversalTime()
+        $chunkToDate = ([datetime]$chunk.ToDate).ToUniversalTime()
+        $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+        $partialPath = "$filePath.partial"
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $eventCount = 0L
+        $pageCount = 0
+        $retryCount = 0
+        $rewindCount = 0
+        $missingTimestampCount = 0L
+        $boundaryTimestampCount = 0L
+        $duplicateRepresentationCount = 0L
+        $failureClass = 'Protocol'
+        $lastCommittedTimestamp = $null
+
+        $parseTimestamp = {
+            param($Value)
+
+            if ($Value -is [datetime]) {
+                return ([datetime]$Value).ToUniversalTime()
+            }
+            if ($Value -is [datetimeoffset]) {
+                return ([datetimeoffset]$Value).UtcDateTime
+            }
+
+            $parsed = [datetimeoffset]::MinValue
+            $styles = [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+            if (-not [string]::IsNullOrWhiteSpace([string]$Value) -and
+                [datetimeoffset]::TryParse([string]$Value, [System.Globalization.CultureInfo]::InvariantCulture, $styles, [ref]$parsed)) {
+                return $parsed.UtcDateTime
+            }
+            return $null
+        }
+
+        $getCeilingUnixSecond = {
+            param([datetime]$Value)
+
+            $utc = $Value.ToUniversalTime()
+            $offset = [datetimeoffset]::new($utc)
+            $seconds = $offset.ToUnixTimeSeconds()
+            if (($utc.Ticks % [timespan]::TicksPerSecond) -ne 0) {
+                $seconds++
+            }
+            return [long]$seconds
+        }
+
+        $canonicalizePayload = {
+            param($Value)
+
+            if ($Value -is [System.Collections.IDictionary]) {
+                $ordered = [ordered]@{}
+                foreach ($name in @($Value.Keys | Sort-Object)) {
+                    $ordered[[string]$name] = & $canonicalizePayload $Value[$name]
+                }
+                return $ordered
+            }
+            if ($Value -is [System.Management.Automation.PSCustomObject]) {
+                $ordered = [ordered]@{}
+                foreach ($property in @($Value.PSObject.Properties | Sort-Object Name)) {
+                    $ordered[$property.Name] = & $canonicalizePayload $property.Value
+                }
+                return $ordered
+            }
+            if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
+                return @($Value | ForEach-Object { & $canonicalizePayload $_ })
+            }
+            return $Value
+        }
+
+        $getEventKey = {
+            param($EventItem, [datetime]$Timestamp)
+
+            # Live responses showed that EventId is reused over time and that the
+            # same EventId/Timestamp representation can recur with request-volatile
+            # Id, RowNumber, and Description values. Include the stable payload so
+            # genuinely distinct records sharing EventId/Timestamp remain distinct.
+            $stablePayload = [ordered]@{}
+            foreach ($property in ($EventItem.PSObject.Properties | Sort-Object Name)) {
+                if ($property.Name -notin @('Id', 'RowNumber', 'Description')) {
+                    $stablePayload[$property.Name] = & $canonicalizePayload $property.Value
+                }
+            }
+            $json = $stablePayload | ConvertTo-Json -Depth 100 -Compress
+            $hashBytes = [System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($json))
+            $idPrefix = if ($EventItem.PSObject.Properties['EventId'] -and
+                -not [string]::IsNullOrWhiteSpace([string]$EventItem.EventId)) {
+                "EventId:$([string]$EventItem.EventId)"
+            } else {
+                'NoEventId'
+            }
+            return "$($Timestamp.ToString('o'))|$idPrefix|Payload:$([Convert]::ToHexString($hashBytes))"
+        }
+
+        try {
+            foreach ($stalePath in @($partialPath)) {
+                if (Test-Path -LiteralPath $stalePath) {
+                    Remove-Item -LiteralPath $stalePath -Force
+                }
+            }
+            [System.IO.File]::WriteAllBytes($partialPath, [byte[]]::new(0))
+
+            $webSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            foreach ($cookieInfo in $sharedParameters.CookieData) {
+                $cookie = [System.Net.Cookie]::new(
+                    [string]$cookieInfo.Name,
+                    [string]$cookieInfo.Value,
+                    [string]$cookieInfo.Path,
+                    [string]$cookieInfo.Domain
+                )
+                $webSession.Cookies.Add($cookie)
+            }
+
+            $requestFromUnix = (& $getCeilingUnixSecond $chunkFromDate) - 1L
+            $requestToUnix = & $getCeilingUnixSecond $chunkToDate
+            $uri = "$($sharedParameters.BaseUrl)/apiproxy/mdi/identity/userapiservice/timeline/mtp"
+            $partStream = $null
+            $partWriter = $null
+            try {
+                $partStream = [System.IO.FileStream]::new(
+                    $partialPath,
+                    [System.IO.FileMode]::Append,
+                    [System.IO.FileAccess]::Write,
+                    [System.IO.FileShare]::None,
+                    1MB,
+                    [System.IO.FileOptions]::SequentialScan
+                )
+                $partWriter = [System.IO.StreamWriter]::new($partStream, [System.Text.UTF8Encoding]::new($false), 1MB, $true)
+                $partWriter.NewLine = "`n"
+
+                while ($true) {
+                    $requestBody = @{
+                        count           = [int]$sharedParameters.PageSize
+                        skip            = 0
+                        userIdentifiers = $sharedParameters.UserIdentifiers
+                        filters         = @{ Timeframe = @{ between = @($requestFromUnix, $requestToUnix) } }
+                    }
+
+                    $response = $null
+                    for ($attempt = 1; $attempt -le [int]$sharedParameters.MaxRetries; $attempt++) {
+                        try {
+                            $response = Invoke-RestMethod -Uri $uri -Method POST -ContentType 'application/json' `
+                                -Body ($requestBody | ConvertTo-Json -Depth 20) -WebSession $webSession `
+                                -Headers $sharedParameters.HeadersData -TimeoutSec $sharedParameters.RequestTimeoutSeconds -ErrorAction Stop
+                            break
+                        }
+                        catch {
+                            $statusCode = $null
+                            if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+                                $statusCode = [int]$_.Exception.Response.StatusCode
+                            }
+                            $isTransient = $null -eq $statusCode -or $statusCode -in @(408, 429, 500, 502, 503, 504)
+                            if (-not $isTransient -or $attempt -eq [int]$sharedParameters.MaxRetries) {
+                                $failureClass = if ($statusCode -in @(401, 403)) {
+                                    'Authentication'
+                                }
+                                elseif ($isTransient -and $null -eq $statusCode) {
+                                    'Transport'
+                                }
+                                elseif ($isTransient) {
+                                    'TransientHttp'
+                                }
+                                else {
+                                    'PermanentHttp'
+                                }
+                                throw
+                            }
+
+                            $retryCount++
+                            $delaySeconds = [math]::Min(30, [math]::Pow(2, $attempt - 1) + (Get-Random -Minimum 0 -Maximum 3))
+                            Start-Sleep -Seconds $delaySeconds
+                        }
+                    }
+
+                    foreach ($requiredProperty in @('count', 'data', 'errors')) {
+                        if (-not $response.PSObject.Properties[$requiredProperty]) {
+                            $failureClass = 'PartialResponse'
+                            throw "Chunk $chunkIndex received a timeline response without '$requiredProperty'."
+                        }
+                    }
+                    $errorPropertyCount = if ($null -eq $response.errors) { 0 } else { @($response.errors.PSObject.Properties).Count }
+                    if ($errorPropertyCount -gt 0) {
+                        $failureClass = 'PartialResponse'
+                        throw "Chunk $chunkIndex received a timeline response containing service errors."
+                    }
+
+                    $responseData = if ($null -eq $response.data) { @() } else { @($response.data) }
+                    if ([int]$response.count -ne $responseData.Count) {
+                        $failureClass = 'PartialResponse'
+                        throw "Chunk $chunkIndex received count=$($response.count) but data contained $($responseData.Count) event(s)."
+                    }
+
+                    $pageCount++
+                    $requestFromDate = [datetimeoffset]::FromUnixTimeSeconds($requestFromUnix).UtcDateTime
+                    $requestToDate = [datetimeoffset]::FromUnixTimeSeconds($requestToUnix).UtcDateTime
+                    $previousTimestamp = $null
+                    $pageRows = [System.Collections.Generic.List[object]]::new()
+                    $pageKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+                    $pageNewestTimestamp = $null
+                    $pageOldestTimestamp = $null
+                    $pageNewestUnixSecond = $null
+                    $pageOldestUnixSecond = $null
+
+                    foreach ($eventItem in $responseData) {
+                        $timestamp = & $parseTimestamp $eventItem.Timestamp
+                        if ($null -eq $timestamp) {
+                            $missingTimestampCount++
+                            throw "Chunk $chunkIndex received an event without a parseable Timestamp."
+                        }
+                        if ($timestamp -le $requestFromDate -or $timestamp -ge $requestToDate) {
+                            throw "Chunk $chunkIndex received an event outside the API's exclusive interval: $($timestamp.ToString('o'))."
+                        }
+                        if ($timestamp -lt $chunkFromDate -or $timestamp -ge $chunkToDate) {
+                            throw "Chunk $chunkIndex received an event outside its logical interval: $($timestamp.ToString('o'))."
+                        }
+                        if ($null -ne $previousTimestamp -and $timestamp -gt $previousTimestamp) {
+                            throw "Chunk $chunkIndex received events outside descending timestamp order."
+                        }
+                        $previousTimestamp = $timestamp
+                        $timestampUnixSecond = [datetimeoffset]::new($timestamp).ToUnixTimeSeconds()
+                        if ($null -eq $pageNewestTimestamp) {
+                            $pageNewestTimestamp = $timestamp
+                            $pageNewestUnixSecond = $timestampUnixSecond
+                        }
+                        $pageOldestTimestamp = $timestamp
+                        $pageOldestUnixSecond = $timestampUnixSecond
+                        if ($timestamp -eq $chunkFromDate -or $timestamp -eq $chunkToDate) {
+                            $boundaryTimestampCount++
+                        }
+
+                        $eventKey = & $getEventKey $eventItem $timestamp
+                        if (-not $pageKeys.Add($eventKey)) {
+                            $duplicateRepresentationCount++
+                            continue
+                        }
+                        $pageRows.Add([PSCustomObject]@{
+                                Timestamp = $timestamp
+                                UnixSecond = $timestampUnixSecond
+                                Json = ($eventItem | ConvertTo-Json -Depth 100 -Compress)
+                            })
+                    }
+
+                    $pageIsFull = $responseData.Count -eq [int]$sharedParameters.PageSize
+                    if ($pageIsFull -and $pageNewestUnixSecond -eq $pageOldestUnixSecond) {
+                        $failureClass = 'UnpageableBoundary'
+                        throw "Chunk $chunkIndex cannot prove completeness because one API timestamp second filled a complete $([int]$sharedParameters.PageSize)-row page at $($pageOldestTimestamp.ToString('o'))."
+                    }
+
+                    foreach ($row in $pageRows) {
+                        if ($pageIsFull -and $row.UnixSecond -eq $pageOldestUnixSecond) {
+                            continue
+                        }
+                        if ($null -ne $lastCommittedTimestamp -and $row.Timestamp -gt $lastCommittedTimestamp) {
+                            throw "Chunk $chunkIndex received overlapping keyset pages outside descending timestamp order."
+                        }
+                        $partWriter.WriteLine($row.Json)
+                        $lastCommittedTimestamp = $row.Timestamp
+                        $eventCount++
+                    }
+                    $partWriter.Flush()
+
+                    $statusMap[$chunkIndex] = [PSCustomObject]@{
+                        Pages      = $pageCount
+                        Events     = $eventCount
+                        Bytes      = $partStream.Position
+                        Rewinds    = $rewindCount
+                        UpdatedUtc = [datetime]::UtcNow
+                    }
+
+                    if (-not $pageIsFull) {
+                        break
+                    }
+
+                    $nextRequestToUnix = $pageOldestUnixSecond + 1L
+                    if ($nextRequestToUnix -ge $requestToUnix) {
+                        $failureClass = 'UnpageableBoundary'
+                        throw "Chunk $chunkIndex cannot advance beyond timestamp $($pageOldestTimestamp.ToString('o'))."
+                    }
+                    $requestToUnix = $nextRequestToUnix
+                    $rewindCount++
+                }
+            }
+            finally {
+                if ($partWriter) { $partWriter.Dispose() }
+                if ($partStream) { $partStream.Dispose() }
+            }
+
+            $fileBytes = (Get-Item -LiteralPath $partialPath).Length
+            $fileSha256 = (Get-FileHash -LiteralPath $partialPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            [System.IO.File]::Move($partialPath, $filePath, $true)
+            $stopwatch.Stop()
+
+            return [PSCustomObject]@{
+                Success                = $true
+                ChunkIndex             = $chunkIndex
+                FromDate               = $chunkFromDate
+                ToDate                 = $chunkToDate
+                FilePath               = $filePath
+                FileSha256             = $fileSha256
+                FileBytes              = $fileBytes
+                EventCount             = $eventCount
+                PageCount              = $pageCount
+                RetryCount             = $retryCount
+                RewindCount            = $rewindCount
+                MissingTimestampCount  = $missingTimestampCount
+                BoundaryTimestampCount = $boundaryTimestampCount
+                DuplicateRepresentationCount = $duplicateRepresentationCount
+                ElapsedSeconds         = [math]::Round($stopwatch.Elapsed.TotalSeconds, 3)
+                Error                  = $null
+                FailureClass           = $null
+            }
+        }
+        catch {
+            $stopwatch.Stop()
+            return [PSCustomObject]@{
+                Success                = $false
+                ChunkIndex             = $chunkIndex
+                FromDate               = $chunkFromDate
+                ToDate                 = $chunkToDate
+                FilePath               = $filePath
+                FileSha256             = $null
+                FileBytes              = 0L
+                EventCount             = $eventCount
+                PageCount              = $pageCount
+                RetryCount             = $retryCount
+                RewindCount            = $rewindCount
+                MissingTimestampCount  = $missingTimestampCount
+                BoundaryTimestampCount = $boundaryTimestampCount
+                DuplicateRepresentationCount = $duplicateRepresentationCount
+                ElapsedSeconds         = [math]::Round($stopwatch.Elapsed.TotalSeconds, 3)
+                Error                  = $_.ToString()
+                FailureClass           = $failureClass
+            }
+        }
+        finally {
+            foreach ($stalePath in @($partialPath)) {
+                if (Test-Path -LiteralPath $stalePath) {
+                    Remove-Item -LiteralPath $stalePath -Force -ErrorAction SilentlyContinue
+                }
+            }
+            [void]$statusMap.TryRemove($chunkIndex, [ref]$null)
+        }
+    }
+}

--- a/XDRInternals/internal/functions/New-XdrIdentityTimelineExportWorker.ps1
+++ b/XDRInternals/internal/functions/New-XdrIdentityTimelineExportWorker.ps1
@@ -189,8 +189,27 @@
                             }
 
                             $retryCount++
-                            $delaySeconds = [math]::Min(30, [math]::Pow(2, $attempt - 1) + (Get-Random -Minimum 0 -Maximum 3))
-                            Start-Sleep -Seconds $delaySeconds
+                            $retryAfterSeconds = $null
+                            if ($statusCode -eq 429 -and $_.Exception.Response.Headers.RetryAfter) {
+                                $retryAfter = $_.Exception.Response.Headers.RetryAfter
+                                if ($null -ne $retryAfter.Delta) {
+                                    $retryAfterSeconds = [math]::Ceiling($retryAfter.Delta.TotalSeconds)
+                                }
+                                elseif ($null -ne $retryAfter.Date) {
+                                    $retryAfterSeconds = [math]::Ceiling(
+                                        ($retryAfter.Date.UtcDateTime - [datetime]::UtcNow).TotalSeconds
+                                    )
+                                }
+                            }
+                            $delaySeconds = if ($null -ne $retryAfterSeconds) {
+                                [math]::Min(300, [math]::Max(0, $retryAfterSeconds))
+                            }
+                            else {
+                                [math]::Min(30, [math]::Pow(2, $attempt - 1) + (Get-Random -Minimum 0 -Maximum 3))
+                            }
+                            if ($delaySeconds -gt 0) {
+                                Start-Sleep -Seconds $delaySeconds
+                            }
                         }
                     }
 

--- a/docs/export-functions.md
+++ b/docs/export-functions.md
@@ -11,12 +11,11 @@ Current and planned coverage:
 | Workload | Export cmdlet | Status |
 | --- | --- | --- |
 | Defender for Endpoint device timeline | `Export-XdrEndpointDeviceTimeline` | Implemented |
-| Defender for Identity user timeline | To be determined | Planned |
+| Defender for Identity user timeline | `Export-XdrIdentityUserTimeline` | Implemented |
 | Defender for Cloud Apps activity timeline | To be determined | Planned |
 
-This document describes the common export model and the device implementation. The
-workload-specific sections can be expanded as the identity and Cloud Apps exporters are
-implemented.
+This document describes the common export model and the workload-specific device and
+identity implementations.
 
 ## Why `Export-` is separate from `Get-`
 
@@ -59,6 +58,57 @@ The implementation is split across four files:
 | `XDRInternals/internal/functions/New-XdrEndpointTimelineExportWorker.ps1` | Downloads and validates one window while streaming NDJSON |
 | `XDRInternals/internal/functions/Merge-XdrEndpointTimelineNdjsonPart.ps1` | Verifies and concatenates completed parts without parsing them again |
 
+The byte-stream merger is shared by both exporters. Request construction, pagination,
+timestamp validation, and recovery remain workload-specific.
+
+## Identity timeline export lifecycle
+
+`Export-XdrIdentityUserTimeline` resolves one user, fingerprints the canonical API
+identifiers, and divides the requested range into adjacent 24-hour windows. Up to eight
+windows run concurrently; pages within each window remain sequential.
+
+Some portal entities cannot be resolved through the UPN lookup even though their AadId
+and SID resolve correctly. The exporter fails that UPN selection instead of sending the
+raw UPN directly: live testing found that the timeline endpoint accepted such a raw UPN
+but returned an empty result for a range that returned events with resolved identifiers.
+Use the AadId or SID from the Defender user URL for those entities.
+
+The identity endpoint is not a continuation API. It accepts POST bodies containing
+`count` and `skip`, but live testing found that offset pages drift when many events
+share a timestamp: adjacent pages can repeat records while omitting different records.
+The exporter therefore sends `skip = 0` and pages by timestamp. It validates that:
+
+- `count` equals the number of returned records;
+- `errors` has no properties (the successful response is an empty object);
+- every `Timestamp` is parseable, descending, and inside the requested interval;
+- only representations differing in observed volatile fields share a duplicate key.
+
+The service treats its Unix-second bounds as exclusive. To implement a conventional
+half-open `[FromDate, ToDate)` interval, the worker sends
+`(ceil(FromDate)-1 second, ceil(ToDate))` and validates the returned timestamps again.
+This prevents an event exactly on an adjacent window boundary from being lost.
+
+For every full 1,000-row response, the worker withholds the complete oldest API-second
+group, commits only the newer prefix, and repeats `skip = 0` with that second included
+as the new exclusive upper bound. A partial response completes the window. If one
+second fills a complete page, the API cannot prove which additional records may exist
+in that second. The export fails with `UnpageableBoundary` and preserves completed
+parts; it never discards the second or publishes a partial final file.
+
+Identity events are written without removing or rewriting correlation properties.
+Live testing also found that `EventId` is reused across timestamps and that identical
+representations can recur with different `Id`, `RowNumber`, and `Description` values.
+The duplicate key therefore combines the timestamp, `EventId` when present, and a
+canonical payload hash excluding those three observed volatile fields. The first raw
+object is retained unchanged and later matching representations are counted. Stable
+payload differences remain separate events.
+
+The identity manifest also supports a recoverable `Publishing` state. The expected final
+length and SHA-256 are committed before the atomic move, allowing an interrupted rerun
+to validate either the final or partial output and complete publication without
+redownloading finished windows. During `-Force`, an existing final file remains readable
+until the replacement has passed validation.
+
 ## Files and atomic publication
 
 For an output path such as `timeline.ndjson`, an in-progress export can use:
@@ -95,16 +145,18 @@ been returned. Throughput therefore comes from concurrent independent windows.
 
 ## Streaming and memory behavior
 
-Each response page is serialized one record at a time to UTF-8 NDJSON. The writer also
-computes the part's SHA-256 hash as bytes are written. Once a page has been processed,
-the response reference is released.
+Each response page is serialized one record at a time to UTF-8 NDJSON. Once a page has
+been processed, the response reference is released. The endpoint worker hashes bytes as
+they are written. The identity worker stages at most one 1,000-row response while it
+decides whether the oldest timestamp group is complete, then hashes the completed part
+before publication.
 
 The complete timeline and completed parts are never parsed into one in-memory
 collection. Memory is primarily bounded by the active response pages, serialization
 overhead, runspaces, and the underlying PowerShell web stack. Finalization copies and
 hashes byte streams; it does not deserialize the NDJSON.
 
-The current internal settings are:
+The current endpoint settings are:
 
 - four-hour windows;
 - four concurrent workers;
@@ -115,24 +167,50 @@ windows or more workers improved some short runs but increased memory, retries, 
 window restarts in longer runs. `ChunkHours` and `ThrottleLimit` should remain private
 until an automatic policy or broadly validated settings can replace manual guessing.
 
+The identity exporter uses 24-hour windows, eight workers, and 1,000-row
+timestamp-keyset pages. Delayed fresh-context probes over a fixed 30-day range for a
+dense test identity produced the same 23,490-event logical set across 36 requests,
+including a page boundary
+with 723 events in one second. Raw bytes differed because the service regenerated
+`Id`, `RowNumber`, and `Description`; no stable payload field differed. The fallback key
+also remained stable for the three events without `EventId`.
+
+Repeated corrected-strategy benchmarks favored 24 hours/eight workers over 48
+hours/four workers: median elapsed time improved from 19.5 to 14.1 seconds over seven
+days and from 87.5 to 54.1 seconds over 30 days. Over 90 days, 24 hours/eight workers
+completed in 192.3 seconds versus 316.9 seconds for 24 hours/four workers. Directly
+comparable event sets were identical, candidate runs had no retries or restarts, and
+peak working set remained below 756 MiB. The settings remain private because these are
+tenant-specific measurements rather than a documented service guarantee.
+
+Independent streaming validation confirmed line count, range, global order, length,
+SHA-256, interruption/resume, and equality across adjacent-window splits. A fixed
+six-hour public-command check also produced identical 1,845-event stable sets from
+`Get-` and `Export-`. One 44-day-old event without an `EventId` appeared between delayed
+90-day snapshots, demonstrating that the service can backfill historical data. The
+manifest timestamps therefore describe a point-in-time collection, not an immutable
+history.
+
 ## Retries, restart, and resume
 
 Recovery occurs at two levels:
 
 - A worker retries transient transport failures, HTTP 408/429/5xx responses, and an
   initially partial response with bounded exponential backoff and jitter.
-- If a window's continuation context appears poisoned, the coordinator can restart the
-  entire window with a fresh correlation ID and request context.
+- If a window's request context appears poisoned, the coordinator can restart the
+  entire window with a fresh session. Device restarts also receive a new correlation ID.
 
 The entire window is restarted because an arbitrary page is not a durable checkpoint.
-Continuation URIs are service-owned and may expire, and appending a retried page to a
-partial file could introduce gaps or duplicates.
+Device continuation URIs are service-owned and may expire; identity page membership can
+drift between identical offset requests. Appending a retried page to a partial file could
+therefore introduce gaps or duplicates.
 
 After an interruption, running the same command with the same path validates each
 completed part by recorded byte length and SHA-256. Valid parts are reused; invalid,
 failed, and in-progress parts are downloaded again. The device ID, time range, Sentinel
-option, window size, and page size must match the manifest. `-Force` deliberately
-discards the output and resumable state.
+option, window size, and page size must match the device manifest. The identity
+fingerprint, range, window size, page size, and pagination strategy must match the identity
+manifest. `-Force` deliberately discards resumable state.
 
 ## Correctness and fail-closed behavior
 
@@ -209,3 +287,18 @@ does not remove the underlying states. A shared export engine may become worthwh
 the identity and Cloud Apps implementations reveal which behavior is genuinely common.
 Until then, keeping service-specific pagination and validation explicit avoids an
 abstraction that hides important differences between these undocumented portal APIs.
+
+## Deferred device exporter follow-ups
+
+The identity implementation exposed several improvements worth evaluating separately
+for the device exporter: recover a manifest interrupted after final publication, retain
+the previous final file throughout a forced replacement, reset all diagnostics when a
+completed part fails resume validation, and complete live `IncludeSentinelEvents`
+validation with a device that has Sentinel-backed timeline data. Identity testing also
+showed that identifiers and descriptive fields can be request-volatile, so any future
+device duplicate validation should first establish device-specific stable keys rather
+than reuse the identity key. Repeated fixed-range device probes should compare complete
+continuation-chain sets both immediately and after a delay, verify cross-page ordering,
+and test whether cache flags or a fresh request context change membership before those
+checks are tightened. The delayed probe matters because the identity service backfilled
+a 44-day-old event between otherwise fixed 90-day snapshots.

--- a/docs/export-functions.md
+++ b/docs/export-functions.md
@@ -64,7 +64,7 @@ timestamp validation, and recovery remain workload-specific.
 ## Identity timeline export lifecycle
 
 `Export-XdrIdentityUserTimeline` resolves one user, fingerprints the canonical API
-identifiers, and divides the requested range into adjacent 24-hour windows. Up to eight
+identifiers, and divides the requested range into adjacent 12-hour windows. Up to eight
 windows run concurrently; pages within each window remain sequential.
 
 Some portal entities cannot be resolved through the UPN lookup even though their AadId
@@ -167,7 +167,7 @@ windows or more workers improved some short runs but increased memory, retries, 
 window restarts in longer runs. `ChunkHours` and `ThrottleLimit` should remain private
 until an automatic policy or broadly validated settings can replace manual guessing.
 
-The identity exporter uses 24-hour windows, eight workers, and 1,000-row
+The identity exporter uses 12-hour windows, eight workers, and 1,000-row
 timestamp-keyset pages. Delayed fresh-context probes over a fixed 30-day range for a
 dense test identity produced the same 23,490-event logical set across 36 requests,
 including a page boundary
@@ -175,13 +175,25 @@ with 723 events in one second. Raw bytes differed because the service regenerate
 `Id`, `RowNumber`, and `Description`; no stable payload field differed. The fallback key
 also remained stable for the three events without `EventId`.
 
-Repeated corrected-strategy benchmarks favored 24 hours/eight workers over 48
-hours/four workers: median elapsed time improved from 19.5 to 14.1 seconds over seven
-days and from 87.5 to 54.1 seconds over 30 days. Over 90 days, 24 hours/eight workers
-completed in 192.3 seconds versus 316.9 seconds for 24 hours/four workers. Directly
-comparable event sets were identical, candidate runs had no retries or restarts, and
-peak working set remained below 756 MiB. The settings remain private because these are
-tenant-specific measurements rather than a documented service guarantee.
+Follow-up page-size probes retained 1,000 rows. Dense 30-day runs at 250 and 500 rows
+failed closed when two individual API seconds filled a page, while 1,000 rows completed
+with 23,502 events and a maximum tied group of 723. A low-volume 30-day range returned
+the same 335-event canonical set at all three sizes, supporting the short-page terminal
+assumption when the page can contain a complete second.
+
+An aligned seven-day matrix of 6-, 12-, and 24-hour windows with 4, 8, and 16 workers
+produced the same 10,070-event canonical set in every configuration. Interleaved 30-day
+runs then completed in 56.2 and 61.0 seconds at 12 hours/eight workers versus 70.8 and
+68.2 seconds at 24 hours/eight workers. Each returned the same 23,502 events with no
+retries or restarts. Peak working set was 573-700 MiB for 12 hours and 658-678 MiB for
+24 hours. The repeatable elapsed-time improvement justified the 12-hour default; the
+settings remain private because these are tenant-specific measurements rather than a
+documented service guarantee.
+
+On a separate midnight-aligned dense range, the service repeatedly returned an event
+one second outside its stated exclusive lower bound. Six-, 12-, and 24-hour variants
+all rejected it after fresh-window restarts. This safe failure is preferable to silently
+duplicating an event across adjacent windows.
 
 Independent streaming validation confirmed line count, range, global order, length,
 SHA-256, interruption/resume, and equality across adjacent-window splits. A fixed
@@ -195,10 +207,12 @@ history.
 
 Recovery occurs at two levels:
 
-- A worker retries transient transport failures, HTTP 408/429/5xx responses, and an
-  initially partial response with bounded exponential backoff and jitter.
-- If a window's request context appears poisoned, the coordinator can restart the
-  entire window with a fresh session. Device restarts also receive a new correlation ID.
+- A worker retries transient transport failures and HTTP 408/429/5xx responses with
+  bounded exponential backoff and jitter. Identity requests honor a 429 `Retry-After`
+  value, capped at five minutes.
+- If a window returns a partial or malformed response, or its request context appears
+  poisoned, the coordinator can restart the entire window with a fresh session. Device
+  restarts also receive a new correlation ID.
 
 The entire window is restarted because an arbitrary page is not a durable checkpoint.
 Device continuation URIs are service-owned and may expire; identity page membership can

--- a/tests/functions/ExportIdentityUserTimeline.Tests.ps1
+++ b/tests/functions/ExportIdentityUserTimeline.Tests.ps1
@@ -1,0 +1,580 @@
+﻿Describe 'Export-XdrIdentityUserTimeline' {
+    BeforeEach {
+        Mock Update-XdrConnectionSettings {} -ModuleName XDRInternals
+        Mock Get-XdrIdentityHeaders { @{} } -ModuleName XDRInternals
+        Mock Get-XdrIdentityUser {
+            [PSCustomObject]@{
+                displayName = 'Timeline User'
+                ids = [PSCustomObject]@{
+                    aad = '11111111-1111-1111-1111-111111111111'
+                    upn = 'user@contoso.com'
+                }
+            }
+        } -ModuleName XDRInternals
+        InModuleScope XDRInternals {
+            $script:session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            $script:headers = @{}
+        }
+        $script:FromDate = [datetime]'2026-01-01T00:00:00Z'
+        $script:ToDate = [datetime]'2026-01-05T01:00:00Z'
+    }
+
+    It 'keeps the public parameter surface intentionally small' {
+        $command = Get-Command Export-XdrIdentityUserTimeline
+        $publicParameters = @($command.Parameters.Keys | Where-Object {
+                $_ -notin [System.Management.Automation.PSCmdlet]::CommonParameters -and
+                $_ -notin [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
+            })
+
+        $publicParameters | Sort-Object | Should -Be @('AadId', 'Force', 'FromDate', 'Path', 'RadiusUserId', 'Sid', 'ToDate', 'Upn')
+    }
+
+    It 'rejects invalid ranges and non-NDJSON output paths before collection' {
+        { Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:ToDate -ToDate $script:FromDate -Path (Join-Path $TestDrive 'reversed.ndjson') } |
+            Should -Throw -ExpectedMessage '*FromDate must be before ToDate*'
+        { Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:FromDate.AddDays(181) -Path (Join-Path $TestDrive 'too-long.ndjson') } |
+            Should -Throw -ExpectedMessage '*cannot exceed 180 days*'
+        { Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:FromDate.AddHours(1) -Path (Join-Path $TestDrive 'wrong.json') } |
+            Should -Throw -ExpectedMessage '*.ndjson extension*'
+    }
+
+    It 'uses exclusive API bounds to implement a logical half-open interval' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $script:RequestBody = $null
+            Mock Invoke-RestMethod {
+                param($Body)
+                $script:RequestBody = $Body | ConvertFrom-Json
+                [PSCustomObject]@{
+                    count = 1
+                    data = @([PSCustomObject]@{ EventId = 'lower'; Timestamp = '2026-01-01T00:00:00Z'; Id = 'raw' })
+                    errors = [PSCustomObject]@{}
+                }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{
+                Index = 0; FromDate = [datetime]'2026-01-01T00:00:00Z'
+                ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'bounds.ndjson'
+            }
+            $shared = @{
+                PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'user@contoso.com' }
+                CookieData = @(); HeadersData = @{}; PageSize = 1000; MaxRetries = 1; RequestTimeoutSeconds = 30
+            }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue -Because $result.Error
+            $result.EventCount | Should -Be 1
+            $script:RequestBody.filters.Timeframe.between[0] | Should -Be 1767225599
+            $script:RequestBody.filters.Timeframe.between[1] | Should -Be 1767229200
+            (Get-Content -LiteralPath $result.FilePath -Raw | ConvertFrom-Json).Id | Should -Be 'raw'
+        }
+    }
+
+    It 'fails closed on nonempty service errors' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{ count = 0; data = @(); errors = [PSCustomObject]@{ backend = 'partial' } }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-02Z'; FileName = 'errors.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 1000; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'PartialResponse'
+            $result.Error | Should -BeLike '*service errors*'
+            Test-Path -LiteralPath (Join-Path $TestRoot 'errors.ndjson') | Should -BeFalse
+        }
+    }
+
+    It 'fails closed when response count does not match data' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{ count = 2; data = @([PSCustomObject]@{ EventId = 1; Timestamp = '2026-01-01T12:00:00Z' }); errors = [PSCustomObject]@{} }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-02Z'; FileName = 'count.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 1000; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'PartialResponse'
+            $result.Error | Should -BeLike '*count=2*data contained 1*'
+        }
+    }
+
+    It 'fails closed when a required response field is absent' -ForEach @('count', 'data', 'errors') {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive; MissingField = $_ } {
+            Mock Invoke-RestMethod {
+                $response = [ordered]@{ count = 0; data = @(); errors = [PSCustomObject]@{} }
+                $response.Remove($MissingField)
+                [PSCustomObject]$response
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-02Z'; FileName = 'missing-field.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 1000; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'PartialResponse'
+            $result.Error | Should -BeLike "*without '$MissingField'*"
+        }
+    }
+
+    It 'rejects ascending events' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{ count = 2; data = @(
+                        [PSCustomObject]@{ EventId = 'a'; Timestamp = '2026-01-01T01:00:00Z' },
+                        [PSCustomObject]@{ EventId = 'b'; Timestamp = '2026-01-01T02:00:00Z' }
+                    ); errors = [PSCustomObject]@{} }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-02Z'; FileName = 'invalid.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 1000; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.Error | Should -BeLike '*descending timestamp order*'
+        }
+    }
+
+    It 'retains a reused EventId when its timestamp differs' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{ count = 2; data = @(
+                        [PSCustomObject]@{ EventId = 'repeat'; Timestamp = '2026-01-01T02:00:00Z' },
+                        [PSCustomObject]@{ EventId = 'repeat'; Timestamp = '2026-01-01T01:00:00Z' }
+                    ); errors = [PSCustomObject]@{} }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-02Z'; FileName = 'reused-id.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 1000; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue -Because $result.Error
+            $result.EventCount | Should -Be 2
+        }
+    }
+
+    It 'suppresses only request-volatile duplicate representations and retains the first raw object' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{ count = 2; data = @(
+                        [PSCustomObject]@{ EventId = 'same'; Timestamp = '2026-01-01T00:20:00Z'; Id = 'first'; RowNumber = 1; Description = 'first description'; Title = 'Stable' },
+                        [PSCustomObject]@{ EventId = 'same'; Timestamp = '2026-01-01T00:20:00Z'; Id = 'second'; RowNumber = 9; Description = 'second description'; Title = 'Stable' }
+                    ); errors = [PSCustomObject]@{} }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'duplicate-representation.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 1000; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+            $eventItem = Get-Content -LiteralPath $result.FilePath -Raw | ConvertFrom-Json
+
+            $result.Success | Should -BeTrue -Because $result.Error
+            $result.EventCount | Should -Be 1
+            $result.DuplicateRepresentationCount | Should -Be 1
+            $eventItem.Id | Should -Be 'first'
+            $eventItem.Description | Should -Be 'first description'
+        }
+    }
+
+    It 'uses timestamp keyset pages without losing the tied boundary group' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            Mock Invoke-RestMethod {
+                param($Body)
+                $request = $Body | ConvertFrom-Json
+                $to = [long]$request.filters.Timeframe.between[1]
+                $pages = @{
+                    '1767229200' = @('50', '40a', '40b')
+                    '1767228001' = @('40a', '40b', '30')
+                    '1767227401' = @('30')
+                }
+                $events = @($pages["$to"] | ForEach-Object {
+                        $minute = ([string]$_ -replace '[ab]$')
+                        [PSCustomObject]@{ EventId = $_; Timestamp = "2026-01-01T00:$minute`:00Z" }
+                    })
+                [PSCustomObject]@{ count = $events.Count; data = $events; errors = [PSCustomObject]@{} }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'keyset.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 3; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+            $ids = @(Get-Content -LiteralPath $result.FilePath | ForEach-Object { ($_ | ConvertFrom-Json).EventId })
+
+            $result.Success | Should -BeTrue -Because $result.Error
+            $result.RewindCount | Should -Be 2
+            $ids | Should -Be @('50', '40a', '40b', '30')
+            Assert-MockCalled Invoke-RestMethod -Times 3 -Exactly -Scope It -ParameterFilter {
+                ($Body | ConvertFrom-Json).skip -eq 0
+            }
+        }
+    }
+
+    It 'fails rather than dropping an unpageable timestamp' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            Mock Invoke-RestMethod {
+                param($Body)
+                [PSCustomObject]@{ count = 2; data = @(
+                        [PSCustomObject]@{ EventId = 'first-a'; Timestamp = '2026-01-01T00:20:00Z' },
+                        [PSCustomObject]@{ EventId = 'first-b'; Timestamp = '2026-01-01T00:20:00Z' }
+                    ); errors = [PSCustomObject]@{} }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'unpageable.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 2; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'UnpageableBoundary'
+            $result.Error | Should -BeLike '*cannot prove completeness*one API timestamp second filled*'
+            Test-Path -LiteralPath (Join-Path $TestRoot 'unpageable.ndjson') | Should -BeFalse
+        }
+    }
+
+    It 'withholds the complete oldest API second when fractional timestamps share it' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            Mock Invoke-RestMethod {
+                param($Body)
+                $request = $Body | ConvertFrom-Json
+                $to = [long]$request.filters.Timeframe.between[1]
+                $events = if ($to -eq 1767229200) {
+                    @(
+                        [PSCustomObject]@{ EventId = 'newer'; Timestamp = '2026-01-01T00:50:00Z' },
+                        [PSCustomObject]@{ EventId = 'fraction-a'; Timestamp = '2026-01-01T00:40:00.900Z' },
+                        [PSCustomObject]@{ EventId = 'fraction-b'; Timestamp = '2026-01-01T00:40:00.100Z' }
+                    )
+                } else {
+                    @(
+                        [PSCustomObject]@{ EventId = 'fraction-a'; Timestamp = '2026-01-01T00:40:00.900Z' },
+                        [PSCustomObject]@{ EventId = 'fraction-b'; Timestamp = '2026-01-01T00:40:00.100Z' }
+                    )
+                }
+                [PSCustomObject]@{ count = $events.Count; data = $events; errors = [PSCustomObject]@{} }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'fractional-keyset.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 3; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+            $ids = @(Get-Content -LiteralPath $result.FilePath | ForEach-Object { ($_ | ConvertFrom-Json).EventId })
+
+            $result.Success | Should -BeTrue -Because $result.Error
+            $result.RewindCount | Should -Be 1
+            $ids | Should -Be @('newer', 'fraction-a', 'fraction-b')
+        }
+    }
+
+    It 'publishes newest-first validated parts and records the identity fingerprint' {
+        Mock New-XdrIdentityTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                $line = [string]::Format('{{"chunk":{0}}}{1}', [int]$chunk.Index, "`n")
+                [System.IO.File]::WriteAllText($filePath, $line, [System.Text.UTF8Encoding]::new($false))
+                [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1
+                    RetryCount = 0; RewindCount = 0; FileBytes = (Get-Item $filePath).Length
+                    FileSha256 = (Get-FileHash $filePath).Hash.ToLowerInvariant(); MissingTimestampCount = 0L
+                    BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01; Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'identity.ndjson'
+
+        $result = Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:ToDate -Path $outputPath
+        $manifest = Get-Content -LiteralPath "$outputPath.manifest.json" -Raw | ConvertFrom-Json
+        $chunks = @(Get-Content -LiteralPath $outputPath | ForEach-Object { ($_ | ConvertFrom-Json).chunk })
+
+        $result.TotalChunks | Should -Be 5
+        $result.TotalEvents | Should -Be 5
+        $chunks | Should -Be @(0, 1, 2, 3, 4)
+        $manifest.IdentityFingerprint | Should -Match '^[0-9a-f]{64}$'
+        $manifest.State | Should -Be 'Complete'
+        $manifest.ChunkHours | Should -Be 24
+        $manifest.PaginationStrategy | Should -Be 'TimestampKeysetV2'
+        $result.FileSha256 | Should -Be (Get-FileHash -LiteralPath $outputPath).Hash.ToLowerInvariant()
+    }
+
+    It 'preserves an existing final file when a forced replacement fails' {
+        Mock New-XdrIdentityTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                [PSCustomObject]@{
+                    Success = $false; ChunkIndex = [int]$chunk.Index; EventCount = 0L; PageCount = 0
+                    RetryCount = 0; RewindCount = 0; FileBytes = 0L; FileSha256 = $null
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01
+                    Error = 'simulated permanent failure'; FailureClass = 'PermanentHttp'
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'existing.ndjson'
+        [System.IO.File]::WriteAllText($outputPath, "old`n", [System.Text.UTF8Encoding]::new($false))
+
+        { Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:ToDate -Path $outputPath -Force } |
+            Should -Throw -ExpectedMessage '*preserved for resume*'
+
+        [System.IO.File]::ReadAllText($outputPath) | Should -Be "old`n"
+        Test-Path -LiteralPath "$outputPath.parts" | Should -BeTrue
+    }
+
+    It 'resolves the selected identity exactly once' {
+        Mock New-XdrIdentityTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                [System.IO.File]::WriteAllText($filePath, "{}`n", [System.Text.UTF8Encoding]::new($false))
+                [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1
+                    RetryCount = 0; RewindCount = 0; FileBytes = (Get-Item $filePath).Length
+                    FileSha256 = (Get-FileHash $filePath).Hash.ToLowerInvariant(); MissingTimestampCount = 0L
+                    BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01; Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'resolved-once.ndjson'
+
+        $null = Export-XdrIdentityUserTimeline -AadId '11111111-1111-1111-1111-111111111111' `
+            -FromDate $script:FromDate -ToDate $script:FromDate.AddHours(1) -Path $outputPath
+
+        Should -Invoke Get-XdrIdentityUser -ModuleName XDRInternals -Times 1 -Exactly -ParameterFilter {
+            $AadId -eq '11111111-1111-1111-1111-111111111111'
+        }
+    }
+
+    It 'rounds subsecond logical bounds outward for the exclusive API' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $script:SubsecondBody = $null
+            Mock Invoke-RestMethod {
+                param($Body)
+                $script:SubsecondBody = $Body | ConvertFrom-Json
+                [PSCustomObject]@{
+                    count = 1
+                    data = @([PSCustomObject]@{ EventId = 'inside'; Timestamp = '2026-01-01T00:00:01Z' })
+                    errors = [PSCustomObject]@{}
+                }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{
+                Index = 0; FromDate = [datetime]'2026-01-01T00:00:00.250Z'
+                ToDate = [datetime]'2026-01-01T01:00:00.100Z'; FileName = 'subsecond.ndjson'
+            }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 1000; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue -Because $result.Error
+            $script:SubsecondBody.filters.Timeframe.between[0] | Should -Be 1767225600
+            $script:SubsecondBody.filters.Timeframe.between[1] | Should -Be 1767229201
+        }
+    }
+
+    It 'retries transient transport failures but fails authentication without retrying' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $script:RetryCall = 0
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $script:RetryCall++
+                if ($script:RetryCall -eq 1) { throw 'temporary transport failure' }
+                [PSCustomObject]@{ count = 0; data = @(); errors = [PSCustomObject]@{} }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-02Z'; FileName = 'retry.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 1000; MaxRetries = 2; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $retried = & $worker $chunk $shared $status
+
+            $retried.Success | Should -BeTrue -Because $retried.Error
+            $retried.RetryCount | Should -Be 1
+            Should -Invoke Start-Sleep -Times 1 -Exactly
+
+            Mock Invoke-RestMethod {
+                $response = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::Unauthorized)
+                throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('unauthorized', $response)
+            }
+            $chunk.FileName = 'authentication.ndjson'
+            $denied = & $worker $chunk $shared $status
+
+            $denied.Success | Should -BeFalse
+            $denied.FailureClass | Should -Be 'Authentication'
+            $denied.RetryCount | Should -Be 0
+        }
+    }
+
+    It 'fails closed on a missing timestamp' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{ count = 1; data = @([PSCustomObject]@{ EventId = 'missing' }); errors = [PSCustomObject]@{} }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-02Z'; FileName = 'missing.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 1000; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.MissingTimestampCount | Should -Be 1
+            Test-Path -LiteralPath (Join-Path $TestRoot 'missing.ndjson') | Should -BeFalse
+        }
+    }
+
+    It 'rejects incompatible resumable state' {
+        Mock New-XdrIdentityTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                [PSCustomObject]@{
+                    Success = $false; ChunkIndex = [int]$chunk.Index; EventCount = 0L; PageCount = 0
+                    RetryCount = 0; RewindCount = 0; FileBytes = 0L; FileSha256 = $null
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01
+                    Error = 'stop after manifest creation'; FailureClass = 'PermanentHttp'
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'incompatible.ndjson'
+        { Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:ToDate -Path $outputPath } | Should -Throw
+
+        { Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate.AddSeconds(1) -ToDate $script:ToDate -Path $outputPath } |
+            Should -Throw -ExpectedMessage '*does not match this request*'
+    }
+
+    It 're-downloads corrupted completed parts and resumes only validated parts' {
+        $script:ResumePhase = 1
+        Mock New-XdrIdentityTimelineExportWorker {
+            if ($script:ResumePhase -eq 1) {
+                return {
+                    param($chunk, $sharedParameters, $statusMap)
+                    if ([int]$chunk.Index -eq 1) {
+                        return [PSCustomObject]@{
+                            Success = $false; ChunkIndex = 1; EventCount = 0L; PageCount = 0; RetryCount = 0
+                            RewindCount = 0; FileBytes = 0L; FileSha256 = $null; MissingTimestampCount = 0L
+                            BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01; Error = 'simulated interruption'; FailureClass = 'PermanentHttp'
+                        }
+                    }
+                    $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                    [System.IO.File]::WriteAllText($filePath, "{`"chunk`":$([int]$chunk.Index)}`n", [System.Text.UTF8Encoding]::new($false))
+                    return [PSCustomObject]@{
+                        Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1; RetryCount = 0
+                        RewindCount = 0; FileBytes = (Get-Item $filePath).Length; FileSha256 = (Get-FileHash $filePath).Hash.ToLowerInvariant()
+                        MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01; Error = $null; FailureClass = $null
+                    }
+                }
+            }
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                [System.IO.File]::WriteAllText($filePath, "{`"chunk`":$([int]$chunk.Index)}`n", [System.Text.UTF8Encoding]::new($false))
+                [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1; RetryCount = 0
+                    RewindCount = 0; FileBytes = (Get-Item $filePath).Length; FileSha256 = (Get-FileHash $filePath).Hash.ToLowerInvariant()
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01; Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'resume-corrupt.ndjson'
+
+        { Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:ToDate -Path $outputPath } | Should -Throw
+        $manifest = Get-Content -LiteralPath "$outputPath.manifest.json" -Raw | ConvertFrom-Json
+        $corruptPart = Join-Path "$outputPath.parts" ([string]$manifest.Chunks[0].FileName)
+        [System.IO.File]::AppendAllText($corruptPart, "corrupt`n", [System.Text.UTF8Encoding]::new($false))
+
+        $script:ResumePhase = 2
+        $result = Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:ToDate -Path $outputPath
+
+        $result.ResumedChunks | Should -Be 3
+        $result.TotalEvents | Should -Be 5
+        Test-Path -LiteralPath "$outputPath.parts" | Should -BeFalse
+    }
+
+    It 'completes a manifest left in Publishing after validating the partial output' {
+        Mock New-XdrIdentityTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                [System.IO.File]::WriteAllText($filePath, "{`"recovered`":true}`n", [System.Text.UTF8Encoding]::new($false))
+                [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1; RetryCount = 0
+                    RewindCount = 0; FileBytes = (Get-Item $filePath).Length; FileSha256 = (Get-FileHash $filePath).Hash.ToLowerInvariant()
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01; Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'publishing.ndjson'
+        $null = Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:FromDate.AddHours(1) -Path $outputPath
+        $manifestPath = "$outputPath.manifest.json"
+        $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -AsHashtable
+        $manifest.State = 'Publishing'
+        $manifest.Summary.PartsRetained = $true
+        [System.IO.File]::WriteAllText($manifestPath, ($manifest | ConvertTo-Json -Depth 20), [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::Move($outputPath, "$outputPath.partial")
+
+        $result = Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:FromDate.AddHours(1) -Path $outputPath
+
+        $result.TotalEvents | Should -Be 1
+        (Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json).State | Should -Be 'Complete'
+        (Get-FileHash -LiteralPath $outputPath).Hash.ToLowerInvariant() | Should -Be $result.FileSha256
+    }
+
+    It 'refuses a completed final file whose hash no longer matches its manifest' {
+        Mock New-XdrIdentityTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                [System.IO.File]::WriteAllText($filePath, "{`"valid`":true}`n", [System.Text.UTF8Encoding]::new($false))
+                [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1; RetryCount = 0
+                    RewindCount = 0; FileBytes = (Get-Item $filePath).Length; FileSha256 = (Get-FileHash $filePath).Hash.ToLowerInvariant()
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01; Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'invalid-final.ndjson'
+        $null = Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:FromDate.AddHours(1) -Path $outputPath
+        [System.IO.File]::WriteAllText($outputPath, "changed but same?`n", [System.Text.UTF8Encoding]::new($false))
+
+        { Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:FromDate.AddHours(1) -Path $outputPath } |
+            Should -Throw -ExpectedMessage '*failed validation*'
+    }
+
+    It 'preserves completed parts when available disk space is insufficient' {
+        Mock New-XdrIdentityTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                [System.IO.File]::WriteAllText($filePath, "{}`n", [System.Text.UTF8Encoding]::new($false))
+                [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1; RetryCount = 0
+                    RewindCount = 0; FileBytes = ([long]::MaxValue / 2); FileSha256 = (Get-FileHash $filePath).Hash.ToLowerInvariant()
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01; Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'no-space.ndjson'
+
+        { Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:FromDate.AddHours(1) -Path $outputPath } |
+            Should -Throw -ExpectedMessage '*requires at least*free*'
+
+        Test-Path -LiteralPath $outputPath | Should -BeFalse
+        Test-Path -LiteralPath "$outputPath.parts" | Should -BeTrue
+    }
+}

--- a/tests/functions/ExportIdentityUserTimeline.Tests.ps1
+++ b/tests/functions/ExportIdentityUserTimeline.Tests.ps1
@@ -304,12 +304,12 @@
         $manifest = Get-Content -LiteralPath "$outputPath.manifest.json" -Raw | ConvertFrom-Json
         $chunks = @(Get-Content -LiteralPath $outputPath | ForEach-Object { ($_ | ConvertFrom-Json).chunk })
 
-        $result.TotalChunks | Should -Be 5
-        $result.TotalEvents | Should -Be 5
-        $chunks | Should -Be @(0, 1, 2, 3, 4)
+        $result.TotalChunks | Should -Be 9
+        $result.TotalEvents | Should -Be 9
+        $chunks | Should -Be @(0, 1, 2, 3, 4, 5, 6, 7, 8)
         $manifest.IdentityFingerprint | Should -Match '^[0-9a-f]{64}$'
         $manifest.State | Should -Be 'Complete'
-        $manifest.ChunkHours | Should -Be 24
+        $manifest.ChunkHours | Should -Be 12
         $manifest.PaginationStrategy | Should -Be 'TimestampKeysetV2'
         $result.FileSha256 | Should -Be (Get-FileHash -LiteralPath $outputPath).Hash.ToLowerInvariant()
     }
@@ -421,6 +421,164 @@
         }
     }
 
+    It 'honors Retry-After when retrying a throttled request' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $script:ThrottleCall = 0
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $script:ThrottleCall++
+                if ($script:ThrottleCall -eq 1) {
+                    $response = [System.Net.Http.HttpResponseMessage]::new(
+                        [System.Net.HttpStatusCode]::TooManyRequests
+                    )
+                    $response.Headers.RetryAfter = [System.Net.Http.Headers.RetryConditionHeaderValue]::new(
+                        [timespan]::FromSeconds(7)
+                    )
+                    throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('throttled', $response)
+                }
+                [PSCustomObject]@{ count = 0; data = @(); errors = [PSCustomObject]@{} }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-02Z'; FileName = 'throttle.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 1000; MaxRetries = 2; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue -Because $result.Error
+            $result.RetryCount | Should -Be 1
+            Should -Invoke Start-Sleep -Times 1 -Exactly -ParameterFilter { $Seconds -eq 7 }
+        }
+    }
+
+    It 'retries a server failure but does not retry a permanent HTTP failure' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $script:ServerCall = 0
+            Mock Get-Random { 0 }
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $script:ServerCall++
+                if ($script:ServerCall -eq 1) {
+                    $response = [System.Net.Http.HttpResponseMessage]::new(
+                        [System.Net.HttpStatusCode]::ServiceUnavailable
+                    )
+                    throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('unavailable', $response)
+                }
+                [PSCustomObject]@{ count = 0; data = @(); errors = [PSCustomObject]@{} }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-02Z'; FileName = 'server.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 1000; MaxRetries = 2; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $retried = & $worker $chunk $shared $status
+
+            $retried.Success | Should -BeTrue -Because $retried.Error
+            $retried.RetryCount | Should -Be 1
+            Should -Invoke Start-Sleep -Times 1 -Exactly -ParameterFilter { $Seconds -eq 1 }
+
+            Mock Invoke-RestMethod {
+                $response = [System.Net.Http.HttpResponseMessage]::new(
+                    [System.Net.HttpStatusCode]::BadRequest
+                )
+                throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('bad request', $response)
+            }
+            $chunk.FileName = 'permanent.ndjson'
+            $permanent = & $worker $chunk $shared $status
+
+            $permanent.Success | Should -BeFalse
+            $permanent.FailureClass | Should -Be 'PermanentHttp'
+            $permanent.RetryCount | Should -Be 0
+        }
+    }
+
+    It 'discards an interval when service errors follow an earlier valid page' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $script:PartialPageCall = 0
+            Mock Invoke-RestMethod {
+                $script:PartialPageCall++
+                if ($script:PartialPageCall -eq 1) {
+                    return [PSCustomObject]@{
+                        count = 2
+                        data = @(
+                            [PSCustomObject]@{ EventId = 'newer'; Timestamp = '2026-01-01T00:50:00Z' },
+                            [PSCustomObject]@{ EventId = 'boundary'; Timestamp = '2026-01-01T00:40:00Z' }
+                        )
+                        errors = [PSCustomObject]@{}
+                    }
+                }
+                [PSCustomObject]@{ count = 0; data = @(); errors = [PSCustomObject]@{ backend = 'partial' } }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'late-errors.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 2; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'PartialResponse'
+            $result.PageCount | Should -Be 1
+            Test-Path -LiteralPath (Join-Path $TestRoot 'late-errors.ndjson') | Should -BeFalse
+            Test-Path -LiteralPath (Join-Path $TestRoot 'late-errors.ndjson.partial') | Should -BeFalse
+        }
+    }
+
+    It 'rejects an out-of-range timestamp' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{
+                    count = 1
+                    data = @([PSCustomObject]@{ EventId = 'outside'; Timestamp = '2026-01-02T00:00:00Z' })
+                    errors = [PSCustomObject]@{}
+                }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-02Z'; FileName = 'outside.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 1000; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'Protocol'
+            $result.Error | Should -BeLike '*outside*interval*'
+        }
+    }
+
+    It 'rejects an ordering reversal on a continuation page' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $script:OrderingPageCall = 0
+            Mock Invoke-RestMethod {
+                $script:OrderingPageCall++
+                $events = if ($script:OrderingPageCall -eq 1) {
+                    @(
+                        [PSCustomObject]@{ EventId = 'newer'; Timestamp = '2026-01-01T00:50:00Z' },
+                        [PSCustomObject]@{ EventId = 'boundary'; Timestamp = '2026-01-01T00:40:00Z' }
+                    )
+                }
+                else {
+                    @(
+                        [PSCustomObject]@{ EventId = 'older'; Timestamp = '2026-01-01T00:30:00.100Z' },
+                        [PSCustomObject]@{ EventId = 'reversed'; Timestamp = '2026-01-01T00:30:00.900Z' }
+                    )
+                }
+                [PSCustomObject]@{ count = 2; data = $events; errors = [PSCustomObject]@{} }
+            }
+            $worker = New-XdrIdentityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; FileName = 'page-order.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; UserIdentifiers = @{ upn = 'u' }; CookieData = @(); HeadersData = @{}; PageSize = 2; MaxRetries = 1; RequestTimeoutSeconds = 30 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'Protocol'
+            $result.Error | Should -BeLike '*descending timestamp order*'
+            $script:OrderingPageCall | Should -Be 2
+        }
+    }
+
     It 'fails closed on a missing timestamp' {
         InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
             Mock Invoke-RestMethod {
@@ -501,9 +659,66 @@
         $script:ResumePhase = 2
         $result = Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:ToDate -Path $outputPath
 
-        $result.ResumedChunks | Should -Be 3
-        $result.TotalEvents | Should -Be 5
+        $result.ResumedChunks | Should -BeGreaterThan 0
+        $result.ResumedChunks | Should -BeLessThan $result.TotalChunks
+        $result.TotalChunks | Should -Be 9
+        $result.TotalEvents | Should -Be 9
         Test-Path -LiteralPath "$outputPath.parts" | Should -BeFalse
+    }
+
+    It 'stops scheduling after authentication failure and resumes completed parts after reconnect' {
+        $script:AuthenticationPhase = 1
+        Mock New-XdrIdentityTimelineExportWorker {
+            if ($script:AuthenticationPhase -eq 1) {
+                return {
+                    param($chunk, $sharedParameters, $statusMap)
+                    if ([int]$chunk.Index -eq 0) {
+                        return [PSCustomObject]@{
+                            Success = $false; ChunkIndex = 0; EventCount = 0L; PageCount = 0; RetryCount = 0
+                            RewindCount = 0; FileBytes = 0L; FileSha256 = $null; MissingTimestampCount = 0L
+                            BoundaryTimestampCount = 0L; DuplicateRepresentationCount = 0L; ElapsedSeconds = 0.01
+                            Error = 'simulated authentication interruption'; FailureClass = 'Authentication'
+                        }
+                    }
+                    $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                    [System.IO.File]::WriteAllText($filePath, "{`"chunk`":$([int]$chunk.Index)}`n", [System.Text.UTF8Encoding]::new($false))
+                    return [PSCustomObject]@{
+                        Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1; RetryCount = 0
+                        RewindCount = 0; FileBytes = (Get-Item $filePath).Length; FileSha256 = (Get-FileHash $filePath).Hash.ToLowerInvariant()
+                        MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; DuplicateRepresentationCount = 0L
+                        ElapsedSeconds = 0.01; Error = $null; FailureClass = $null
+                    }
+                }
+            }
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                [System.IO.File]::WriteAllText($filePath, "{`"chunk`":$([int]$chunk.Index)}`n", [System.Text.UTF8Encoding]::new($false))
+                [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; PageCount = 1; RetryCount = 0
+                    RewindCount = 0; FileBytes = (Get-Item $filePath).Length; FileSha256 = (Get-FileHash $filePath).Hash.ToLowerInvariant()
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; DuplicateRepresentationCount = 0L
+                    ElapsedSeconds = 0.01; Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $outputPath = Join-Path $TestDrive 'authentication-resume.ndjson'
+
+        { Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:ToDate -Path $outputPath } |
+            Should -Throw -ExpectedMessage '*preserved for resume*'
+
+        $interruptedManifest = Get-Content -LiteralPath "$outputPath.manifest.json" -Raw | ConvertFrom-Json
+        @($interruptedManifest.Chunks | Where-Object Status -eq 'Completed').Count | Should -BeGreaterThan 0
+        @($interruptedManifest.Chunks | Where-Object Status -eq 'Pending').Count | Should -BeGreaterThan 0
+        Test-Path -LiteralPath "$outputPath.parts" | Should -BeTrue
+
+        $script:AuthenticationPhase = 2
+        $result = Export-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:ToDate -Path $outputPath
+
+        $result.ResumedChunks | Should -BeGreaterThan 0
+        $result.TotalChunks | Should -Be 9
+        $result.TotalEvents | Should -Be 9
+        (Get-Content -LiteralPath "$outputPath.manifest.json" -Raw | ConvertFrom-Json).State | Should -Be 'Complete'
     }
 
     It 'completes a manifest left in Publishing after validating the partial output' {

--- a/tests/functions/IdentityUserTimeline.Tests.ps1
+++ b/tests/functions/IdentityUserTimeline.Tests.ps1
@@ -1,0 +1,180 @@
+﻿BeforeAll {
+    $script:HasStartThreadJob = $null -ne (Get-Command Start-ThreadJob -ErrorAction SilentlyContinue)
+
+    if (-not ('IdentityUserTimelineTestJob' -as [type])) {
+        Add-Type -TypeDefinition @"
+using System.Management.Automation;
+
+public sealed class IdentityUserTimelineTestJob : Job
+{
+    public IdentityUserTimelineTestJob() : base("Get-XdrIdentityUserTimeline", "IdentityUserTimelineTestJob")
+    {
+        SetJobState(JobState.Completed);
+    }
+
+    public override string StatusMessage => string.Empty;
+    public override bool HasMoreData => false;
+    public override string Location => "localhost";
+    public override void StopJob() { }
+}
+"@
+    }
+}
+
+Describe 'Get-XdrIdentityUserTimeline hardening' {
+    BeforeEach {
+        Mock Update-XdrConnectionSettings {} -ModuleName XDRInternals
+        Mock Get-XdrIdentityHeaders { @{} } -ModuleName XDRInternals
+        Mock Get-XdrIdentityUser {
+            [PSCustomObject]@{
+                displayName = 'Timeline User'
+                ids = [PSCustomObject]@{ aad = '11111111-1111-1111-1111-111111111111'; upn = 'user@contoso.com' }
+            }
+        } -ModuleName XDRInternals
+        InModuleScope XDRInternals {
+            $script:session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            $script:headers = @{}
+        }
+
+        $script:FromDate = [datetime]'2026-01-01T00:00:00Z'
+        $script:ToDate = [datetime]'2026-01-01T02:00:00Z'
+        $script:FakeIdentityTimelineResults = @()
+        $script:ChunkEvents = @()
+
+        if ($script:HasStartThreadJob) {
+            Mock Start-ThreadJob {
+                param($ArgumentList)
+                $runTempPath = [string]$ArgumentList[4]
+                if ($script:ChunkEvents.Count -gt 0) {
+                    New-Item -Path $runTempPath -ItemType Directory -Force | Out-Null
+                    $payload = [ordered]@{
+                        ChunkIndex = 0
+                        FromDate = $script:FromDate.ToString('o')
+                        ToDate = $script:ToDate.ToString('o')
+                        EventCount = $script:ChunkEvents.Count
+                        Events = $script:ChunkEvents
+                    } | ConvertTo-Json -Depth 20 -Compress
+                    [System.IO.File]::WriteAllText(
+                        (Join-Path $runTempPath 'chunk_0000_20260101_20260101.json'),
+                        $payload,
+                        [System.Text.UTF8Encoding]::new($false)
+                    )
+                }
+                [IdentityUserTimelineTestJob]::new()
+            } -ModuleName XDRInternals
+            Mock Receive-Job { $script:FakeIdentityTimelineResults } -ModuleName XDRInternals
+            Mock Remove-Job {} -ModuleName XDRInternals
+        }
+    }
+
+    It 'exposes AllowPartial' {
+        (Get-Command Get-XdrIdentityUserTimeline).Parameters.ContainsKey('AllowPartial') | Should -BeTrue
+    }
+
+    It 'classifies authentication and permanent HTTP failures as non-retryable' {
+        $definition = (Get-Command Get-XdrIdentityUserTimeline).ScriptBlock.ToString()
+
+        $definition | Should -Match '\$statusCode -in @\(401, 403\)'
+        $definition | Should -Match '\$chunkFailureIsRetryable = \$false'
+        $definition | Should -Match '\$nonRetryableChunkFailure'
+    }
+
+    It 'fails when any chunk fails unless partial output is explicitly allowed' {
+        if (-not $script:HasStartThreadJob) {
+            Set-ItResult -Skipped -Because 'Start-ThreadJob is unavailable in this session.'
+        }
+        $script:FakeIdentityTimelineResults = @(
+            [PSCustomObject]@{
+                ChunkIndex = 0; Success = $false; Error = 'simulated failure'
+                FromDate = $script:FromDate; ToDate = $script:ToDate
+                ElapsedSeconds = 1; PagesRetrieved = 0; FileSizeKB = 0
+            }
+        )
+
+        {
+            Get-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:ToDate -OutputPath $TestDrive
+        } | Should -Throw -ExpectedMessage '*failed for 1 chunk*Use -AllowPartial*'
+    }
+
+    It 'retains distinct EventIds and returns completed chunks with AllowPartial' {
+        if (-not $script:HasStartThreadJob) {
+            Set-ItResult -Skipped -Because 'Start-ThreadJob is unavailable in this session.'
+        }
+        $script:ChunkEvents = @(
+            [PSCustomObject]@{ EventId = 'event-1'; Id = 'volatile-1'; RowNumber = 1; Timestamp = '2026-01-01T01:00:00Z'; Title = 'Same' },
+            [PSCustomObject]@{ EventId = 'event-2'; Id = 'volatile-2'; RowNumber = 2; Timestamp = '2026-01-01T01:00:00Z'; Title = 'Same' }
+        )
+        $script:FakeIdentityTimelineResults = @(
+            [PSCustomObject]@{
+                ChunkIndex = 0; Success = $true; EventCount = 2
+                FromDate = $script:FromDate; ToDate = $script:ToDate
+                ElapsedSeconds = 1; PagesRetrieved = 1; FileSizeKB = 1
+            },
+            [PSCustomObject]@{
+                ChunkIndex = 1; Success = $false; Error = 'simulated failure'
+                FromDate = $script:FromDate; ToDate = $script:ToDate
+                ElapsedSeconds = 1; PagesRetrieved = 0; FileSizeKB = 0
+            }
+        )
+
+        $result = @(Get-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:ToDate -OutputPath $TestDrive -AllowPartial -WarningAction SilentlyContinue)
+
+        $result.Count | Should -Be 2
+        @($result.EventId | Sort-Object) | Should -Be @('event-1', 'event-2')
+        @($result.Id | Sort-Object) | Should -Be @('volatile-1', 'volatile-2')
+    }
+
+    It 'retains EventId reuse across timestamps and suppresses only volatile duplicate representations' {
+        if (-not $script:HasStartThreadJob) {
+            Set-ItResult -Skipped -Because 'Start-ThreadJob is unavailable in this session.'
+        }
+        $script:ChunkEvents = @(
+            [PSCustomObject]@{ EventId = 'reused'; Timestamp = '2026-01-01T01:30:00Z'; Id = 'newer'; RowNumber = 1; Description = 'newer description'; Title = 'Stable' },
+            [PSCustomObject]@{ EventId = 'reused'; Timestamp = '2026-01-01T01:00:00Z'; Id = 'first'; RowNumber = 2; Description = 'first description'; Title = 'Stable' },
+            [PSCustomObject]@{ EventId = 'reused'; Timestamp = '2026-01-01T01:00:00Z'; Id = 'second'; RowNumber = 9; Description = 'second description'; Title = 'Stable' }
+        )
+        $script:FakeIdentityTimelineResults = @(
+            [PSCustomObject]@{
+                ChunkIndex = 0; Success = $true; EventCount = 3
+                FromDate = $script:FromDate; ToDate = $script:ToDate
+                ElapsedSeconds = 1; PagesRetrieved = 1; FileSizeKB = 1
+            }
+        )
+
+        $result = @(Get-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate -ToDate $script:ToDate -OutputPath $TestDrive)
+
+        $result.Count | Should -Be 2
+        @($result.Id) | Should -Be @('newer', 'first')
+        @($result.Description) | Should -Be @('newer description', 'first description')
+    }
+
+    It 'fails closed on <Name> unless partial output is explicitly allowed' -ForEach @(
+        @{ Name = 'missing timestamps'; InvalidEvent = [PSCustomObject]@{ EventId = 'invalid-missing'; Title = 'Missing' }; Error = '*missing timestamp*' },
+        @{ Name = 'timestamp parse errors'; InvalidEvent = [PSCustomObject]@{ EventId = 'invalid-parse'; Timestamp = 'not-a-date'; Title = 'Invalid' }; Error = '*timestamp parse error*' }
+    ) {
+        if (-not $script:HasStartThreadJob) {
+            Set-ItResult -Skipped -Because 'Start-ThreadJob is unavailable in this session.'
+        }
+        $script:ChunkEvents = @(
+            [PSCustomObject]@{ EventId = 'valid'; Timestamp = '2026-01-01T01:00:00Z'; Title = 'Valid' },
+            $InvalidEvent
+        )
+        $script:FakeIdentityTimelineResults = @(
+            [PSCustomObject]@{
+                ChunkIndex = 0; Success = $true; EventCount = 2
+                FromDate = $script:FromDate; ToDate = $script:ToDate
+                ElapsedSeconds = 1; PagesRetrieved = 1; FileSizeKB = 1
+            }
+        )
+
+        {
+            Get-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate `
+                -ToDate $script:ToDate -OutputPath $TestDrive
+        } | Should -Throw -ExpectedMessage $Error
+
+        $partialResult = @(Get-XdrIdentityUserTimeline -Upn 'user@contoso.com' -FromDate $script:FromDate `
+                -ToDate $script:ToDate -OutputPath $TestDrive -AllowPartial)
+        $partialResult.Count | Should -Be 1
+        $partialResult[0].EventId | Should -Be 'valid'
+    }
+}


### PR DESCRIPTION
## Summary

- add `Export-XdrIdentityUserTimeline` as a resumable, hash-validated NDJSON exporter
- keep identity pagination separate from the endpoint continuation API
- use timestamp-keyset paging with complete API-second boundary withholding and fail-closed validation
- tune the private default to 12-hour windows and eight workers after repeatable live comparison
- honor HTTP 429 `Retry-After` and expand retry, malformed-response, ordering, range, authentication, and recovery tests

This remains intentionally stacked on `feature/export-endpoint-device-timeline`. The branch now includes the updated stacked base and resolves the prior PR conflict.

## Why

Live investigation found that the undocumented identity timeline API does not behave like the endpoint API:

- both Unix-second bounds are exclusive, but the service can occasionally return a row outside a lower boundary
- offset pages can drift when many records share one timestamp
- `EventId` is reused and is not a durable unique key
- repeated logical records can vary in `Id`, `RowNumber`, and `Description`
- a raw UPN can return an empty timeline when AadId or SID resolution returns real events

The worker therefore always requests `skip = 0`, withholds the complete oldest API-second group from a full page, and advances the exclusive upper timestamp bound. It refuses publication when one second fills the whole page or any response cannot prove completeness.

## Behavior and impact

- selects one identity by UPN, AadId, SID, or RadiusUserId
- supports explicit half-open UTC ranges up to 180 days
- writes fixed 12-hour parts through eight bounded workers with 1,000-row pages
- validates response shape, count, service errors, timestamps, ordering, and range
- records part length/SHA-256, retries, restarts, rewinds, and suppressed representations
- resumes only hash-validated parts and stops new scheduling after authentication failure
- preserves the previous final file throughout `-Force` replacement
- atomically publishes only after all parts and the merged stream validate

Changing the private window size makes older 24-hour manifests intentionally incompatible; rerun with `-Force` or choose a new path.

## Follow-up evidence

The selected dense identity was resolved through the supported UPN-to-AadId workflow and recorded only as fingerprint `c231a8620d45`.

- Dense 30-day range: `2026-07-06T22:54:48.2388087Z` to `2026-08-05T22:54:48.2388087Z`
- Page size 1,000 completed with 23,502 events; the two densest API seconds each held 723 events
- Page sizes 250 and 500 failed closed on two seconds that filled a complete page
- A separate low-volume 30-day range returned the same 335-event canonical set at page sizes 250, 500, and 1,000
- An aligned 7-day matrix of 6/12/24-hour windows and 4/8/16 workers produced the same current 10,070-event canonical set in all nine configurations
- Interleaved 30-day timings were 56.2s and 61.0s for 12h/8 versus 70.8s and 68.2s for 24h/8; every run returned the same 23,502-event canonical set with no retry or restart
- Peak working set was 573-700 MiB for 12h/8 and 658-678 MiB for 24h/8
- A midnight-aligned stress range repeatedly returned a 23:59:59 row outside the service lower bound; every tested window size rejected it after fresh-window restarts

## Validation

Automated:

- identity-focused suites: 38 passed, 0 failed
- combined identity/endpoint export suites after updating the stacked base: 76 passed, 0 failed
- full repository harness after the merge: 20,524 passed, 0 failed, 3 expected platform/coverage skips
- `git diff --check`: clean

Sanitized live-service proof:

- interrupted a 60-window export with 18 completed parts; reconnect resumed all 18 and completed 23,502 rows
- interrupted a `-Force` replacement with 24 completed parts; the prior final SHA-256 remained unchanged, then reconnect resumed all 24
- final exact-commit 7-day proof completed 10,070 rows across 14 windows and 21 pages with 7 safe rewinds, 0 retries, and 0 restarts
- independent final checks passed for half-open range, global descending order, byte length, SHA-256, completed manifest state, and temporary-part cleanup

Raw file hashes can vary because the service regenerates observed volatile representation fields. Canonical payload-set comparisons are used for cross-run completeness evidence.
