### PR TITLE
Add high-fidelity Cloud Apps timeline export

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Get-XdrTenantContext -Force
 | ConvertTo-XdrEncodedAdvancedHuntingQuery                        | Encodes an Advanced Hunting query for use in Microsoft Defender XDR. |
 | Disconnect-XdrEndpointDeviceLiveResponse                        | Closes an active Live Response session in Microsoft Defender XDR. |
 | Export-XdrAzureDataExplorer                                     | Exports pipeline data to Azure Data Explorer using queued ingestion. |
+| Export-XdrCloudAppsActivityTimeline                             | Exports Microsoft Defender for Cloud Apps activity timeline data to NDJSON. |
 | Export-XdrToSentinel                                            | Exports XDR data to a Microsoft Sentinel (Log Analytics) custom table. |
 | Get-XdrActionsCenterHistory                                     | Retrieves historical actions from the Microsoft Defender XDR Action Center. |
 | Get-XdrActionsCenterPending                                     | Retrieves pending actions from the Microsoft Defender XDR Action Center. |
@@ -314,6 +315,12 @@ Get-XdrCloudAppsActivityTimeline -LastNDays 1
 # Push harder for time-sensitive incident response while preserving completeness checks
 Get-XdrCloudAppsActivityTimeline -LastNDays 7 -Aggressive -ExportPath ".\cloud-apps-activity.ndjson" -ExportFormat Ndjson
 
+# Export a large, resumable activity timeline without retaining it in memory
+Export-XdrCloudAppsActivityTimeline `
+    -FromDate (Get-Date).ToUniversalTime().AddDays(-90) `
+    -ToDate (Get-Date).ToUniversalTime() `
+    -Path ".\cloud-apps-activity-90d.ndjson"
+
 # Explore grouped app and discovery surfaces
 Get-XdrCloudAppsApp -Type Discovered -Limit 50
 Get-XdrCloudAppsDiscovery -ListStreams
@@ -323,6 +330,24 @@ Get-XdrCloudAppsConfiguration -Type DiscoveryStream
 Get-XdrCloudAppsGovernance
 Get-XdrCloudAppsPolicy -Type OAuth -Metadata
 ```
+
+`Export-XdrCloudAppsActivityTimeline` writes six-hour recent or archived parts with up to
+eight concurrent workers. It uses timestamp-keyset pagination because the activity APIs
+cap pages at 250 records. Dense recent timestamps are further paginated by creation time;
+dense archived timestamps use bounded, stable-ID-validated offset sweeps because the
+archived API does not expose creation time as a filter. Completed parts are length- and
+SHA-256-validated, so rerunning the same command resumes
+only incomplete or corrupted windows. The final file is published atomically after every
+part and the merged SHA-256 are validated; `-Force` keeps an existing final export in place
+until its replacement is complete.
+
+The Cloud Apps count API is used as a consistency signal, but it is not an exact snapshot
+of the activity list. A shortfall restarts the affected window once with a fresh request
+contexts. Persistent count differences are recorded in the result and manifest as
+`CountDelta`, while the exporter preserves the complete unique payload returned by the
+list API. Exact repeated payloads are suppressed at pagination boundaries. Normal keyset
+pagination retains records that reuse identifiers but differ in content; archived dense
+timestamp recovery requires stable activity IDs to verify convergence.
 
 #### Azure Data Explorer export
 

--- a/XDRInternals/XDRInternals.psd1
+++ b/XDRInternals/XDRInternals.psd1
@@ -73,6 +73,7 @@
         "ConvertTo-XdrEncodedAdvancedHuntingQuery",
         "Disconnect-XdrEndpointDeviceLiveResponse",
         "Export-XdrAzureDataExplorer",
+        "Export-XdrCloudAppsActivityTimeline",
         "Export-XdrToSentinel",
         "Get-XdrActionsCenterHistory",
         "Get-XdrActionsCenterPending",

--- a/XDRInternals/functions/Export-XdrCloudAppsActivityTimeline.ps1
+++ b/XDRInternals/functions/Export-XdrCloudAppsActivityTimeline.ps1
@@ -1,0 +1,681 @@
+﻿function Export-XdrCloudAppsActivityTimeline {
+    <#
+    .SYNOPSIS
+        Exports Microsoft Defender for Cloud Apps activity timeline data to NDJSON.
+
+    .DESCRIPTION
+        Exports a bounded Cloud Apps activity timeline through the Defender XDR portal
+        APIs. The range is divided into fixed, newest-first recent and archived intervals
+        and written to resumable, hash-validated NDJSON parts. Each interval is checked
+        against the matching count API. The final path is published only after every
+        interval succeeds and the complete byte stream is independently verified.
+
+        This cmdlet is intended for large incident-response collections. Use
+        Get-XdrCloudAppsActivityTimeline for smaller in-memory retrieval.
+
+    .PARAMETER FromDate
+        Inclusive beginning of the export range. The value is converted to UTC.
+
+    .PARAMETER ToDate
+        Exclusive end of the export range. The value is converted to UTC.
+
+    .PARAMETER Path
+        Destination NDJSON file. The path must end in .ndjson.
+
+    .PARAMETER Filters
+        Additional Cloud Apps activity filters. The date filter is managed by the
+        exporter and cannot be supplied here. The archived activity API does not
+        support the created filter, so created cannot be used when the range includes
+        archived activity.
+
+    .PARAMETER Force
+        Starts a replacement export when Path or incompatible resumable state exists.
+        An existing final file remains available until the replacement is complete.
+
+    .EXAMPLE
+        Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $to -Path '.\cloud-apps.ndjson'
+        Exports the requested Cloud Apps activity timeline and returns a compact summary.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Cloud Apps is the product name')]
+    [OutputType([PSCustomObject])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [datetime]$FromDate,
+
+        [Parameter(Mandatory)]
+        [datetime]$ToDate,
+
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter()]
+        [hashtable]$Filters = @{},
+
+        [Parameter()]
+        [switch]$Force
+    )
+
+    begin {
+        if ($PSVersionTable.PSVersion.Major -lt 7) {
+            throw 'Export-XdrCloudAppsActivityTimeline requires PowerShell 7 or later.'
+        }
+        Update-XdrConnectionSettings
+    }
+
+    process {
+        $operationStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $rangeStart = $FromDate.ToUniversalTime()
+        $rangeEnd = $ToDate.ToUniversalTime()
+        if ($rangeStart -ge $rangeEnd) {
+            throw 'FromDate must be before ToDate.'
+        }
+        if (($rangeEnd - $rangeStart).TotalDays -gt 180) {
+            throw 'The time range between FromDate and ToDate cannot exceed 180 days.'
+        }
+        if (@($Filters.Keys | Where-Object { [string]$_ -ieq 'date' }).Count -gt 0) {
+            throw 'Filters cannot contain date because the exporter manages the bounded date filter.'
+        }
+
+        $canonicalize = {
+            param($Value)
+
+            if ($Value -is [System.Collections.IDictionary]) {
+                $ordered = [ordered]@{}
+                foreach ($key in @($Value.Keys | Sort-Object)) {
+                    $ordered[[string]$key] = & $canonicalize $Value[$key]
+                }
+                return $ordered
+            }
+            if ($Value -is [System.Management.Automation.PSCustomObject]) {
+                $ordered = [ordered]@{}
+                foreach ($property in @($Value.PSObject.Properties | Sort-Object Name)) {
+                    $ordered[$property.Name] = & $canonicalize $property.Value
+                }
+                return $ordered
+            }
+            if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
+                return @($Value | ForEach-Object { & $canonicalize $_ })
+            }
+            return $Value
+        }
+        $filterJson = (& $canonicalize $Filters) | ConvertTo-Json -Depth 100 -Compress
+        $filterFingerprint = [Convert]::ToHexString(
+            [System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($filterJson))
+        ).ToLowerInvariant()
+
+        $outputPath = [System.IO.Path]::GetFullPath($Path)
+        if ([System.IO.Path]::GetExtension($outputPath) -ine '.ndjson') {
+            throw "Path '$Path' must use the .ndjson extension."
+        }
+        if (Test-Path -LiteralPath $outputPath -PathType Container) {
+            throw "Path '$Path' resolves to a directory."
+        }
+        $outputDirectory = Split-Path -Parent $outputPath
+        if (-not (Test-Path -LiteralPath $outputDirectory)) {
+            New-Item -Path $outputDirectory -ItemType Directory -Force -ErrorAction Stop | Out-Null
+        }
+
+        $manifestPath = "$outputPath.manifest.json"
+        $manifestPartialPath = "$manifestPath.partial"
+        $partsPath = "$outputPath.parts"
+        $outputPartialPath = "$outputPath.partial"
+        $writeManifest = {
+            param($Manifest)
+
+            $Manifest.UpdatedUtc = [datetime]::UtcNow.ToString('o')
+            [System.IO.File]::WriteAllText(
+                $manifestPartialPath,
+                ($Manifest | ConvertTo-Json -Depth 30),
+                [System.Text.UTF8Encoding]::new($false)
+            )
+            [System.IO.File]::Move($manifestPartialPath, $manifestPath, $true)
+        }
+
+        $chunkHours = 6
+        $pageSize = 250
+        $paginationStrategy = 'TimestampKeysetDenseFallbackV1'
+        $throttleLimit = 8
+        $requestTimeoutSeconds = 120
+        $maxRetries = 5
+        $retryDelaySeconds = 1
+        $maxChunkRestarts = 1
+        $maxPagesPerChunk = 10000
+        $baseUrl = 'https://security.microsoft.com'
+        $archiveBoundary = [datetime]::UtcNow.AddDays(-30)
+        if ($rangeStart -lt $archiveBoundary -and @($Filters.Keys | Where-Object { [string]$_ -ieq 'created' }).Count -gt 0) {
+            throw 'Filters cannot contain created when the export includes archived activity because the archived API does not support that filter.'
+        }
+        $manifest = $null
+        $loadedManifest = $false
+        $resumedChunkCount = 0
+        $existingOutputAtStart = Test-Path -LiteralPath $outputPath -PathType Leaf
+
+        if ($Force) {
+            foreach ($staleFile in @($manifestPath, $manifestPartialPath, $outputPartialPath)) {
+                if (Test-Path -LiteralPath $staleFile) {
+                    Remove-Item -LiteralPath $staleFile -Force -ErrorAction Stop
+                }
+            }
+            if (Test-Path -LiteralPath $partsPath) {
+                Remove-Item -LiteralPath $partsPath -Recurse -Force -ErrorAction Stop
+            }
+        }
+        elseif (Test-Path -LiteralPath $manifestPath) {
+            try {
+                $manifest = Get-Content -LiteralPath $manifestPath -Raw -ErrorAction Stop |
+                    ConvertFrom-Json -AsHashtable -Depth 30 -ErrorAction Stop
+            }
+            catch {
+                throw "Manifest '$manifestPath' could not be read. Use -Force to start a new export. $($_.Exception.Message)"
+            }
+            $loadedManifest = $true
+        }
+        elseif ($existingOutputAtStart) {
+            throw "Path '$outputPath' already exists without resumable state. Use -Force to replace it."
+        }
+
+        if ($manifest) {
+            $compatible =
+                [int]$manifest.SchemaVersion -eq 1 -and
+                ([datetime]$manifest.FromDateUtc).ToUniversalTime().Ticks -eq $rangeStart.Ticks -and
+                ([datetime]$manifest.ToDateUtc).ToUniversalTime().Ticks -eq $rangeEnd.Ticks -and
+                [string]$manifest.FilterFingerprint -eq $filterFingerprint -and
+                [int]$manifest.ChunkHours -eq $chunkHours -and
+                [int]$manifest.PageSize -eq $pageSize -and
+                [string]$manifest.PaginationStrategy -eq $paginationStrategy
+            if (-not $compatible) {
+                throw "Manifest '$manifestPath' does not match this request. Use -Force to discard it or choose another Path."
+            }
+        }
+
+        if ($manifest -and [string]$manifest.State -in @('Publishing', 'Complete')) {
+            $expectedBytes = [long]$manifest.Summary.FileBytes
+            $expectedHash = [string]$manifest.Summary.FileSha256
+            $validOutput = $false
+            if (Test-Path -LiteralPath $outputPath -PathType Leaf) {
+                $validOutput = (Get-Item -LiteralPath $outputPath).Length -eq $expectedBytes
+                if ($validOutput) {
+                    $validOutput = (Get-FileHash -LiteralPath $outputPath -Algorithm SHA256).Hash.ToLowerInvariant() -eq $expectedHash
+                }
+            }
+            if (-not $validOutput -and [string]$manifest.State -eq 'Publishing' -and
+                (Test-Path -LiteralPath $outputPartialPath -PathType Leaf)) {
+                $validPartial = (Get-Item -LiteralPath $outputPartialPath).Length -eq $expectedBytes
+                if ($validPartial) {
+                    $validPartial = (Get-FileHash -LiteralPath $outputPartialPath -Algorithm SHA256).Hash.ToLowerInvariant() -eq $expectedHash
+                }
+                if ($validPartial) {
+                    [System.IO.File]::Move($outputPartialPath, $outputPath, $true)
+                    $validOutput = $true
+                }
+            }
+
+            if ($validOutput) {
+                $partsRetained = $false
+                if (Test-Path -LiteralPath $partsPath) {
+                    try { Remove-Item -LiteralPath $partsPath -Recurse -Force -ErrorAction Stop }
+                    catch { $partsRetained = $true }
+                }
+                $manifest.State = 'Complete'
+                $manifest.Summary.PartsRetained = $partsRetained
+                & $writeManifest $manifest
+                return [PSCustomObject]@{
+                    OutputPath = $outputPath; ManifestPath = $manifestPath
+                    TotalEvents = [long]$manifest.Summary.EventCount; TotalPages = [long]$manifest.Summary.PageCount
+                    TotalRetries = [long]$manifest.Summary.RetryCount; TotalChunkRestarts = [long]$manifest.Summary.ChunkRestartCount
+                    TotalPaginationRewinds = [long]$manifest.Summary.PaginationRewindCount
+                    TotalChunks = @($manifest.Chunks).Count; ResumedChunks = @($manifest.Chunks).Count
+                    ArchivedChunks = @($manifest.Chunks | Where-Object Archived).Count
+                    CountLowerBoundChunks = [long]$manifest.Summary.CountLowerBoundChunkCount
+                    CountUnderreportedChunks = [long]$manifest.Summary.CountUnderreportedChunkCount
+                    CountOverreportedChunks = [long]$manifest.Summary.CountOverreportedChunkCount
+                    CountDelta = [long]$manifest.Summary.CountDelta
+                    FileBytes = $expectedBytes; FileSha256 = $expectedHash
+                    MissingTimestampCount = [long]$manifest.Summary.MissingTimestampCount
+                    BoundaryTimestampCount = [long]$manifest.Summary.BoundaryTimestampCount
+                    DuplicateRepresentationCount = [long]$manifest.Summary.DuplicateRepresentationCount
+                    MergeSeconds = [double]$manifest.Summary.MergeSeconds
+                    ElapsedSeconds = [double]$manifest.Summary.ElapsedSeconds
+                    TemporaryPartsRetained = $partsRetained
+                }
+            }
+            if ([string]$manifest.State -eq 'Complete') {
+                throw "Completed export '$outputPath' failed validation. Use -Force to replace it."
+            }
+            $manifest.State = 'InProgress'
+            if (Test-Path -LiteralPath $outputPartialPath) {
+                Remove-Item -LiteralPath $outputPartialPath -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        if (-not $manifest) {
+            $chunks = [System.Collections.Generic.List[object]]::new()
+            $addChunks = {
+                param([datetime]$SegmentStart, [datetime]$SegmentEnd, [bool]$Archived)
+
+                $chunkEnd = $SegmentEnd
+                while ($chunkEnd -gt $SegmentStart) {
+                    $chunkStart = $chunkEnd.AddHours(-$chunkHours)
+                    if ($chunkStart -lt $SegmentStart) { $chunkStart = $SegmentStart }
+                    $index = $chunks.Count
+                    $chunks.Add([PSCustomObject]@{
+                            Index = $index; FromDate = $chunkStart; ToDate = $chunkEnd; Archived = $Archived
+                            DurationTicks = ($chunkEnd - $chunkStart).Ticks
+                            FileName = ('chunk_{0:D4}_{1}_{2:yyyyMMddTHHmmssfffZ}_{3:yyyyMMddTHHmmssfffZ}.ndjson' -f $index, $(if ($Archived) { 'archived' } else { 'recent' }), $chunkStart, $chunkEnd)
+                        })
+                    $chunkEnd = $chunkStart
+                }
+            }
+
+            if ($rangeEnd -gt $archiveBoundary) {
+                $recentStart = if ($rangeStart -gt $archiveBoundary) { $rangeStart } else { $archiveBoundary }
+                & $addChunks $recentStart $rangeEnd $false
+            }
+            if ($rangeStart -lt $archiveBoundary) {
+                $archivedEnd = if ($rangeEnd -lt $archiveBoundary) { $rangeEnd } else { $archiveBoundary }
+                & $addChunks $rangeStart $archivedEnd $true
+            }
+
+            $manifestChunks = @(
+                foreach ($plannedChunk in $chunks) {
+                    [ordered]@{
+                        Index = $plannedChunk.Index; FromDateUtc = $plannedChunk.FromDate.ToString('o')
+                        ToDateUtc = $plannedChunk.ToDate.ToString('o'); Archived = $plannedChunk.Archived
+                        DurationTicks = $plannedChunk.DurationTicks; FileName = $plannedChunk.FileName
+                        Status = 'Pending'; EventCount = 0L; ExpectedEventCount = 0L; CountIsLowerBound = $false
+                        CountDelta = 0L
+                        PageCount = 0; RetryCount = 0; RewindCount = 0; AttemptCount = 0
+                        FileBytes = 0L; FileSha256 = $null; MissingTimestampCount = 0L
+                        BoundaryTimestampCount = 0L; DuplicateRepresentationCount = 0L
+                        ElapsedSeconds = 0.0; Error = $null
+                    }
+                }
+            )
+            $manifest = [ordered]@{
+                SchemaVersion = 1; State = 'InProgress'; FilterFingerprint = $filterFingerprint
+                FromDateUtc = $rangeStart.ToString('o'); ToDateUtc = $rangeEnd.ToString('o')
+                ArchiveBoundaryUtc = $archiveBoundary.ToString('o'); ChunkHours = $chunkHours
+                PageSize = $pageSize; PaginationStrategy = $paginationStrategy
+                Ordering = 'NewestTimeWindowFirst;ApiTimestampDescending'; ReplaceExisting = $existingOutputAtStart
+                CreatedUtc = [datetime]::UtcNow.ToString('o'); UpdatedUtc = [datetime]::UtcNow.ToString('o')
+                Chunks = $manifestChunks; Summary = $null
+            }
+        }
+
+        New-Item -Path $partsPath -ItemType Directory -Force -ErrorAction Stop | Out-Null
+        foreach ($manifestChunk in @($manifest.Chunks)) {
+            if ([string]$manifestChunk.Status -eq 'Completed') {
+                $partPath = Join-Path $partsPath ([string]$manifestChunk.FileName)
+                $validPart = Test-Path -LiteralPath $partPath -PathType Leaf
+                if ($validPart) { $validPart = (Get-Item -LiteralPath $partPath).Length -eq [long]$manifestChunk.FileBytes }
+                if ($validPart) {
+                    $validPart = (Get-FileHash -LiteralPath $partPath -Algorithm SHA256).Hash.ToLowerInvariant() -eq [string]$manifestChunk.FileSha256
+                }
+                if ($validPart) {
+                    $resumedChunkCount++
+                    continue
+                }
+                if (Test-Path -LiteralPath $partPath) { Remove-Item -LiteralPath $partPath -Force -ErrorAction SilentlyContinue }
+            }
+
+            $manifestChunk.Status = 'Pending'; $manifestChunk.EventCount = 0L; $manifestChunk.ExpectedEventCount = 0L
+            $manifestChunk.CountIsLowerBound = $false; $manifestChunk.CountDelta = 0L
+            $manifestChunk.PageCount = 0; $manifestChunk.RetryCount = 0
+            $manifestChunk.RewindCount = 0; $manifestChunk.AttemptCount = 0; $manifestChunk.FileBytes = 0L
+            $manifestChunk.FileSha256 = $null; $manifestChunk.MissingTimestampCount = 0L
+            $manifestChunk.BoundaryTimestampCount = 0L; $manifestChunk.DuplicateRepresentationCount = 0L
+            $manifestChunk.ElapsedSeconds = 0.0; $manifestChunk.Error = $null
+        }
+
+        if ($loadedManifest) {
+            $resumeChunks = [System.Collections.Generic.List[object]]::new()
+            $nextResumeChunkIndex = 1 + [int](($manifest.Chunks | ForEach-Object { [int]$_.Index } | Measure-Object -Maximum).Maximum)
+            foreach ($pendingChunk in @($manifest.Chunks)) {
+                if ([string]$pendingChunk.Status -eq 'Completed') {
+                    $resumeChunks.Add($pendingChunk)
+                    continue
+                }
+                $pendingStart = ([datetime]$pendingChunk.FromDateUtc).ToUniversalTime()
+                $pendingEnd = ([datetime]$pendingChunk.ToDateUtc).ToUniversalTime()
+                $segments = @()
+                if ($pendingEnd -gt $archiveBoundary) {
+                    $recentStart = if ($pendingStart -gt $archiveBoundary) { $pendingStart } else { $archiveBoundary }
+                    $segments += [PSCustomObject]@{ FromDate = $recentStart; ToDate = $pendingEnd; Archived = $false }
+                }
+                if ($pendingStart -lt $archiveBoundary) {
+                    $archivedEnd = if ($pendingEnd -lt $archiveBoundary) { $pendingEnd } else { $archiveBoundary }
+                    $segments += [PSCustomObject]@{ FromDate = $pendingStart; ToDate = $archivedEnd; Archived = $true }
+                }
+
+                $segmentNumber = 0
+                foreach ($segment in $segments) {
+                    if ($segment.FromDate -ge $segment.ToDate) { continue }
+                    $segmentIndex = if ($segmentNumber -eq 0) {
+                        [int]$pendingChunk.Index
+                    }
+                    else {
+                        $assignedIndex = $nextResumeChunkIndex
+                        $nextResumeChunkIndex++
+                        $assignedIndex
+                    }
+                    $routeName = if ([bool]$segment.Archived) { 'archived' } else { 'recent' }
+                    $resumeChunks.Add([PSCustomObject][ordered]@{
+                            Index = $segmentIndex; FromDateUtc = $segment.FromDate.ToString('o'); ToDateUtc = $segment.ToDate.ToString('o')
+                            Archived = [bool]$segment.Archived; DurationTicks = ($segment.ToDate - $segment.FromDate).Ticks
+                            FileName = ('chunk_{0:D4}_{1}_{2:yyyyMMddTHHmmssfffZ}_{3:yyyyMMddTHHmmssfffZ}.ndjson' -f $segmentIndex, $routeName, $segment.FromDate, $segment.ToDate)
+                            Status = 'Pending'; EventCount = 0L; ExpectedEventCount = 0L
+                            CountIsLowerBound = $false; CountDelta = 0L; PageCount = 0; RetryCount = 0
+                            RewindCount = 0; AttemptCount = 0; FileBytes = 0L; FileSha256 = $null
+                            MissingTimestampCount = 0L; BoundaryTimestampCount = 0L
+                            DuplicateRepresentationCount = 0L; ElapsedSeconds = 0.0; Error = $null
+                        })
+                    $segmentNumber++
+                }
+            }
+
+            $resumeChunkArray = [object[]]::new($resumeChunks.Count)
+            $resumeChunks.CopyTo($resumeChunkArray)
+            $manifest.Chunks = $resumeChunkArray
+            $manifest.ArchiveBoundaryUtc = $archiveBoundary.ToString('o')
+        }
+        $manifest.State = 'InProgress'
+        & $writeManifest $manifest
+
+        $cookieData = @(
+            foreach ($cookie in $script:session.Cookies.GetCookies([uri]$baseUrl)) {
+                [PSCustomObject]@{ Name = $cookie.Name; Value = $cookie.Value; Domain = $cookie.Domain; Path = $cookie.Path }
+            }
+        )
+        $headersData = @{}
+        foreach ($headerName in $script:headers.Keys) { $headersData[$headerName] = $script:headers[$headerName] }
+        $sharedParameters = @{
+            BaseUrl = $baseUrl; Filters = $Filters; PageSize = $pageSize; MaxRetries = $maxRetries
+            RequestTimeoutSeconds = $requestTimeoutSeconds; MaxPagesPerChunk = $maxPagesPerChunk
+            RetryDelaySeconds = $retryDelaySeconds
+            MaxCountMismatchRestarts = $maxChunkRestarts
+            PartsPath = $partsPath; CookieData = $cookieData; HeadersData = $headersData
+        }
+        $pendingChunks = @(
+            foreach ($manifestChunk in @($manifest.Chunks | Where-Object Status -eq 'Pending')) {
+                [PSCustomObject]@{
+                    Index = [int]$manifestChunk.Index; FromDate = [datetime]$manifestChunk.FromDateUtc
+                    ToDate = [datetime]$manifestChunk.ToDateUtc; Archived = [bool]$manifestChunk.Archived
+                    DurationTicks = [long]$manifestChunk.DurationTicks; FileName = [string]$manifestChunk.FileName
+                    Attempt = [int]$manifestChunk.AttemptCount
+                }
+            }
+        )
+
+        $totalChunkCount = @($manifest.Chunks).Count
+        $totalDurationTicks = [long](($manifest.Chunks | ForEach-Object { [long]$_.DurationTicks } | Measure-Object -Sum).Sum)
+        $initialCompletedTicks = [long](($manifest.Chunks | Where-Object Status -eq 'Completed' | ForEach-Object { [long]$_.DurationTicks } | Measure-Object -Sum).Sum)
+        Write-Information "Cloud Apps activity timeline export: $totalChunkCount $chunkHours-hour window(s), $resumedChunkCount resumed, throttle=$throttleLimit, output='$outputPath'." -InformationAction Continue
+
+        $workerScriptText = (New-XdrCloudAppsActivityTimelineExportWorker).ToString()
+        $statusMap = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+        $chunkQueue = [System.Collections.Generic.Queue[object]]::new()
+        foreach ($pendingChunk in $pendingChunks) { $chunkQueue.Enqueue($pendingChunk) }
+        $runspacePool = [runspacefactory]::CreateRunspacePool(1, $throttleLimit)
+        $activeJobs = [System.Collections.Generic.List[object]]::new()
+        $failureResults = [System.Collections.Generic.List[object]]::new()
+        $completedDuringRunTicks = 0L
+        $lastProgressUpdate = [datetime]::MinValue
+        $lastHeartbeat = [datetime]::UtcNow
+        $stopScheduling = $false
+        $capturedError = $null
+
+        $startChunkJob = {
+            param($Chunk)
+            $powerShell = [powershell]::Create()
+            $powerShell.RunspacePool = $runspacePool
+            [void]$powerShell.AddScript($workerScriptText)
+            [void]$powerShell.AddParameter('chunk', $Chunk)
+            [void]$powerShell.AddParameter('sharedParameters', $sharedParameters)
+            [void]$powerShell.AddParameter('statusMap', $statusMap)
+            [PSCustomObject]@{ PowerShell = $powerShell; Handle = $powerShell.BeginInvoke(); Chunk = $Chunk }
+        }
+
+        try {
+            $runspacePool.Open()
+            while ($chunkQueue.Count -gt 0 -and $activeJobs.Count -lt $throttleLimit) {
+                $activeJobs.Add((& $startChunkJob $chunkQueue.Dequeue()))
+            }
+            while ($activeJobs.Count -gt 0) {
+                $completedJobs = @($activeJobs | Where-Object { $_.Handle.IsCompleted })
+                foreach ($job in $completedJobs) {
+                    try {
+                        $jobOutput = @($job.PowerShell.EndInvoke($job.Handle))
+                        $result = $jobOutput | Select-Object -Last 1
+                        if (-not $result) { throw "Chunk $($job.Chunk.Index) returned no result." }
+                    }
+                    catch {
+                        $result = [PSCustomObject]@{
+                            Success = $false; ChunkIndex = [int]$job.Chunk.Index; EventCount = 0L
+                            ExpectedEventCount = 0L; CountIsLowerBound = $false; CountDelta = 0L; PageCount = 0
+                            RetryCount = 0; RewindCount = 0; FileBytes = 0L; FileSha256 = $null
+                            MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.0
+                            DuplicateRepresentationCount = 0L
+                            Error = $_.Exception.Message; FailureClass = 'WorkerFailure'
+                        }
+                    }
+                    finally {
+                        $job.PowerShell.Dispose()
+                        [void]$activeJobs.Remove($job)
+                    }
+
+                    $manifestChunk = @($manifest.Chunks | Where-Object { [int]$_.Index -eq [int]$result.ChunkIndex })[0]
+                    $manifestChunk.RetryCount = [int]$manifestChunk.RetryCount + [int]$result.RetryCount
+                    $manifestChunk.RewindCount = [int]$manifestChunk.RewindCount + [int]$result.RewindCount
+                    $manifestChunk.DuplicateRepresentationCount = [long]$manifestChunk.DuplicateRepresentationCount + [long]$result.DuplicateRepresentationCount
+                    $manifestChunk.AttemptCount = [int]$job.Chunk.Attempt
+                    $manifestChunk.ElapsedSeconds = [double]$manifestChunk.ElapsedSeconds + [double]$result.ElapsedSeconds
+
+                    if ($result.Success) {
+                        $manifestChunk.Status = 'Completed'; $manifestChunk.EventCount = [long]$result.EventCount
+                        $manifestChunk.ExpectedEventCount = [long]$result.ExpectedEventCount
+                        $manifestChunk.CountIsLowerBound = [bool]$result.CountIsLowerBound
+                        $manifestChunk.CountDelta = [long]$result.CountDelta
+                        $manifestChunk.PageCount = [int]$result.PageCount; $manifestChunk.FileBytes = [long]$result.FileBytes
+                        $manifestChunk.FileSha256 = [string]$result.FileSha256
+                        $manifestChunk.MissingTimestampCount = [long]$result.MissingTimestampCount
+                        $manifestChunk.BoundaryTimestampCount = [long]$result.BoundaryTimestampCount
+                        $manifestChunk.Error = $null
+                        $completedDuringRunTicks += [long]$manifestChunk.DurationTicks
+                    }
+                    elseif ([string]$result.FailureClass -in @('PartialResponse', 'TransientHttp', 'Transport', 'Protocol') -and
+                        [int]$job.Chunk.Attempt -lt $maxChunkRestarts) {
+                        $nextAttempt = [int]$job.Chunk.Attempt + 1
+                        $manifestChunk.Status = 'Pending'; $manifestChunk.AttemptCount = $nextAttempt
+                        $manifestChunk.EventCount = 0L; $manifestChunk.ExpectedEventCount = 0L
+                        $manifestChunk.CountIsLowerBound = $false; $manifestChunk.CountDelta = 0L
+                        $manifestChunk.PageCount = 0
+                        $manifestChunk.FileBytes = 0L; $manifestChunk.FileSha256 = $null
+                        $manifestChunk.MissingTimestampCount = 0L; $manifestChunk.BoundaryTimestampCount = 0L
+                        $manifestChunk.DuplicateRepresentationCount = 0L
+                        $manifestChunk.Error = $result.Error
+                        $chunkQueue.Enqueue([PSCustomObject]@{
+                                Index = [int]$manifestChunk.Index; FromDate = [datetime]$manifestChunk.FromDateUtc
+                                ToDate = [datetime]$manifestChunk.ToDateUtc; Archived = [bool]$manifestChunk.Archived
+                                DurationTicks = [long]$manifestChunk.DurationTicks; FileName = [string]$manifestChunk.FileName
+                                Attempt = $nextAttempt
+                            })
+                        Write-Information "Restarting Cloud Apps activity window $($manifestChunk.Index) with a fresh request context after $($result.FailureClass)." -InformationAction Continue
+                    }
+                    else {
+                        $manifestChunk.Status = 'Failed'; $manifestChunk.Error = $result.Error
+                        $failureResults.Add($result); $stopScheduling = $true
+                    }
+                    & $writeManifest $manifest
+
+                    while (-not $stopScheduling -and $chunkQueue.Count -gt 0 -and $activeJobs.Count -lt $throttleLimit) {
+                        $activeJobs.Add((& $startChunkJob $chunkQueue.Dequeue()))
+                    }
+                }
+
+                $now = [datetime]::UtcNow
+                if (($now - $lastProgressUpdate).TotalSeconds -ge 2) {
+                    $completedTicks = $initialCompletedTicks + $completedDuringRunTicks
+                    $percent = if ($totalDurationTicks -gt 0) { [math]::Min(100, [math]::Round(100 * $completedTicks / $totalDurationTicks, 1)) } else { 100 }
+                    $completedCount = @($manifest.Chunks | Where-Object Status -eq 'Completed').Count
+                    $activeEvents = [long](($statusMap.Values | ForEach-Object { [long]$_.Events } | Measure-Object -Sum).Sum)
+                    Write-Progress -Activity 'Exporting XDR Cloud Apps activity timeline' -Status "Completed $completedCount/$totalChunkCount windows; active events $activeEvents" -PercentComplete $percent
+                    $lastProgressUpdate = $now
+                }
+                if (($now - $lastHeartbeat).TotalSeconds -ge 30) {
+                    $completedCount = @($manifest.Chunks | Where-Object Status -eq 'Completed').Count
+                    Write-Information "Cloud Apps activity timeline heartbeat: windows $completedCount/$totalChunkCount; active $($activeJobs.Count); queued $($chunkQueue.Count); elapsed $($operationStopwatch.Elapsed.ToString('c'))." -InformationAction Continue
+                    $lastHeartbeat = $now
+                }
+                if ($completedJobs.Count -eq 0) { Start-Sleep -Milliseconds 200 }
+            }
+        }
+        catch { $capturedError = $_ }
+        finally {
+            foreach ($job in @($activeJobs)) {
+                try { $job.PowerShell.Stop() } catch { Write-Verbose "Could not stop chunk $($job.Chunk.Index): $_" }
+                $job.PowerShell.Dispose()
+            }
+            $activeJobs.Clear(); $runspacePool.Close(); $runspacePool.Dispose()
+            Write-Progress -Activity 'Exporting XDR Cloud Apps activity timeline' -Completed
+        }
+
+        if ($capturedError) {
+            $manifest.State = 'Failed'; $manifest.Summary = [ordered]@{ Error = $capturedError.Exception.Message }
+            & $writeManifest $manifest
+            throw $capturedError
+        }
+        if ($failureResults.Count -gt 0 -or $chunkQueue.Count -gt 0) {
+            $manifest.State = 'Failed'
+            $manifest.Summary = [ordered]@{
+                FailedChunkCount = $failureResults.Count
+                Errors = @($failureResults | ForEach-Object { "chunk $($_.ChunkIndex): $($_.Error)" })
+            }
+            & $writeManifest $manifest
+            throw "Cloud Apps activity timeline export failed. Completed parts were preserved for resume. $($manifest.Summary.Errors -join '; ')"
+        }
+        if (@($manifest.Chunks | Where-Object Status -ne 'Completed').Count -gt 0) {
+            throw 'Cloud Apps activity timeline export has incomplete windows; the final file was not published.'
+        }
+
+        $orderedParts = @(
+            foreach ($manifestChunk in @($manifest.Chunks)) {
+                [PSCustomObject]@{
+                    FilePath = Join-Path $partsPath ([string]$manifestChunk.FileName)
+                    FileSha256 = [string]$manifestChunk.FileSha256; EventCount = [long]$manifestChunk.EventCount
+                }
+            }
+        )
+        $totalPartBytes = [long](($manifest.Chunks | ForEach-Object { [long]$_.FileBytes } | Measure-Object -Sum).Sum)
+        $requiredMergeBytes = $totalPartBytes + [long][math]::Max([long]64MB, [long][math]::Ceiling($totalPartBytes * 0.05))
+        $outputDrive = [System.IO.DriveInfo]::new([System.IO.Path]::GetPathRoot($outputPath))
+        if ($outputDrive.AvailableFreeSpace -lt $requiredMergeBytes) {
+            $manifest.State = 'Failed'; $manifest.Summary = [ordered]@{ Error = 'Insufficient disk space to finalize the Cloud Apps activity timeline export.' }
+            & $writeManifest $manifest
+            throw "Finalizing the Cloud Apps activity timeline requires at least $([math]::Round($requiredMergeBytes / 1GB, 2)) GiB free. Completed parts were preserved for resume."
+        }
+
+        if (Test-Path -LiteralPath $outputPartialPath) { Remove-Item -LiteralPath $outputPartialPath -Force }
+        $mergeStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $destination = $null
+        $outputHasher = $null
+        $hashingDestination = $null
+        try {
+            $destination = [System.IO.FileStream]::new(
+                $outputPartialPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write,
+                [System.IO.FileShare]::None, 1MB, [System.IO.FileOptions]::SequentialScan
+            )
+            $outputHasher = [System.Security.Cryptography.SHA256]::Create()
+            $hashingDestination = [System.Security.Cryptography.CryptoStream]::new(
+                $destination, $outputHasher, [System.Security.Cryptography.CryptoStreamMode]::Write, $true
+            )
+            foreach ($partItem in $orderedParts) {
+                $source = $null; $partHasher = $null; $hashingSource = $null
+                try {
+                    $source = [System.IO.FileStream]::new(
+                        [string]$partItem.FilePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read,
+                        [System.IO.FileShare]::Read, 1MB, [System.IO.FileOptions]::SequentialScan
+                    )
+                    $partHasher = [System.Security.Cryptography.SHA256]::Create()
+                    $hashingSource = [System.Security.Cryptography.CryptoStream]::new(
+                        $source, $partHasher, [System.Security.Cryptography.CryptoStreamMode]::Read, $true
+                    )
+                    $hashingSource.CopyTo($hashingDestination, 1MB)
+                }
+                finally {
+                    if ($hashingSource) { $hashingSource.Dispose() }
+                    if ($source) { $source.Dispose() }
+                }
+                $actualPartHash = [Convert]::ToHexString($partHasher.Hash).ToLowerInvariant()
+                $partHasher.Dispose()
+                if ($actualPartHash -ne [string]$partItem.FileSha256) {
+                    throw "Timeline part '$($partItem.FilePath)' failed SHA-256 validation."
+                }
+            }
+            $hashingDestination.FlushFinalBlock(); $hashingDestination.Dispose(); $hashingDestination = $null
+            $destination.Flush($true); $destination.Dispose(); $destination = $null
+            $mergedFileHash = [Convert]::ToHexString($outputHasher.Hash).ToLowerInvariant()
+        }
+        finally {
+            if ($hashingDestination) { $hashingDestination.Dispose() }
+            if ($outputHasher) { $outputHasher.Dispose() }
+            if ($destination) { $destination.Dispose() }
+        }
+        $mergeStopwatch.Stop()
+
+        $totalEvents = [long](($manifest.Chunks | ForEach-Object { [long]$_.EventCount } | Measure-Object -Sum).Sum)
+        $totalPages = [long](($manifest.Chunks | ForEach-Object { [long]$_.PageCount } | Measure-Object -Sum).Sum)
+        $totalRetries = [long](($manifest.Chunks | ForEach-Object { [long]$_.RetryCount } | Measure-Object -Sum).Sum)
+        $totalRewinds = [long](($manifest.Chunks | ForEach-Object { [long]$_.RewindCount } | Measure-Object -Sum).Sum)
+        $totalRestarts = [long](($manifest.Chunks | ForEach-Object { [long]$_.AttemptCount } | Measure-Object -Sum).Sum)
+        $missingTimestampCount = [long](($manifest.Chunks | ForEach-Object { [long]$_.MissingTimestampCount } | Measure-Object -Sum).Sum)
+        $boundaryTimestampCount = [long](($manifest.Chunks | ForEach-Object { [long]$_.BoundaryTimestampCount } | Measure-Object -Sum).Sum)
+        $duplicateRepresentationCount = [long](($manifest.Chunks | ForEach-Object { [long]$_.DuplicateRepresentationCount } | Measure-Object -Sum).Sum)
+        $countLowerBoundChunkCount = @($manifest.Chunks | Where-Object CountIsLowerBound).Count
+        $countUnderreportedChunkCount = @($manifest.Chunks | Where-Object { [long]$_.CountDelta -gt 0 }).Count
+        $countOverreportedChunkCount = @($manifest.Chunks | Where-Object { [long]$_.CountDelta -lt 0 }).Count
+        $countDelta = [long](($manifest.Chunks | ForEach-Object { [long]$_.CountDelta } | Measure-Object -Sum).Sum)
+        $operationStopwatch.Stop()
+        $manifest.State = 'Publishing'
+        $manifest.Summary = [ordered]@{
+            OutputPath = $outputPath; EventCount = $totalEvents; PageCount = $totalPages
+            RetryCount = $totalRetries; ChunkRestartCount = $totalRestarts; PaginationRewindCount = $totalRewinds
+            FileBytes = (Get-Item -LiteralPath $outputPartialPath).Length; FileSha256 = $mergedFileHash
+            MissingTimestampCount = $missingTimestampCount; BoundaryTimestampCount = $boundaryTimestampCount
+            DuplicateRepresentationCount = $duplicateRepresentationCount
+            CountLowerBoundChunkCount = $countLowerBoundChunkCount; ResumedChunkCount = $resumedChunkCount
+            CountUnderreportedChunkCount = $countUnderreportedChunkCount; CountDelta = $countDelta
+            CountOverreportedChunkCount = $countOverreportedChunkCount
+            PartsRetained = $true; MergeSeconds = [math]::Round($mergeStopwatch.Elapsed.TotalSeconds, 3)
+            ElapsedSeconds = [math]::Round($operationStopwatch.Elapsed.TotalSeconds, 3)
+            CompletedUtc = [datetime]::UtcNow.ToString('o')
+        }
+        & $writeManifest $manifest
+        [System.IO.File]::Move($outputPartialPath, $outputPath, $true)
+
+        $partsRetained = $false
+        try { Remove-Item -LiteralPath $partsPath -Recurse -Force -ErrorAction Stop }
+        catch {
+            $partsRetained = $true
+            Write-Warning "The export completed, but temporary parts could not be removed from '$partsPath': $($_.Exception.Message)"
+        }
+        $manifest.State = 'Complete'; $manifest.Summary.PartsRetained = $partsRetained
+        & $writeManifest $manifest
+
+        Write-Information "Cloud Apps activity timeline export complete: $totalEvents events, $totalChunkCount windows, $([math]::Round($manifest.Summary.FileBytes / 1MB, 2)) MiB." -InformationAction Continue
+        [PSCustomObject]@{
+            OutputPath = $outputPath; ManifestPath = $manifestPath; TotalEvents = $totalEvents
+            TotalPages = $totalPages; TotalRetries = $totalRetries; TotalChunkRestarts = $totalRestarts
+            TotalPaginationRewinds = $totalRewinds; TotalChunks = $totalChunkCount; ResumedChunks = $resumedChunkCount
+            ArchivedChunks = @($manifest.Chunks | Where-Object Archived).Count
+            CountLowerBoundChunks = $countLowerBoundChunkCount; CountUnderreportedChunks = $countUnderreportedChunkCount
+            CountOverreportedChunks = $countOverreportedChunkCount; CountDelta = $countDelta
+            FileBytes = [long]$manifest.Summary.FileBytes
+            FileSha256 = $mergedFileHash; MissingTimestampCount = $missingTimestampCount
+            BoundaryTimestampCount = $boundaryTimestampCount; DuplicateRepresentationCount = $duplicateRepresentationCount
+            MergeSeconds = [math]::Round($mergeStopwatch.Elapsed.TotalSeconds, 3)
+            ElapsedSeconds = [math]::Round($operationStopwatch.Elapsed.TotalSeconds, 3)
+            TemporaryPartsRetained = $partsRetained
+        }
+    }
+}

--- a/XDRInternals/functions/Get-XdrCloudAppsActivityTimeline.ps1
+++ b/XDRInternals/functions/Get-XdrCloudAppsActivityTimeline.ps1
@@ -1,4 +1,4 @@
-﻿function Read-XdrCloudAppsActivityChunkFile {
+﻿function Read-XdrCloudAppsActivityPartFile {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
@@ -8,21 +8,27 @@
         [switch]$AllowPartial
     )
 
+    $lineNumber = 0
     try {
-        $json = Get-Content -Path $File.FullName -Raw -ErrorAction Stop
-        if ((Get-Command ConvertFrom-Json -ErrorAction Stop).Parameters.ContainsKey('AsHashtable')) {
-            return $json | ConvertFrom-Json -AsHashtable -ErrorAction Stop
-        }
+        foreach ($line in [System.IO.File]::ReadLines($File.FullName)) {
+            $lineNumber++
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
 
-        Add-Type -AssemblyName System.Web.Extensions -ErrorAction Stop
-        $serializer = New-Object System.Web.Script.Serialization.JavaScriptSerializer
-        $serializer.MaxJsonLength = [int]::MaxValue
-        return $serializer.DeserializeObject($json)
+            if ((Get-Command ConvertFrom-Json -ErrorAction Stop).Parameters.ContainsKey('AsHashtable')) {
+                $line | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+            }
+            else {
+                Add-Type -AssemblyName System.Web.Extensions -ErrorAction Stop
+                $serializer = New-Object System.Web.Script.Serialization.JavaScriptSerializer
+                $serializer.MaxJsonLength = [int]::MaxValue
+                $serializer.DeserializeObject($line)
+            }
+        }
     }
     catch {
         if ($AllowPartial) {
-            Write-Warning "Skipping unreadable Cloud Apps activity chunk file '$($File.Name)': $($_.Exception.Message)"
-            return $null
+            Write-Warning "Skipping unreadable Cloud Apps activity part '$($File.Name)' at line $lineNumber`: $($_.Exception.Message)"
+            return
         }
 
         throw
@@ -101,13 +107,6 @@ function Get-XdrCloudAppsActivityStableKey {
         [System.Security.Cryptography.SHA256]$Sha256
     )
 
-    foreach ($name in @('_id', 'id', 'recordId')) {
-        $value = Get-XdrCloudAppsObjectValue -InputObject $Activity -Name $name
-        if ($value) {
-            return [string]$value
-        }
-    }
-
     $stableJson = $Activity | ConvertTo-Json -Depth 20 -Compress
     return [System.BitConverter]::ToString($Sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($stableJson))).Replace('-', '')
 }
@@ -120,6 +119,8 @@ function Get-XdrCloudAppsActivityTimeline {
     .DESCRIPTION
         Retrieves Cloud Apps activity events with reliable chunking, retry handling,
         recent/archived API routing, export support, and typed admin-friendly output.
+        Bounded requests reuse the same endpoint-specific pagination worker as
+        Export-XdrCloudAppsActivityTimeline.
 
     .PARAMETER Metadata
         Returns filter metadata for the recent activities API.
@@ -131,7 +132,9 @@ function Get-XdrCloudAppsActivityTimeline {
         Returns raw API metadata or response data when supported.
 
     .PARAMETER CountOnly
-        Returns activity counts without retrieving full activity records.
+        Returns activity count snapshots without retrieving full activity records.
+        The Cloud Apps count API is a diagnostic consistency signal and may not
+        exactly match a concurrently changing activity-list query.
 
     .PARAMETER FromDate
         Start of the timeline range.
@@ -146,7 +149,9 @@ function Get-XdrCloudAppsActivityTimeline {
         Number of activities to request per page.
 
     .PARAMETER Filters
-        Cloud Apps activity filters to include in the query body.
+        Cloud Apps activity filters to include in the query body. For bounded
+        requests, the date filter is managed by this command and cannot be supplied.
+        The created filter cannot be used when the range includes archived activity.
 
     .PARAMETER IncludeThreatScores
         Adds threat score data for recent activities when available.
@@ -358,6 +363,12 @@ function Get-XdrCloudAppsActivityTimeline {
             if ($rangeDays -gt $maxDaysTotal) {
                 throw "Date range cannot exceed $maxDaysTotal days. Requested range: $([math]::Round($rangeDays, 1)) days."
             }
+            if (@($Filters.Keys | Where-Object { [string]$_ -ieq 'date' }).Count -gt 0) {
+                throw 'Filters cannot contain date for a bounded request because the command manages the date filter.'
+            }
+            if ($FromDate -lt $regularBoundaryUtc -and @($Filters.Keys | Where-Object { [string]$_ -ieq 'created' }).Count -gt 0) {
+                throw 'Filters cannot contain created when the request includes archived activity because the archived API does not support that filter.'
+            }
         }
 
         if ($Aggressive) {
@@ -446,6 +457,9 @@ function Get-XdrCloudAppsActivityTimeline {
                     ToDate   = $chunkEnd
                     Archived = $Archived
                     Index    = $dateChunks.Count
+                    DurationTicks = ($chunkEnd - $cursor).Ticks
+                    FileName = ('chunk_{0:D4}_{1}_{2:yyyyMMddTHHmmssfffZ}_{3:yyyyMMddTHHmmssfffZ}.ndjson' -f $dateChunks.Count, $(if ($Archived) { 'archived' } else { 'recent' }), $cursor, $chunkEnd)
+                    Attempt  = 0
                 })
                 $cursor = $chunkEnd
             }
@@ -470,162 +484,36 @@ function Get-XdrCloudAppsActivityTimeline {
         foreach ($key in $script:headers.Keys) { $headersData[$key] = $script:headers[$key] }
 
         $baseParams = @{
-            RegularApiPath        = "https://security.microsoft.com/apiproxy$regularApiPath"
-            ArchivedApiPath       = "https://security.microsoft.com/apiproxy$archivedApiPath"
+            BaseUrl               = $xdrBaseUrl
             Filters               = $Filters
             PageSize              = $PageSize
             MaxRetries            = $MaxRetries
             RetryDelaySeconds     = $RetryDelaySeconds
             RequestTimeoutSeconds = $RequestTimeoutSeconds
-            TempPath              = $runTempPath
+            MaxPagesPerChunk      = 10000
+            MaxCountMismatchRestarts = 1
+            PartsPath             = $runTempPath
+            CookieData            = $cookieData
+            HeadersData           = $headersData
         }
 
+        $workerScriptText = (New-XdrCloudAppsActivityTimelineExportWorker).ToString()
+        $statusMap = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
         $chunkScript = {
-            param($Chunk, $Params, $CookieInfo, $HeaderInfo)
+            param($Chunk, $Params, $StatusMap, $WorkerText)
 
-            $webSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
-            foreach ($c in $CookieInfo) {
-                $webSession.Cookies.Add([System.Net.Cookie]::new($c.Name, $c.Value, $c.Path, $c.Domain))
-            }
-
-            $chunkStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-            $fileName = 'chunk_{0:D4}_{1:yyyyMMdd_HHmmss}_{2:yyyyMMdd_HHmmss}.json' -f $Chunk.Index, $Chunk.FromDate, $Chunk.ToDate
-            $filePath = Join-Path $Params.TempPath $fileName
-            $progressPath = Join-Path $Params.TempPath ('progress_{0:D4}.txt' -f $Chunk.Index)
-            $writer = $null
-            $eventCount = 0
-            $pagesRetrieved = 0
-            $retryCount = 0
-            $retryErrors = [System.Collections.Generic.List[string]]::new()
-
-            try {
-                $uri = if ($Chunk.Archived) { $Params.ArchivedApiPath } else { $Params.RegularApiPath }
-                $epochStart = [long]($Chunk.FromDate.ToUniversalTime() - [datetime]'1970-01-01').TotalMilliseconds
-                $epochEnd = [long]($Chunk.ToDate.ToUniversalTime() - [datetime]'1970-01-01').TotalMilliseconds
-                $filters = $Params.Filters.Clone()
-                if ($Chunk.Archived) {
-                    $filters.date = @{ range = @( @{ start = $epochStart; end = $epochEnd } ) }
+            $worker = [scriptblock]::Create($WorkerText)
+            do {
+                $result = & $worker -chunk $Chunk -sharedParameters $Params -statusMap $StatusMap
+                if ($result.Success -or
+                    [string]$result.FailureClass -notin @('PartialResponse', 'TransientHttp', 'Transport', 'Protocol') -or
+                    [int]$Chunk.Attempt -ge [int]$Params.MaxCountMismatchRestarts) {
+                    break
                 }
-                else {
-                    $filters.date = @{ gte = $epochStart; lte = $epochEnd }
-                }
+                $Chunk.Attempt = [int]$Chunk.Attempt + 1
+            } while ($true)
 
-                $writer = [System.IO.StreamWriter]::new($filePath, $false, [System.Text.Encoding]::UTF8)
-                $writer.Write('{"ChunkIndex":' + $Chunk.Index + ',"FromDate":"' + $Chunk.FromDate.ToString('o') + '","ToDate":"' + $Chunk.ToDate.ToString('o') + '","Archived":' + $Chunk.Archived.ToString().ToLowerInvariant() + ',"Events":[')
-                $first = $true
-                $skip = 0
-                $hasMore = $true
-                while ($hasMore -and $pagesRetrieved -lt 10000) {
-                    $body = @{
-                        distributedId     = [guid]::NewGuid().ToString()
-                        filters           = $filters
-                        limit             = $Params.PageSize
-                        performAsyncTotal = $true
-                        skip              = $skip
-                        sortDirection     = 'desc'
-                        sortField         = 'date'
-                    } | ConvertTo-Json -Depth 20 -Compress
-
-                    $attempt = 0
-                    $response = $null
-                    while ($attempt -lt $Params.MaxRetries) {
-                        $attempt++
-                        try {
-                            $response = Invoke-RestMethod -Uri $uri -Method Post -Body $body -ContentType 'application/json' -WebSession $webSession -Headers $HeaderInfo -TimeoutSec $Params.RequestTimeoutSeconds -ErrorAction Stop
-                            break
-                        }
-                        catch {
-                            $statusCode = $null
-                            if ($_.Exception.Response) { $statusCode = [int]$_.Exception.Response.StatusCode }
-                            if ($attempt -ge $Params.MaxRetries) { throw }
-                            $retryCount++
-                            $delay = [math]::Min(300, [int]($Params.RetryDelaySeconds * [math]::Pow(2, $attempt - 1)))
-                            if ($statusCode -eq 429 -or $statusCode -eq 403) { $delay = [math]::Max($delay, 30) }
-                            $delay += Get-Random -Minimum 0 -Maximum 5
-                            $retryErrors.Add("Page $pagesRetrieved attempt $attempt failed: $($_.Exception.Message)")
-                            Start-Sleep -Seconds $delay
-                        }
-                    }
-
-                    if ($response -is [string] -and -not [string]::IsNullOrWhiteSpace($response)) {
-                        if ((Get-Command ConvertFrom-Json -ErrorAction Stop).Parameters.ContainsKey('AsHashtable')) {
-                            $response = $response | ConvertFrom-Json -AsHashtable -ErrorAction Stop
-                        }
-                        else {
-                            Add-Type -AssemblyName System.Web.Extensions -ErrorAction Stop
-                            $serializer = New-Object System.Web.Script.Serialization.JavaScriptSerializer
-                            $serializer.MaxJsonLength = [int]::MaxValue
-                            $response = $serializer.DeserializeObject($response)
-                        }
-                    }
-                    $responseData = if ($response -is [System.Collections.IDictionary]) { $response['data'] } else { $response.data }
-                    if ($null -ne $responseData) {
-                        foreach ($item in @($responseData)) {
-                            if ($null -eq $item) {
-                                continue
-                            }
-
-                            if (-not $first) { $writer.Write(',') }
-                            $writer.Write(($item | ConvertTo-Json -Depth 20 -Compress))
-                            $first = $false
-                            $eventCount++
-                        }
-                    }
-                    $pagesRetrieved++
-                    Set-Content -Path $progressPath -Value $pagesRetrieved -Encoding UTF8
-                    $hasMoreValue = if ($response -is [System.Collections.IDictionary]) { $response['hasNext'] } else { $response.hasNext }
-                    $hasMore = $hasMoreValue -eq $true
-                    $skip += $Params.PageSize
-                }
-                $writer.Write('],"EventCount":' + $eventCount + '}')
-                $writer.Close()
-                $writer.Dispose()
-                $writer = $null
-                $chunkStopwatch.Stop()
-
-                [PSCustomObject]@{
-                    ChunkIndex     = $Chunk.Index
-                    FromDate       = $Chunk.FromDate
-                    ToDate         = $Chunk.ToDate
-                    Archived       = $Chunk.Archived
-                    FilePath       = $filePath
-                    EventCount     = $eventCount
-                    PagesRetrieved = $pagesRetrieved
-                    RetryCount     = $retryCount
-                    RetryErrors    = $retryErrors.ToArray()
-                    FileSizeKB     = [math]::Round((Get-Item $filePath).Length / 1KB, 2)
-                    ElapsedSeconds = [math]::Round($chunkStopwatch.Elapsed.TotalSeconds, 2)
-                    Success        = $true
-                }
-            }
-            catch {
-                if ($writer) {
-                    try {
-                        $writer.Dispose()
-                    }
-                    catch {
-                        Write-Verbose "Failed to dispose Cloud Apps activity chunk writer: $($_.Exception.Message)"
-                    }
-                }
-                $chunkStopwatch.Stop()
-                [PSCustomObject]@{
-                    ChunkIndex     = $Chunk.Index
-                    FromDate       = $Chunk.FromDate
-                    ToDate         = $Chunk.ToDate
-                    Archived       = $Chunk.Archived
-                    FilePath       = $filePath
-                    EventCount     = $eventCount
-                    PagesRetrieved = $pagesRetrieved
-                    RetryCount     = $retryCount
-                    RetryErrors    = $retryErrors.ToArray()
-                    ElapsedSeconds = [math]::Round($chunkStopwatch.Elapsed.TotalSeconds, 2)
-                    Success        = $false
-                    Error          = $_.Exception.Message
-                }
-            }
-            finally {
-                Remove-Item -Path $progressPath -Force -ErrorAction SilentlyContinue
-            }
+            return $result
         }
 
         $operationStart = [System.Diagnostics.Stopwatch]::StartNew()
@@ -633,11 +521,11 @@ function Get-XdrCloudAppsActivityTimeline {
         try {
             if ($PSVersionTable.PSVersion.Major -ge 7) {
                 $parallelJob = Start-ThreadJob -ScriptBlock {
-                    param($Chunks, $Throttle, $Params, $CookieInfo, $HeaderInfo, $ScriptText)
+                    param($Chunks, $Throttle, $Params, $StatusMap, $WorkerText, $WrapperText)
                     $Chunks | ForEach-Object -Parallel {
-                        & ([scriptblock]::Create($using:ScriptText)) -Chunk $_ -Params $using:Params -CookieInfo $using:CookieInfo -HeaderInfo $using:HeaderInfo
+                        & ([scriptblock]::Create($using:WrapperText)) -Chunk $_ -Params $using:Params -StatusMap $using:StatusMap -WorkerText $using:WorkerText
                     } -ThrottleLimit $Throttle
-                } -ArgumentList $dateChunks.ToArray(), $ThrottleLimit, $baseParams, $cookieData, $headersData, $chunkScript.ToString()
+                } -ArgumentList $dateChunks.ToArray(), $ThrottleLimit, $baseParams, $statusMap, $workerScriptText, $chunkScript.ToString()
 
                 $lastProgress = [System.Diagnostics.Stopwatch]::StartNew()
                 $lastCompleted = 0
@@ -646,9 +534,8 @@ function Get-XdrCloudAppsActivityTimeline {
                         Stop-Job -Job $parallelJob -ErrorAction SilentlyContinue
                         throw "Activity timeline timed out after $TimeoutSeconds seconds."
                     }
-                    $completedFiles = @(Get-ChildItem -Path $runTempPath -Filter 'chunk_*.json' -ErrorAction SilentlyContinue).Count
-                    $recentProgress = Get-ChildItem -Path $runTempPath -Filter 'progress_*.txt' -ErrorAction SilentlyContinue |
-                        Where-Object { ([datetime]::UtcNow - $_.LastWriteTimeUtc).TotalSeconds -lt 60 }
+                    $completedFiles = @(Get-ChildItem -Path $runTempPath -Filter 'chunk_*.ndjson' -ErrorAction SilentlyContinue).Count
+                    $recentProgress = @($statusMap.Values | Where-Object { ([datetime]::UtcNow - $_.UpdatedUtc).TotalSeconds -lt 60 }).Count -gt 0
                     if ($completedFiles -gt $lastCompleted -or $recentProgress) {
                         $lastCompleted = $completedFiles
                         $lastProgress.Restart()
@@ -666,7 +553,7 @@ function Get-XdrCloudAppsActivityTimeline {
             }
             else {
                 foreach ($chunk in $dateChunks) {
-                    $results += & $chunkScript -Chunk $chunk -Params $baseParams -CookieInfo $cookieData -HeaderInfo $headersData
+                    $results += & $chunkScript -Chunk $chunk -Params $baseParams -StatusMap $statusMap -WorkerText $workerScriptText
                 }
             }
 
@@ -687,7 +574,7 @@ function Get-XdrCloudAppsActivityTimeline {
 
             $fromUtc = $FromDate.ToUniversalTime()
             $toUtc = $ToDate.ToUniversalTime()
-            $jsonFiles = @(
+            $partFiles = @(
                 $results |
                     Where-Object { $_.Success -and $_.FilePath -and (Test-Path -LiteralPath $_.FilePath) } |
                     ForEach-Object { Get-Item -LiteralPath $_.FilePath } |
@@ -703,10 +590,8 @@ function Get-XdrCloudAppsActivityTimeline {
                 $exportCount = 0
                 $writer = [System.IO.StreamWriter]::new($ExportPath, $false, [System.Text.Encoding]::UTF8)
                 try {
-                    foreach ($file in @($jsonFiles | Sort-Object Name -Descending)) {
-                        $chunkData = Read-XdrCloudAppsActivityChunkFile -File $file -AllowPartial:$AllowPartial
-                        if ($null -eq $chunkData) { continue }
-                        foreach ($activity in @(Get-XdrCloudAppsObjectValue -InputObject $chunkData -Name 'Events')) {
+                    foreach ($file in @($partFiles | Sort-Object Name -Descending)) {
+                        foreach ($activity in @(Read-XdrCloudAppsActivityPartFile -File $file -AllowPartial:$AllowPartial)) {
                             $eventUtc = Get-XdrCloudAppsActivityEventTime -Activity $activity
 
                             if ($null -eq $eventUtc -or $eventUtc -lt $fromUtc -or $eventUtc -ge $toUtc) {
@@ -744,10 +629,8 @@ function Get-XdrCloudAppsActivityTimeline {
             $eventRows = [System.Collections.Generic.List[object]]::new()
             $seenKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
             $sha256 = [System.Security.Cryptography.SHA256]::Create()
-            foreach ($file in $jsonFiles) {
-                $chunkData = Read-XdrCloudAppsActivityChunkFile -File $file -AllowPartial:$AllowPartial
-                if ($null -eq $chunkData) { continue }
-                foreach ($activity in @(Get-XdrCloudAppsObjectValue -InputObject $chunkData -Name 'Events')) {
+            foreach ($file in $partFiles) {
+                foreach ($activity in @(Read-XdrCloudAppsActivityPartFile -File $file -AllowPartial:$AllowPartial)) {
                     $eventUtc = Get-XdrCloudAppsActivityEventTime -Activity $activity
 
                     if ($null -eq $eventUtc -or $eventUtc -lt $fromUtc -or $eventUtc -ge $toUtc) {

--- a/XDRInternals/internal/functions/New-XdrCloudAppsActivityTimelineExportWorker.ps1
+++ b/XDRInternals/internal/functions/New-XdrCloudAppsActivityTimelineExportWorker.ps1
@@ -1,0 +1,727 @@
+﻿function New-XdrCloudAppsActivityTimelineExportWorker {
+    <#
+    .SYNOPSIS
+        Creates the self-contained Cloud Apps activity timeline export worker.
+
+    .DESCRIPTION
+        Returns a scriptblock that downloads one bounded recent or archived activity
+        interval, validates it against the count API, uses endpoint-specific keyset and
+        dense-timestamp pagination, and writes UTF-8 NDJSON without retaining the complete
+        interval in memory.
+
+    .EXAMPLE
+        $worker = New-XdrCloudAppsActivityTimelineExportWorker
+        Creates the worker used by Export-XdrCloudAppsActivityTimeline.
+    #>
+    [OutputType([scriptblock])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Private factory that only returns a worker scriptblock.')]
+    [CmdletBinding()]
+    param ()
+
+    return {
+        param($chunk, $sharedParameters, $statusMap)
+
+        $chunkIndex = [int]$chunk.Index
+        $chunkFromDate = ([datetime]$chunk.FromDate).ToUniversalTime()
+        $chunkToDate = ([datetime]$chunk.ToDate).ToUniversalTime()
+        $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+        $partialPath = "$filePath.partial"
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $eventCount = 0L
+        $pageCount = 0
+        $rewindCount = 0
+        $missingTimestampCount = 0L
+        $boundaryTimestampCount = 0L
+        $duplicateRepresentationCount = 0L
+        $expectedEventCount = 0L
+        $countIsLowerBound = $false
+        $state = @{
+            RetryCount  = 0
+            FailureClass = 'Protocol'
+        }
+
+        $getValue = {
+            param($InputObject, [string]$Name)
+
+            if ($null -eq $InputObject) { return $null }
+            if ($InputObject -is [System.Collections.IDictionary]) {
+                if ($InputObject.Contains($Name)) { return $InputObject[$Name] }
+                foreach ($key in $InputObject.Keys) {
+                    if ([string]$key -ceq $Name) { return $InputObject[$key] }
+                }
+                foreach ($key in $InputObject.Keys) {
+                    if ([string]$key -ieq $Name) { return $InputObject[$key] }
+                }
+                return $null
+            }
+            $property = $InputObject.PSObject.Properties | Where-Object Name -CEQ $Name | Select-Object -First 1
+            if ($property) { return $property.Value }
+            $property = $InputObject.PSObject.Properties | Where-Object Name -IEQ $Name | Select-Object -First 1
+            if ($property) { return $property.Value }
+            return $null
+        }
+
+        $hasProperty = {
+            param($InputObject, [string]$Name)
+
+            if ($null -eq $InputObject) { return $false }
+            if ($InputObject -is [System.Collections.IDictionary]) {
+                foreach ($key in $InputObject.Keys) {
+                    if ([string]$key -ieq $Name) { return $true }
+                }
+                return $false
+            }
+            return $null -ne ($InputObject.PSObject.Properties | Where-Object Name -IEQ $Name | Select-Object -First 1)
+        }
+
+        $parseResponse = {
+            param($Response)
+
+            if ($Response -is [string]) {
+                if ([string]::IsNullOrWhiteSpace($Response)) { return $null }
+                $convertFromJson = Get-Command ConvertFrom-Json -ErrorAction Stop
+                if ($convertFromJson.Parameters.ContainsKey('AsHashtable')) {
+                    return $Response | ConvertFrom-Json -AsHashtable -Depth 100 -ErrorAction Stop
+                }
+
+                Add-Type -AssemblyName System.Web.Extensions -ErrorAction Stop
+                $serializer = New-Object System.Web.Script.Serialization.JavaScriptSerializer
+                $serializer.MaxJsonLength = [int]::MaxValue
+                return $serializer.DeserializeObject($Response)
+            }
+            return $Response
+        }
+
+        $getCeilingUnixMillisecond = {
+            param([datetime]$Value)
+
+            $utc = $Value.ToUniversalTime()
+            $offset = [datetimeoffset]::new($utc)
+            $milliseconds = $offset.ToUnixTimeMilliseconds()
+            if (($utc.Ticks % [timespan]::TicksPerMillisecond) -ne 0) { $milliseconds++ }
+            return [long]$milliseconds
+        }
+
+        $parseTimeValue = {
+            param($Value)
+
+            if ($null -ne $Value -and -not [string]::IsNullOrWhiteSpace([string]$Value)) {
+                $numericTimestamp = 0L
+                if ([long]::TryParse([string]$Value, [ref]$numericTimestamp)) {
+                    try {
+                        if ([math]::Abs($numericTimestamp) -gt 9999999999L) {
+                            return [PSCustomObject]@{
+                                DateTime = [datetimeoffset]::FromUnixTimeMilliseconds($numericTimestamp).UtcDateTime
+                                UnixMilliseconds = $numericTimestamp
+                            }
+                        }
+                        $dateTime = [datetimeoffset]::FromUnixTimeSeconds($numericTimestamp).UtcDateTime
+                        return [PSCustomObject]@{
+                            DateTime = $dateTime
+                            UnixMilliseconds = [datetimeoffset]::new($dateTime).ToUnixTimeMilliseconds()
+                        }
+                    }
+                    catch { return $null }
+                }
+                $parsed = [datetimeoffset]::MinValue
+                $styles = [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+                if ([datetimeoffset]::TryParse([string]$Value, [System.Globalization.CultureInfo]::InvariantCulture, $styles, [ref]$parsed)) {
+                    return [PSCustomObject]@{
+                        DateTime = $parsed.UtcDateTime
+                        UnixMilliseconds = $parsed.ToUnixTimeMilliseconds()
+                    }
+                }
+            }
+            return $null
+        }
+
+        $parseTimestamp = {
+            param($Activity)
+
+            $timestamp = & $parseTimeValue (& $getValue $Activity 'timestamp')
+            if ($null -ne $timestamp) { return $timestamp }
+            return & $parseTimeValue (& $getValue $Activity 'date')
+        }
+
+        $getStableKey = {
+            param([string]$Json)
+
+            $sha256 = [System.Security.Cryptography.SHA256]::Create()
+            try {
+                $hashBytes = $sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Json))
+                return "payload:$([System.BitConverter]::ToString($hashBytes).Replace('-', ''))"
+            }
+            finally {
+                $sha256.Dispose()
+            }
+        }
+
+        $invokeRequest = {
+            param([string]$Uri, [hashtable]$Body)
+
+            $response = $null
+            for ($attempt = 1; $attempt -le [int]$sharedParameters.MaxRetries; $attempt++) {
+                try {
+                    $response = Invoke-RestMethod -Uri $Uri -Method POST -ContentType 'application/json' `
+                        -Body ($Body | ConvertTo-Json -Depth 20 -Compress) -WebSession $webSession `
+                        -Headers $sharedParameters.HeadersData -TimeoutSec $sharedParameters.RequestTimeoutSeconds -ErrorAction Stop
+                    return & $parseResponse $response
+                }
+                catch {
+                    $statusCode = $null
+                    if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+                        $statusCode = [int]$_.Exception.Response.StatusCode
+                    }
+                    $isTransient = $null -eq $statusCode -or $statusCode -in @(408, 429, 500, 502, 503, 504)
+                    if (-not $isTransient -or $attempt -eq [int]$sharedParameters.MaxRetries) {
+                        $state.FailureClass = if ($statusCode -in @(401, 403)) {
+                            'Authentication'
+                        }
+                        elseif ($isTransient -and $null -eq $statusCode) {
+                            'Transport'
+                        }
+                        elseif ($isTransient) {
+                            'TransientHttp'
+                        }
+                        else {
+                            'PermanentHttp'
+                        }
+                        throw
+                    }
+
+                    $state.RetryCount++
+                    $baseDelaySeconds = if ($sharedParameters.ContainsKey('RetryDelaySeconds')) {
+                        [double]$sharedParameters.RetryDelaySeconds
+                    }
+                    else { 1.0 }
+                    $delaySeconds = [math]::Min(300, $baseDelaySeconds * [math]::Pow(2, $attempt - 1) + (Get-Random -Minimum 0 -Maximum 3))
+                    if ($statusCode -eq 429 -and $_.Exception.Response -and $_.Exception.Response.Headers -and
+                        $_.Exception.Response.Headers.RetryAfter) {
+                        $retryAfter = $_.Exception.Response.Headers.RetryAfter
+                        $retryAfterSeconds = if ($retryAfter.Delta) {
+                            [math]::Ceiling($retryAfter.Delta.TotalSeconds)
+                        }
+                        elseif ($retryAfter.Date) {
+                            [math]::Ceiling(($retryAfter.Date.UtcDateTime - [datetime]::UtcNow).TotalSeconds)
+                        }
+                        else { 0 }
+                        $delaySeconds = [math]::Max($delaySeconds, [math]::Min(300, $retryAfterSeconds))
+                    }
+                    Start-Sleep -Seconds $delaySeconds
+                }
+            }
+        }
+
+        try {
+            if (Test-Path -LiteralPath $partialPath) {
+                Remove-Item -LiteralPath $partialPath -Force
+            }
+            [System.IO.File]::WriteAllBytes($partialPath, [byte[]]@())
+
+            $webSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            foreach ($cookieInfo in $sharedParameters.CookieData) {
+                $cookie = [System.Net.Cookie]::new(
+                    [string]$cookieInfo.Name,
+                    [string]$cookieInfo.Value,
+                    [string]$cookieInfo.Path,
+                    [string]$cookieInfo.Domain
+                )
+                $webSession.Cookies.Add($cookie)
+            }
+
+            $requestFromMilliseconds = & $getCeilingUnixMillisecond $chunkFromDate
+            $requestToMilliseconds = (& $getCeilingUnixMillisecond $chunkToDate) - 1L
+            if ($requestFromMilliseconds -gt $requestToMilliseconds) {
+                throw "Chunk $chunkIndex does not contain a complete API timestamp millisecond."
+            }
+
+            $activityPath = if ([bool]$chunk.Archived) { 'archived_activities' } else { 'activities' }
+            $activityUri = "$($sharedParameters.BaseUrl)/apiproxy/mcas/cas/api/v1/$activityPath/"
+            $countUri = "$($sharedParameters.BaseUrl)/apiproxy/mcas/cas/api/v1/$activityPath/count/"
+            $newFilter = {
+                param([long]$EndMilliseconds)
+
+                $filters = $sharedParameters.Filters.Clone()
+                if ([bool]$chunk.Archived) {
+                    $filters.date = @{ range = @(@{ start = $requestFromMilliseconds; end = $EndMilliseconds }) }
+                }
+                else {
+                    $filters.date = @{ gte = $requestFromMilliseconds; lte = $EndMilliseconds }
+                }
+                return $filters
+            }
+
+            $countResponse = & $invokeRequest $countUri @{ filters = (& $newFilter $requestToMilliseconds) }
+            if (-not (& $hasProperty $countResponse 'total') -or -not (& $hasProperty $countResponse 'moreThanTotal')) {
+                $state.FailureClass = 'PartialResponse'
+                throw "Chunk $chunkIndex received an incomplete count response."
+            }
+            $expectedEventCount = [long](& $getValue $countResponse 'total')
+            $countIsLowerBound = [bool](& $getValue $countResponse 'moreThanTotal')
+
+            $partStream = $null
+            $partWriter = $null
+            try {
+                $partStream = [System.IO.FileStream]::new(
+                    $partialPath,
+                    [System.IO.FileMode]::Append,
+                    [System.IO.FileAccess]::Write,
+                    [System.IO.FileShare]::None,
+                    1MB,
+                    [System.IO.FileOptions]::SequentialScan
+                )
+                $partWriter = [System.IO.StreamWriter]::new($partStream, [System.Text.UTF8Encoding]::new($false), 1MB, $true)
+                $partWriter.NewLine = "`n"
+                $seenKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+
+                while ($true) {
+                    if ($pageCount -ge [int]$sharedParameters.MaxPagesPerChunk) {
+                        throw "Chunk $chunkIndex exceeded the page safety limit."
+                    }
+
+                    $requestBody = @{
+                        distributedId     = [guid]::NewGuid().ToString()
+                        filters           = & $newFilter $requestToMilliseconds
+                        limit             = [int]$sharedParameters.PageSize
+                        performAsyncTotal = $true
+                        skip              = 0
+                        sortDirection     = 'desc'
+                        sortField         = 'date'
+                    }
+                    $response = & $invokeRequest $activityUri $requestBody
+                    $hasData = & $hasProperty $response 'data'
+                    $dataValue = if ($hasData) { & $getValue $response 'data' } else { $null }
+                    $responseData = if ($null -eq $dataValue) { @() } else { @($dataValue) }
+
+                    if (-not $hasData -and ($eventCount -lt $expectedEventCount -or $countIsLowerBound)) {
+                        $state.FailureClass = 'PartialResponse'
+                        throw "Chunk $chunkIndex received an activity response without data before the counted events were retrieved."
+                    }
+                    if ($responseData.Count -gt [int]$sharedParameters.PageSize) {
+                        throw "Chunk $chunkIndex received more rows than its requested page size."
+                    }
+
+                    $pageCount++
+                    $previousTimestamp = $null
+                    $pageRows = [System.Collections.Generic.List[object]]::new()
+                    $pageNewestMilliseconds = $null
+                    $pageOldestMilliseconds = $null
+                    foreach ($activity in $responseData) {
+                        if ($null -eq $activity) {
+                            $state.FailureClass = 'PartialResponse'
+                            throw "Chunk $chunkIndex received a null activity record."
+                        }
+                        $timestamp = & $parseTimestamp $activity
+                        if ($null -eq $timestamp) {
+                            $missingTimestampCount++
+                            throw "Chunk $chunkIndex received an activity without a parseable timestamp."
+                        }
+                        if ($timestamp.DateTime -lt $chunkFromDate -or $timestamp.DateTime -ge $chunkToDate) {
+                            throw "Chunk $chunkIndex received an activity outside its logical interval: $($timestamp.DateTime.ToString('o'))."
+                        }
+                        if ($timestamp.UnixMilliseconds -lt $requestFromMilliseconds -or
+                            $timestamp.UnixMilliseconds -gt $requestToMilliseconds) {
+                            throw "Chunk $chunkIndex received an activity outside its requested API interval."
+                        }
+                        if ($null -ne $previousTimestamp -and $timestamp.UnixMilliseconds -gt $previousTimestamp) {
+                            throw "Chunk $chunkIndex received activities outside descending timestamp order."
+                        }
+                        $previousTimestamp = $timestamp.UnixMilliseconds
+                        if ($null -eq $pageNewestMilliseconds) { $pageNewestMilliseconds = $timestamp.UnixMilliseconds }
+                        $pageOldestMilliseconds = $timestamp.UnixMilliseconds
+                        if ($timestamp.DateTime -eq $chunkFromDate -or $timestamp.DateTime -eq $chunkToDate) {
+                            $boundaryTimestampCount++
+                        }
+                        $json = $activity | ConvertTo-Json -Depth 100 -Compress
+                        $pageRows.Add([PSCustomObject]@{
+                                UnixMilliseconds = $timestamp.UnixMilliseconds
+                                StableKey = & $getStableKey $json
+                                Json = $json
+                            })
+                    }
+
+                    $pageIsFull = $responseData.Count -eq [int]$sharedParameters.PageSize
+                    $hasNext = & $getValue $response 'hasNext'
+                    $pageHasMore = $pageIsFull -or $hasNext -eq $true
+                    if ($pageHasMore -and $pageNewestMilliseconds -eq $pageOldestMilliseconds) {
+                        $denseTimestampMilliseconds = [long]$pageOldestMilliseconds
+                        $rewindCount++
+
+                        if ([bool]$chunk.Archived) {
+                            $denseFilters = $sharedParameters.Filters.Clone()
+                            $denseFilters.date = @{ range = @(@{ start = $denseTimestampMilliseconds; end = $denseTimestampMilliseconds }) }
+                            $denseCountResponse = & $invokeRequest $countUri @{ filters = $denseFilters }
+                            if (-not (& $hasProperty $denseCountResponse 'total') -or -not (& $hasProperty $denseCountResponse 'moreThanTotal')) {
+                                $state.FailureClass = 'PartialResponse'
+                                throw "Chunk $chunkIndex received an incomplete dense timestamp count response."
+                            }
+                            $denseExpectedCount = [long](& $getValue $denseCountResponse 'total')
+                            $denseCountIsLowerBound = [bool](& $getValue $denseCountResponse 'moreThanTotal')
+
+                            $denseSeenIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+                            $densePayloadKeyById = @{}
+                            $denseDirectionConverged = @{ desc = $false; asc = $false }
+                            $denseCountSatisfied = $false
+                            for ($denseSweep = 0; $denseSweep -lt 6; $denseSweep++) {
+                                $denseSweepDirection = if ($denseSweep % 2 -eq 0) { 'desc' } else { 'asc' }
+                                $denseCountBeforeSweep = $denseSeenIds.Count
+                                $denseSkip = 0
+                                while ($true) {
+                                    if ($pageCount -ge [int]$sharedParameters.MaxPagesPerChunk) {
+                                        throw "Chunk $chunkIndex exceeded the page safety limit."
+                                    }
+                                    $secondaryResponse = & $invokeRequest $activityUri @{
+                                        distributedId     = [guid]::NewGuid().ToString()
+                                        filters           = $denseFilters
+                                        limit             = [int]$sharedParameters.PageSize
+                                        performAsyncTotal = $true
+                                        skip              = $denseSkip
+                                        sortDirection     = $denseSweepDirection
+                                        sortField         = 'created'
+                                    }
+                                    $secondaryHasData = & $hasProperty $secondaryResponse 'data'
+                                    $secondaryDataValue = if ($secondaryHasData) { & $getValue $secondaryResponse 'data' } else { $null }
+                                    $secondaryData = if ($null -eq $secondaryDataValue) { @() } else { @($secondaryDataValue) }
+                                    if (-not $secondaryHasData -or $secondaryData.Count -eq 0) {
+                                        $state.FailureClass = 'PartialResponse'
+                                        throw "Chunk $chunkIndex received an incomplete archived dense timestamp response."
+                                    }
+                                    if ($secondaryData.Count -gt [int]$sharedParameters.PageSize) {
+                                        throw "Chunk $chunkIndex received more rows than its requested page size."
+                                    }
+
+                                    $pageCount++
+                                    $secondaryPreviousMilliseconds = $null
+                                    foreach ($activity in $secondaryData) {
+                                        if ($null -eq $activity) {
+                                            $state.FailureClass = 'PartialResponse'
+                                            throw "Chunk $chunkIndex received a null activity record."
+                                        }
+                                        $timestamp = & $parseTimestamp $activity
+                                        if ($null -eq $timestamp) {
+                                            $missingTimestampCount++
+                                            throw "Chunk $chunkIndex received an activity without a parseable timestamp."
+                                        }
+                                        if ($timestamp.UnixMilliseconds -ne $denseTimestampMilliseconds) {
+                                            throw "Chunk $chunkIndex received an activity outside its dense timestamp interval."
+                                        }
+                                        $created = & $parseTimeValue (& $getValue $activity 'created')
+                                        if ($null -eq $created) {
+                                            $state.FailureClass = 'UnpageableBoundary'
+                                            throw "Chunk $chunkIndex received an archived dense timestamp activity without a parseable created value."
+                                        }
+                                        $outOfOrder = $null -ne $secondaryPreviousMilliseconds -and (
+                                            ($denseSweepDirection -eq 'desc' -and $created.UnixMilliseconds -gt $secondaryPreviousMilliseconds) -or
+                                            ($denseSweepDirection -eq 'asc' -and $created.UnixMilliseconds -lt $secondaryPreviousMilliseconds)
+                                        )
+                                        if ($outOfOrder) {
+                                            throw "Chunk $chunkIndex received activities outside $denseSweepDirection created order."
+                                        }
+                                        $secondaryPreviousMilliseconds = $created.UnixMilliseconds
+
+                                        $activityId = $null
+                                        foreach ($idName in @('_id', 'id', 'recordId')) {
+                                            $candidateId = & $getValue $activity $idName
+                                            if (-not [string]::IsNullOrWhiteSpace([string]$candidateId)) {
+                                                $activityId = [string]$candidateId
+                                                break
+                                            }
+                                        }
+                                        if ($null -eq $activityId) {
+                                            $state.FailureClass = 'UnpageableBoundary'
+                                            throw "Chunk $chunkIndex received an archived dense timestamp activity without a stable identifier."
+                                        }
+
+                                        $json = $activity | ConvertTo-Json -Depth 100 -Compress
+                                        $payloadKey = & $getStableKey $json
+                                        if ($densePayloadKeyById.ContainsKey($activityId) -and
+                                            [string]$densePayloadKeyById[$activityId] -ne [string]$payloadKey) {
+                                            $state.FailureClass = 'UnpageableBoundary'
+                                            throw "Chunk $chunkIndex received different archived dense-timestamp payloads for stable activity identifier '$activityId'."
+                                        }
+                                        $densePayloadKeyById[$activityId] = $payloadKey
+
+                                        if ($denseSeenIds.Add($activityId)) {
+                                            $partWriter.WriteLine($json)
+                                            $eventCount++
+                                        }
+                                    }
+                                    $partWriter.Flush()
+                                    $statusMap[$chunkIndex] = [PSCustomObject]@{
+                                        Pages = $pageCount; Events = $eventCount; Bytes = $partStream.Position
+                                        Rewinds = $rewindCount; UpdatedUtc = [datetime]::UtcNow
+                                    }
+
+                                    $secondaryPageIsFull = $secondaryData.Count -eq [int]$sharedParameters.PageSize
+                                    $secondaryHasNext = & $getValue $secondaryResponse 'hasNext'
+                                    if ($secondaryHasNext -ne $true -and -not $secondaryPageIsFull) { break }
+                                    if ($secondaryHasNext -eq $false) { break }
+                                    $denseSkip += $secondaryData.Count
+                                }
+                                if ($denseSeenIds.Count -eq $denseCountBeforeSweep) {
+                                    $denseDirectionConverged[$denseSweepDirection] = $true
+                                }
+                                if (-not $denseCountIsLowerBound -and $denseSeenIds.Count -ge $denseExpectedCount) {
+                                    $denseCountSatisfied = $true
+                                    break
+                                }
+                                if ($denseDirectionConverged.desc -and $denseDirectionConverged.asc) { break }
+                            }
+                            if (-not $denseCountSatisfied -and (-not $denseDirectionConverged.desc -or -not $denseDirectionConverged.asc)) {
+                                $state.FailureClass = 'PartialResponse'
+                                throw "Chunk $chunkIndex could not converge archived dense timestamp pagination after six alternating sweeps; retrieved $($denseSeenIds.Count) stable activities and the count snapshot reported $denseExpectedCount."
+                            }
+
+                            $requestToMilliseconds = $denseTimestampMilliseconds - 1L
+                            if ($requestToMilliseconds -lt $requestFromMilliseconds) { break }
+                            continue
+                        }
+
+                        $createdCursorMilliseconds = $null
+
+                        while ($true) {
+                            if ($pageCount -ge [int]$sharedParameters.MaxPagesPerChunk) {
+                                throw "Chunk $chunkIndex exceeded the page safety limit."
+                            }
+
+                            $secondaryFilters = $sharedParameters.Filters.Clone()
+                            if ([bool]$chunk.Archived) {
+                                $secondaryFilters.date = @{ range = @(@{ start = $denseTimestampMilliseconds; end = $denseTimestampMilliseconds }) }
+                            }
+                            else {
+                                $secondaryFilters.date = @{ gte = $denseTimestampMilliseconds; lte = $denseTimestampMilliseconds }
+                            }
+                            if ($null -ne $createdCursorMilliseconds) {
+                                $existingCreatedFilter = & $getValue $secondaryFilters 'created'
+                                if ($null -ne $existingCreatedFilter -and $existingCreatedFilter -isnot [System.Collections.IDictionary]) {
+                                    $state.FailureClass = 'UnpageableBoundary'
+                                    throw "Chunk $chunkIndex cannot refine the caller-supplied created filter for dense timestamp pagination."
+                                }
+                                $createdFilter = @{}
+                                if ($existingCreatedFilter -is [System.Collections.IDictionary]) {
+                                    foreach ($key in $existingCreatedFilter.Keys) { $createdFilter[$key] = $existingCreatedFilter[$key] }
+                                }
+                                $existingUpperBound = & $getValue $createdFilter 'lte'
+                                if ($null -ne $existingUpperBound) {
+                                    $parsedUpperBound = & $parseTimeValue $existingUpperBound
+                                    if ($null -eq $parsedUpperBound) {
+                                        $state.FailureClass = 'UnpageableBoundary'
+                                        throw "Chunk $chunkIndex cannot parse the caller-supplied created upper bound."
+                                    }
+                                    $createdFilter.lte = [math]::Min($parsedUpperBound.UnixMilliseconds, $createdCursorMilliseconds)
+                                }
+                                else {
+                                    $createdFilter.lte = $createdCursorMilliseconds
+                                }
+                                $secondaryFilters.created = $createdFilter
+                            }
+
+                            $secondaryResponse = & $invokeRequest $activityUri @{
+                                distributedId     = [guid]::NewGuid().ToString()
+                                filters           = $secondaryFilters
+                                limit             = [int]$sharedParameters.PageSize
+                                performAsyncTotal = $true
+                                skip              = 0
+                                sortDirection     = 'desc'
+                                sortField         = 'created'
+                            }
+                            $secondaryHasData = & $hasProperty $secondaryResponse 'data'
+                            $secondaryDataValue = if ($secondaryHasData) { & $getValue $secondaryResponse 'data' } else { $null }
+                            $secondaryData = if ($null -eq $secondaryDataValue) { @() } else { @($secondaryDataValue) }
+                            if (-not $secondaryHasData -or $secondaryData.Count -eq 0) {
+                                $state.FailureClass = 'PartialResponse'
+                                throw "Chunk $chunkIndex received an incomplete dense timestamp response."
+                            }
+                            if ($secondaryData.Count -gt [int]$sharedParameters.PageSize) {
+                                throw "Chunk $chunkIndex received more rows than its requested page size."
+                            }
+
+                            $pageCount++
+                            $secondaryPreviousMilliseconds = $null
+                            $secondaryNewestMilliseconds = $null
+                            $secondaryOldestMilliseconds = $null
+                            $secondaryRows = [System.Collections.Generic.List[object]]::new()
+                            foreach ($activity in $secondaryData) {
+                                if ($null -eq $activity) {
+                                    $state.FailureClass = 'PartialResponse'
+                                    throw "Chunk $chunkIndex received a null activity record."
+                                }
+                                $timestamp = & $parseTimestamp $activity
+                                if ($null -eq $timestamp) {
+                                    $missingTimestampCount++
+                                    throw "Chunk $chunkIndex received an activity without a parseable timestamp."
+                                }
+                                if ($timestamp.UnixMilliseconds -ne $denseTimestampMilliseconds) {
+                                    throw "Chunk $chunkIndex received an activity outside its dense timestamp interval."
+                                }
+                                $created = & $parseTimeValue (& $getValue $activity 'created')
+                                if ($null -eq $created) {
+                                    $state.FailureClass = 'UnpageableBoundary'
+                                    throw "Chunk $chunkIndex received a dense timestamp activity without a parseable created value."
+                                }
+                                if ($null -ne $secondaryPreviousMilliseconds -and $created.UnixMilliseconds -gt $secondaryPreviousMilliseconds) {
+                                    throw "Chunk $chunkIndex received activities outside descending created order."
+                                }
+                                $secondaryPreviousMilliseconds = $created.UnixMilliseconds
+                                if ($null -eq $secondaryNewestMilliseconds) { $secondaryNewestMilliseconds = $created.UnixMilliseconds }
+                                $secondaryOldestMilliseconds = $created.UnixMilliseconds
+                                $json = $activity | ConvertTo-Json -Depth 100 -Compress
+                                $secondaryRows.Add([PSCustomObject]@{
+                                        UnixMilliseconds = $created.UnixMilliseconds
+                                        StableKey = & $getStableKey $json
+                                        Json = $json
+                                    })
+                            }
+
+                            $secondaryPageIsFull = $secondaryData.Count -eq [int]$sharedParameters.PageSize
+                            $secondaryHasNext = & $getValue $secondaryResponse 'hasNext'
+                            $secondaryPageHasMore = $secondaryPageIsFull -or $secondaryHasNext -eq $true
+                            if ($secondaryPageHasMore -and $secondaryNewestMilliseconds -eq $secondaryOldestMilliseconds) {
+                                $state.FailureClass = 'UnpageableBoundary'
+                                throw "Chunk $chunkIndex cannot prove completeness because one created timestamp millisecond filled a complete $([int]$sharedParameters.PageSize)-row page."
+                            }
+
+                            foreach ($row in $secondaryRows) {
+                                if ($secondaryPageHasMore -and $row.UnixMilliseconds -eq $secondaryOldestMilliseconds) { continue }
+                                if ($seenKeys.Add([string]$row.StableKey)) {
+                                    $partWriter.WriteLine($row.Json)
+                                    $eventCount++
+                                }
+                                else {
+                                    $duplicateRepresentationCount++
+                                }
+                            }
+                            $partWriter.Flush()
+                            $statusMap[$chunkIndex] = [PSCustomObject]@{
+                                Pages = $pageCount; Events = $eventCount; Bytes = $partStream.Position
+                                Rewinds = $rewindCount; UpdatedUtc = [datetime]::UtcNow
+                            }
+
+                            if (-not $secondaryPageHasMore) { break }
+                            if ($null -ne $createdCursorMilliseconds -and $secondaryOldestMilliseconds -ge $createdCursorMilliseconds) {
+                                $state.FailureClass = 'UnpageableBoundary'
+                                throw "Chunk $chunkIndex cannot advance beyond its oldest created timestamp."
+                            }
+                            $createdCursorMilliseconds = [long]$secondaryOldestMilliseconds
+                            $rewindCount++
+                        }
+
+                        $requestToMilliseconds = $denseTimestampMilliseconds - 1L
+                        if ($requestToMilliseconds -lt $requestFromMilliseconds) { break }
+                        continue
+                    }
+
+                    foreach ($row in $pageRows) {
+                        if ($pageHasMore -and $row.UnixMilliseconds -eq $pageOldestMilliseconds) { continue }
+                        if ($seenKeys.Add([string]$row.StableKey)) {
+                            $partWriter.WriteLine($row.Json)
+                            $eventCount++
+                        }
+                        else {
+                            $duplicateRepresentationCount++
+                        }
+                    }
+                    $partWriter.Flush()
+
+                    $statusMap[$chunkIndex] = [PSCustomObject]@{
+                        Pages      = $pageCount
+                        Events     = $eventCount
+                        Bytes      = $partStream.Position
+                        Rewinds    = $rewindCount
+                        UpdatedUtc = [datetime]::UtcNow
+                    }
+
+                    if (-not $pageHasMore) { break }
+                    if ($pageOldestMilliseconds -ge $requestToMilliseconds) {
+                        $state.FailureClass = 'UnpageableBoundary'
+                        throw "Chunk $chunkIndex cannot advance beyond its oldest activity timestamp."
+                    }
+                    $requestToMilliseconds = $pageOldestMilliseconds
+                    $rewindCount++
+                }
+            }
+            finally {
+                if ($partWriter) { $partWriter.Dispose() }
+                if ($partStream) { $partStream.Dispose() }
+            }
+
+            $countDelta = $eventCount - $expectedEventCount
+            $countMismatchRestartLimit = if ($sharedParameters.ContainsKey('MaxCountMismatchRestarts')) {
+                [int]$sharedParameters.MaxCountMismatchRestarts
+            }
+            else { 2 }
+            if ($countDelta -lt 0 -and [int]$chunk.Attempt -lt $countMismatchRestartLimit) {
+                $state.FailureClass = 'PartialResponse'
+                throw "Chunk $chunkIndex retrieved $eventCount activities but the count snapshot reported $expectedEventCount."
+            }
+
+            $fileBytes = (Get-Item -LiteralPath $partialPath).Length
+            $fileSha256 = (Get-FileHash -LiteralPath $partialPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            if (Test-Path -LiteralPath $filePath) {
+                Remove-Item -LiteralPath $filePath -Force -ErrorAction Stop
+            }
+            [System.IO.File]::Move($partialPath, $filePath)
+            $stopwatch.Stop()
+
+            return [PSCustomObject]@{
+                Success                = $true
+                ChunkIndex             = $chunkIndex
+                FromDate               = $chunkFromDate
+                ToDate                 = $chunkToDate
+                Archived               = [bool]$chunk.Archived
+                FilePath               = $filePath
+                FileSha256             = $fileSha256
+                FileBytes              = $fileBytes
+                EventCount             = $eventCount
+                ExpectedEventCount     = $expectedEventCount
+                CountIsLowerBound      = $countIsLowerBound
+                CountDelta             = $countDelta
+                PageCount              = $pageCount
+                RetryCount             = [int]$state.RetryCount
+                RewindCount            = $rewindCount
+                MissingTimestampCount  = $missingTimestampCount
+                BoundaryTimestampCount = $boundaryTimestampCount
+                DuplicateRepresentationCount = $duplicateRepresentationCount
+                ElapsedSeconds         = [math]::Round($stopwatch.Elapsed.TotalSeconds, 3)
+                Error                  = $null
+                FailureClass           = $null
+            }
+        }
+        catch {
+            $stopwatch.Stop()
+            $errorText = $_.Exception.Message
+            if ([string]::IsNullOrWhiteSpace($errorText)) { $errorText = $_.Exception.GetType().FullName }
+            elseif ($errorText -match '<html|<!doctype|var __ADALLOM_CONSTS') { $errorText = 'The service returned an HTML portal error page.' }
+            elseif ($errorText.Length -gt 1000) { $errorText = $errorText.Substring(0, 1000) + '...' }
+            return [PSCustomObject]@{
+                Success                = $false
+                ChunkIndex             = $chunkIndex
+                FromDate               = $chunkFromDate
+                ToDate                 = $chunkToDate
+                Archived               = [bool]$chunk.Archived
+                FilePath               = $filePath
+                FileSha256             = $null
+                FileBytes              = 0L
+                EventCount             = $eventCount
+                ExpectedEventCount     = $expectedEventCount
+                CountIsLowerBound      = $countIsLowerBound
+                CountDelta             = $eventCount - $expectedEventCount
+                PageCount              = $pageCount
+                RetryCount             = [int]$state.RetryCount
+                RewindCount            = $rewindCount
+                MissingTimestampCount  = $missingTimestampCount
+                BoundaryTimestampCount = $boundaryTimestampCount
+                DuplicateRepresentationCount = $duplicateRepresentationCount
+                ElapsedSeconds         = [math]::Round($stopwatch.Elapsed.TotalSeconds, 3)
+                Error                  = $errorText
+                FailureClass           = [string]$state.FailureClass
+            }
+        }
+        finally {
+            if (Test-Path -LiteralPath $partialPath) {
+                Remove-Item -LiteralPath $partialPath -Force -ErrorAction SilentlyContinue
+            }
+            [void]$statusMap.TryRemove($chunkIndex, [ref]$null)
+        }
+    }
+}

--- a/docs/cloud-apps-timeline-export-validation.md
+++ b/docs/cloud-apps-timeline-export-validation.md
@@ -1,0 +1,78 @@
+# Cloud Apps timeline export validation
+
+## Scope
+
+This note records the correctness, recovery, and performance evidence used for the Cloud Apps timeline implementation on `feature/export-cloud-apps-activity-timeline`. It contains aggregate results only; no activity payloads, cookies, tokens, or tenant identifiers are retained.
+
+## Kept implementation decisions
+
+- `Export-XdrCloudAppsActivityTimeline` uses six-hour windows, page size 250, eight workers, timestamp keyset pagination, creation-time keyset recovery for dense recent timestamps, and stable-ID convergence only for dense archived timestamps.
+- Bounded `Get-XdrCloudAppsActivityTimeline` now invokes the same internal pagination worker. The older independent offset loop was removed because short pages with `hasNext=true` and unstable ordering at dense timestamp boundaries could skip records.
+- Normal duplicate suppression uses the complete serialized payload, not `_id`, `id`, or `recordId`. Reused identifiers therefore do not collapse distinct representations.
+- Archived dense recovery fails closed if an activity lacks a stable ID or if one stable ID maps to different payloads.
+- Null rows, missing/unparseable timestamps, out-of-range rows, ordering reversals, incomplete response shapes, and unpageable timestamp boundaries fail closed.
+- A caller-provided `date` filter is rejected for bounded requests. A `created` filter is rejected whenever the range uses the archived API because that endpoint does not support it.
+- HTTP 401/403 failures are not retried. Transient transport, 408, 429, and 5xx failures are retried; 429 honors a bounded `Retry-After` value.
+- Count is a consistency signal, not an exact snapshot. A list shortfall receives one fresh-window restart. Persistent differences are retained in `CountDelta` rather than causing loss of successfully retrieved payloads.
+- On resume, completed parts retain their hashes and route. Pending intervals are replanned against the current moving archive boundary and split if necessary before new work starts.
+
+## Automated validation
+
+The focused suites cover:
+
+- short pages that still report more data;
+- exact/full page continuation and timestamp rewinds;
+- case-colliding JSON properties;
+- recent and archived filter shapes;
+- list/count mismatch and lower-bound behavior;
+- repeated payload suppression while preserving reused IDs and distinct payloads;
+- missing and null activity records;
+- authentication, throttling with `Retry-After`, timeout, and 5xx handling;
+- dense recent creation-time pagination;
+- a creation timestamp that itself fills a page;
+- archived dense stable-ID convergence and ID/payload collision failure;
+- interruption/resume, incompatible manifests, archive-boundary aging, atomic replacement, publishing recovery, and final-hash rejection.
+
+Run them with:
+
+```powershell
+Invoke-Pester ./tests/functions/CloudApps.Tests.ps1,./tests/functions/ExportCloudAppsActivityTimeline.Tests.ps1
+```
+
+The final focused run passed 60 of 60 tests. The repository harness then passed 19,992 tests with zero failures and three expected platform/coverage skips.
+
+## Sanitized live-service evidence
+
+### Recent 24-hour export
+
+UTC range `2026-08-05T22:53:59.7426626Z` through `2026-08-06T22:53:59.7426626Z` produced 3,942 rows, 20 pages, four windows, and 15,627,611 bytes. Independent streaming validation found zero missing timestamps, out-of-range rows, ordering reversals, or duplicate payloads, and the final SHA-256 matched the manifest. One count remained 17 above the list after two fresh-window restarts.
+
+Running the repaired `Get-XdrCloudAppsActivityTimeline` over the identical range with eight three-hour windows returned 3,986 payloads. Its canonical payload set contained all 3,942 payloads from the earlier export plus 44 later-visible payloads; none from the earlier export were lost.
+
+### Interruption and resume
+
+A seven-day export for `2026-07-30T22:58:29.4439428Z` through `2026-08-06T22:58:29.4439428Z` was interrupted after the manifest recorded 18 of 28 completed parts. At interruption there was no final output, no partial part, and ten windows remained pending.
+
+After reconnecting, the exporter reported 18 resumed windows and completed with 11,485 rows, 69 pages, 46,829,763 bytes, and final SHA-256 `3d5d1feac1362ec4596732100399da04d13dad3e8276d4a1fba32fbb3028760e`. Independent validation found zero missing timestamps, out-of-range rows, ordering reversals, or duplicate payloads. The manifest was `Complete`; the parts and final `.partial` paths were absent.
+
+### Archived route
+
+UTC range `2026-07-06T17:08:23.5203495Z` through `2026-07-06T23:08:23.5203495Z` used one archived window and returned 212 rows with exact count parity. Independent validation found zero missing timestamps, out-of-range rows, ordering reversals, or duplicate payloads, and the final SHA-256 matched.
+
+### Restart policy comparison
+
+The same fixed recent 24-hour interval was queried with zero and one allowed count-mismatch restart after late-arriving service data had stabilized:
+
+| Restarts allowed | Rows | Canonical set | Count delta | Elapsed |
+| --- | ---: | --- | ---: | ---: |
+| 0 | 4,039 | Reference | -17 | 36.972 s |
+| 1 | 4,039 | Identical to zero-restart run | -17 | 71.220 s |
+
+The extra request did not change the canonical payload set or count delta. One restart is retained as a conservative defense against a genuinely partial list response; the previous second restart was removed because it added latency without evidence of additional coverage.
+
+## Remaining limitations and future probes
+
+- A real manifest cannot be aged by days during one test session. Moving archive-boundary resume is covered synthetically and should be observed opportunistically on a naturally aged interrupted export.
+- The archived dense fallback was exercised synthetically and a normal archived live window completed cleanly, but a naturally occurring archived timestamp containing more than 250 rows was not found in this proof.
+- Count snapshots and fixed-range list contents can change as late activities become visible. Compare canonical payload sets and range/order invariants rather than expecting byte-identical independent runs.
+- A prior 60-day bulk exercise covered both routes with approximately 205,000 rows and roughly 1 GiB of output. Repeat a 30- or 60-day run only after meaningful pagination or worker changes; focused dense, recovery, and archive-boundary proofs are more diagnostic for the current delta.

--- a/docs/device-timeline-export-follow-up-plan.md
+++ b/docs/device-timeline-export-follow-up-plan.md
@@ -1,0 +1,73 @@
+# Device timeline exporter follow-up plan
+
+## Purpose
+
+Use this plan in a dedicated session to stress and tune `Export-XdrEndpointDeviceTimeline` without importing assumptions from Identity or Cloud Apps. The implementation is on branch `feature/export-endpoint-device-timeline` in `/home/nathan/GitHub/XdrInternals-export-timeline` and is associated with PR #123.
+
+The current exporter uses four-hour chunks, page size 1,000, four workers, and at most two fresh-window restarts. Pagination follows the service-provided `Prev` continuation URI regardless of page length and deliberately ignores `Next`. The worker validates continuation host/path, repeated cursors, page limits, partial-response reasons, timestamp range, newest-first ordering, and half-open chunk boundaries.
+
+Device timeline data was materially volatile in prior fixed-range repetitions. There is no proven durable event identifier. Do not add ID- or payload-based deduplication merely to make repeated runs look identical; it could discard legitimate representations.
+
+## Initial setup
+
+1. Work only in `/home/nathan/GitHub/XdrInternals-export-timeline`; confirm the branch and dirty state before editing.
+2. Import the worktree module and authenticate with:
+
+   ```powershell
+   Import-Module ./XDRInternals/XDRInternals.psd1 -Force
+   Connect-XdrBySoftwarePasskey -KeyFilePath /home/nathan/GitHub/XdrInternals/.github/secadmin.passkey
+   ```
+
+3. Select the busiest available device and retain only sanitized identifiers and aggregate measurements.
+4. Run the focused baseline before experiments:
+
+   ```powershell
+   Invoke-Pester ./tests/functions/ExportEndpointDeviceTimeline.Tests.ps1
+   ```
+
+## Experiments
+
+### 1. Dense timestamps across server cursors
+
+Find a high-volume interval containing many events with identical timestamps. Verify that the same timestamp can span multiple `Prev` pages without loss, duplication introduced by the client, ordering failure, or a repeated-cursor loop. Add a synthetic test that distributes equal timestamps over at least three continuation pages.
+
+The server cursor is expected to disambiguate ties; do not replace it with timestamp keyset pagination unless live evidence disproves that contract.
+
+### 2. Cursor-contract adversarial tests
+
+Exercise a short page with a valid `Prev`, a full page without `Prev`, both `Prev` and `Next`, a repeated `Prev`, an off-host continuation, an unexpected path/query shape, partial-response reasons on a later page, and a continuation page whose newest timestamp is newer than the prior page's oldest timestamp. Confirm the exporter follows only validated `Prev` values and fails closed on ambiguity.
+
+### 3. Performance matrix
+
+Benchmark representative 7-day and 30-day ranges using disposable parameterized copies or a temporary spike. Suggested matrix:
+
+| Variable | Values |
+| --- | --- |
+| Page size | 250, 500, 1,000 |
+| Chunk hours | 2, 4, 8 |
+| Workers | 2, 4, 8, 16 |
+
+Screen configurations on seven days and retest finalists over 30 days. Judge range/order/cursor validation first, then warnings/restarts, peak working set, output rows/bytes, and wall-clock time. Because the source is volatile, do not require exact set or byte equality between separate live runs.
+
+### 4. Recovery and authentication interruption
+
+Interrupt a real multi-chunk export after completed parts exist. Reconnect and rerun it. Verify `ResumedChunks`, part length/hash validation, final SHA-256, atomic publication, `Finalizing` recovery, and preservation of the previous output during a failed `-Force` replacement. Simulate a 401/403 in one worker and confirm scheduling stops while completed parts remain resumable.
+
+### 5. Retry and partial-response injection
+
+Add focused tests for 429 with `Retry-After`, 5xx, timeout/transport failure, malformed JSON, explicit partial-response reasons after valid pages, and worker failure during part writing. Authentication and permanent HTTP failures must not be retried as transient failures.
+
+### 6. Sentinel-backed inclusion
+
+The Sentinel request flag is covered by unit tests, but inclusion of Sentinel-backed events has not been proven live. If the tenant has a known Sentinel-only event, compare exports with and without the option over a fixed range and retain sanitized aggregate evidence.
+
+## Decision gates
+
+- Keep current defaults unless a 30-day proof produces a repeatable win without weaker cursor validation or materially higher memory.
+- Do not add deduplication without a proven durable device-event identity.
+- If pagination semantics change, add an explicit manifest strategy such as `ServerPrevCursorV1` and invalidate incompatible resumable state. Otherwise defer the marker to avoid churn.
+- Add tests before promotion, then run the focused suite, repository harness, and a sanitized live proof.
+
+## Expected handoff
+
+Record the device selection method, UTC ranges, parameter matrix, rows/pages/restarts, peak memory, elapsed time, output hash, continuation diagnostics, and observed volatility. Separate mock evidence from live-service evidence. Update PR #123 but do not merge unless explicitly requested.

--- a/docs/identity-timeline-export-follow-up-plan.md
+++ b/docs/identity-timeline-export-follow-up-plan.md
@@ -1,0 +1,71 @@
+# Identity timeline exporter follow-up plan
+
+## Purpose
+
+Use this plan in a dedicated session to stress and tune `Export-XdrIdentityUserTimeline` without importing assumptions from the Cloud Apps or device APIs. The implementation is on branch `feature/export-identity-user-timeline` in `/home/nathan/GitHub/XdrInternals-identity-export` and is associated with PR #130.
+
+The current exporter uses 24-hour chunks, page size 1,000, eight workers, at most two fresh-window restarts, and manifest pagination strategy `TimestampKeysetV2`. Its worker always requests `skip=0`, moves an exclusive upper timestamp bound, withholds the oldest complete API-second group on a full page, validates the response `count`, `data`, and `errors` contract, and fails closed when one API second fills an entire page.
+
+Do not use EventId as a durable deduplication key. Prior live work found that it can be reused or change between requests. Do not port the Cloud Apps archived stable-ID convergence algorithm unless new identity-specific evidence proves a stable key.
+
+## Initial setup
+
+1. Work only in `/home/nathan/GitHub/XdrInternals-identity-export`; confirm the branch and dirty state before editing.
+2. Import the worktree module and authenticate with:
+
+   ```powershell
+   Import-Module ./XDRInternals/XDRInternals.psd1 -Force
+   Connect-XdrBySoftwarePasskey -KeyFilePath /home/nathan/GitHub/XdrInternals/.github/secadmin.passkey
+   ```
+
+3. Select a known high-activity identity using the supported identity resolution workflow. Record only sanitized identifiers and aggregate metrics.
+4. Run the focused baseline before experiments:
+
+   ```powershell
+   Invoke-Pester ./tests/functions/ExportIdentityUserTimeline.Tests.ps1
+   ```
+
+## Experiments
+
+### 1. Dense API-second boundary
+
+Export a 30- or 60-day range for the busiest available identity. Inspect manifests and output to determine the maximum events sharing one API second and whether pagination rewinds occur. Repeat a focused dense interval with page sizes 250, 500, and 1,000 in a disposable spike.
+
+The important failure condition is a full page whose records all occupy the same API second. The current safe behavior is to fail closed because no proven secondary ordering/filter exists. If this occurs, capture the sanitized response shape and investigate the service contract before changing code.
+
+### 2. Short-page terminal assumption
+
+The identity response has no `hasNext`. The exporter therefore treats a short page as terminal. For fixed historical windows, compare the stable payload set obtained with page sizes 250, 500, and 1,000. A smaller-page run returning records absent from a larger-page run would disprove the terminal assumption and requires a new API-specific continuation strategy.
+
+Do not demand byte-identical output when the service is changing. Compare canonical payload hashes, timestamp distributions, range validity, and page-boundary groups.
+
+### 3. Performance matrix
+
+Benchmark representative 7-day and 30-day ranges using disposable parameterized copies or a temporary spike. Suggested matrix:
+
+| Variable | Values |
+| --- | --- |
+| Page size | 250, 500, 1,000 |
+| Chunk hours | 6, 12, 24 |
+| Workers | 4, 8, 16 |
+
+Screen configurations on seven days, then retest the best candidates over 30 days. Judge results in this order: completeness and validation, warnings/restarts, peak working set, output bytes/rows, then wall-clock time. Do not keep a faster configuration that weakens boundary handling or materially increases memory.
+
+### 4. Recovery and authentication interruption
+
+Interrupt a real multi-chunk export after completed parts exist. Reconnect and rerun the same command. Verify `ResumedChunks`, part length/hash validation, final SHA-256, atomic publication, and preservation of a prior output under `-Force`. Also simulate or induce a 401/403 in one worker and confirm new scheduling stops while completed parts remain resumable.
+
+### 5. Retry and malformed-response injection
+
+Add focused tests for 429 with `Retry-After`, 5xx, timeout/transport failure, an `errors` collection after earlier valid pages, missing `data`, response-count mismatch, out-of-range timestamps, and an ordering reversal between pages. Authentication and permanent HTTP failures must not be retried as transient failures.
+
+## Decision gates
+
+- Keep existing defaults unless a 30-day proof shows a repeatable improvement with identical correctness evidence and acceptable memory.
+- Keep fail-closed dense-second behavior unless an identity-specific secondary cursor is proven live.
+- Version `PaginationStrategy` and invalidate incompatible manifests if pagination semantics change.
+- Add tests before promoting any finding. Run focused tests, then the repository harness and a sanitized live proof.
+
+## Expected handoff
+
+Record the entity selection method, UTC ranges, parameter matrix, rows/pages/restarts/rewinds, peak memory, elapsed time, output hash, and any cross-run volatility. Separate mock evidence from live-service evidence. Update PR #130 but do not merge unless explicitly requested.

--- a/tests/functions/CloudApps.Tests.ps1
+++ b/tests/functions/CloudApps.Tests.ps1
@@ -231,11 +231,47 @@
         }
     }
 
-    It 'skips null activity payload items when writing chunk files' {
+    It 'rejects caller-supplied date filters for bounded requests' {
+        $from = [datetime]::UtcNow.AddHours(-2)
+        $to = [datetime]::UtcNow.AddHours(-1)
+
+        {
+            Get-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $to -Filters @{ date = @{ gte = 1 } }
+        } | Should -Throw -ExpectedMessage '*Filters cannot contain date for a bounded request*'
+    }
+
+    It 'rejects created filters when bounded requests include archived activity' {
+        $from = [datetime]::UtcNow.AddDays(-31)
+        $to = [datetime]::UtcNow.AddDays(-30).AddHours(-1)
+
+        {
+            Get-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $to -Filters @{ created = @{ gte = 1 } }
+        } | Should -Throw -ExpectedMessage '*archived API does not support that filter*'
+    }
+
+    It 'does not collapse distinct payloads that reuse an activity identifier' {
+        InModuleScope XDRInternals {
+            $sha256 = [System.Security.Cryptography.SHA256]::Create()
+            try {
+                $first = Get-XdrCloudAppsActivityStableKey -Activity ([pscustomobject]@{ _id = 'shared'; detail = 'first' }) -Sha256 $sha256
+                $second = Get-XdrCloudAppsActivityStableKey -Activity ([pscustomobject]@{ _id = 'shared'; detail = 'second' }) -Sha256 $sha256
+
+                $first | Should -Not -Be $second
+            }
+            finally {
+                $sha256.Dispose()
+            }
+        }
+    }
+
+    It 'fails closed on null activity payload items' {
         $eventTime = [datetime]::UtcNow.AddMinutes(-5)
         $eventTimestamp = [long](($eventTime - [datetime]'1970-01-01').TotalMilliseconds)
 
         Mock Invoke-RestMethod {
+            if ($Uri -like '*/count/') {
+                return [pscustomobject]@{ total = 1; moreThanTotal = $false; searchedSince = 'test' }
+            }
             [pscustomobject]@{
                 data    = @(
                     $null,
@@ -262,15 +298,9 @@
             try {
                 $script:PSVersionTable = @{ PSVersion = [version]'5.1.0' }
 
-                $result = @(Get-XdrCloudAppsActivityTimeline -FromDate $EventTime.AddHours(-1) -ToDate $EventTime.AddHours(1) -OutputPath $TempPath -KeepTempFiles)
-
-                $result | Should -HaveCount 1
-                $result[0]._id | Should -Be 'activity-1'
-
-                $chunkPath = Get-ChildItem -Path $TempPath -Recurse -Filter 'chunk_*.json' | Select-Object -First 1 -ExpandProperty FullName
-                $chunkContent = Get-Content -Path $chunkPath -Raw
-
-                $chunkContent | Should -Not -Match 'null'
+                {
+                    Get-XdrCloudAppsActivityTimeline -FromDate $EventTime.AddMinutes(-30) -ToDate $EventTime.AddMinutes(1) -ChunkHours 1 -OutputPath $TempPath
+                } | Should -Throw -ExpectedMessage '*received a null activity record*'
             }
             finally {
                 if ($hadScriptVersionTable) {
@@ -287,6 +317,9 @@
         $eventTime = [datetime]::UtcNow.AddMinutes(-5)
         $eventTimestamp = [long](($eventTime - [datetime]'1970-01-01').TotalMilliseconds)
         Mock Invoke-RestMethod {
+            if ($Uri -like '*/count/') {
+                return [pscustomobject]@{ total = 1; moreThanTotal = $false; searchedSince = 'test' }
+            }
             @{
                 data = @(
                     @{
@@ -311,7 +344,7 @@
             try {
                 $script:PSVersionTable = @{ PSVersion = [version]'5.1.0' }
 
-                $result = @(Get-XdrCloudAppsActivityTimeline -FromDate $EventTime.AddHours(-1) -ToDate $EventTime.AddHours(1) -OutputPath $TempPath -KeepTempFiles)
+                $result = @(Get-XdrCloudAppsActivityTimeline -FromDate $EventTime.AddMinutes(-30) -ToDate $EventTime.AddMinutes(1) -ChunkHours 1 -OutputPath $TempPath -KeepTempFiles)
 
                 $result | Should -HaveCount 1
                 $result[0]._id | Should -Be 'activity-string-1'
@@ -327,28 +360,27 @@
         }
     }
 
-    It 'skips unreadable activity chunk files when partial data is allowed' {
-        $chunkPath = Join-Path $TestDrive 'chunk_bad.json'
-        Set-Content -Path $chunkPath -Value '{"Events":[{"_id":"activity-1"}' -Encoding UTF8
+    It 'skips unreadable activity part files when partial data is allowed' {
+        $chunkPath = Join-Path $TestDrive 'chunk_bad.ndjson'
+        Set-Content -Path $chunkPath -Value '{"_id":"activity-1"' -Encoding UTF8
 
         InModuleScope -ModuleName XDRInternals -Parameters @{ ChunkPath = $chunkPath } {
             param($ChunkPath)
 
-            $result = Read-XdrCloudAppsActivityChunkFile -File (Get-Item -Path $ChunkPath) -AllowPartial -WarningAction SilentlyContinue
+            $result = @(Read-XdrCloudAppsActivityPartFile -File (Get-Item -Path $ChunkPath) -AllowPartial -WarningAction SilentlyContinue)
 
             $result | Should -BeNullOrEmpty
         }
     }
 
-    It 'reads activity chunk files that contain keys differing only by case' {
-        $chunkPath = Join-Path $TestDrive 'chunk_case_keys.json'
-        Set-Content -Path $chunkPath -Value '{"Events":[{"_id":"activity-1","timestamp":1710000000000,"level":"low","Level":"High"}],"EventCount":1}' -Encoding UTF8
+    It 'reads activity part files that contain keys differing only by case' {
+        $chunkPath = Join-Path $TestDrive 'chunk_case_keys.ndjson'
+        Set-Content -Path $chunkPath -Value '{"_id":"activity-1","timestamp":1710000000000,"level":"low","Level":"High"}' -Encoding UTF8
 
         InModuleScope -ModuleName XDRInternals -Parameters @{ ChunkPath = $chunkPath } {
             param($ChunkPath)
 
-            $result = Read-XdrCloudAppsActivityChunkFile -File (Get-Item -Path $ChunkPath)
-            $activity = @(Get-XdrCloudAppsObjectValue -InputObject $result -Name 'Events')[0]
+            $activity = @(Read-XdrCloudAppsActivityPartFile -File (Get-Item -Path $ChunkPath))[0]
 
             (Get-XdrCloudAppsObjectValue -InputObject $activity -Name 'level') | Should -Be 'low'
             (Get-XdrCloudAppsObjectValue -InputObject $activity -Name 'Level') | Should -Be 'High'
@@ -356,14 +388,14 @@
         }
     }
 
-    It 'throws unreadable activity chunk errors when partial data is not allowed' {
-        $chunkPath = Join-Path $TestDrive 'chunk_bad_strict.json'
-        Set-Content -Path $chunkPath -Value '{"Events":[{"_id":"activity-1"}' -Encoding UTF8
+    It 'throws unreadable activity part errors when partial data is not allowed' {
+        $chunkPath = Join-Path $TestDrive 'chunk_bad_strict.ndjson'
+        Set-Content -Path $chunkPath -Value '{"_id":"activity-1"' -Encoding UTF8
 
         InModuleScope -ModuleName XDRInternals -Parameters @{ ChunkPath = $chunkPath } {
             param($ChunkPath)
 
-            { Read-XdrCloudAppsActivityChunkFile -File (Get-Item -Path $ChunkPath) } |
+            { Read-XdrCloudAppsActivityPartFile -File (Get-Item -Path $ChunkPath) } |
                 Should -Throw -ExpectedMessage '*Conversion from JSON failed*'
         }
     }

--- a/tests/functions/ExportCloudAppsActivityTimeline.Tests.ps1
+++ b/tests/functions/ExportCloudAppsActivityTimeline.Tests.ps1
@@ -1,0 +1,864 @@
+﻿Describe 'Export-XdrCloudAppsActivityTimeline worker' {
+    BeforeEach {
+        InModuleScope XDRInternals {
+            $script:session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            $script:headers = @{}
+        }
+    }
+
+    It 'uses timestamp keyset pagination and writes every counted activity once' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $from = [datetime]'2026-01-01T00:00:00Z'
+            $to = $from.AddHours(1)
+            $firstTimestamp = [datetimeoffset]::new($from.AddMinutes(50)).ToUnixTimeMilliseconds()
+            $firstPage = @(
+                for ($i = 0; $i -lt 250; $i++) {
+                    [ordered]@{ _id = "activity-$i"; timestamp = $firstTimestamp - $i; date = [datetimeoffset]::FromUnixTimeMilliseconds($firstTimestamp - $i).ToString('o') }
+                }
+            )
+            $oldestTimestamp = [long]$firstPage[-1].timestamp
+            $secondPage = @(
+                $firstPage[-1],
+                [ordered]@{ _id = 'activity-250'; timestamp = $oldestTimestamp - 1; date = [datetimeoffset]::FromUnixTimeMilliseconds($oldestTimestamp - 1).ToString('o') }
+            )
+            $script:ActivityRequest = 0
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') {
+                    return [PSCustomObject]@{ total = 251; moreThanTotal = $false; searchedSince = 'test' }
+                }
+                $script:ActivityRequest++
+                if ($script:ActivityRequest -eq 1) {
+                    return [PSCustomObject]@{ data = $firstPage; hasNext = $true; performAsyncTotal = $true }
+                }
+                $request = $Body | ConvertFrom-Json
+                $request.filters.date.lte | Should -Be $oldestTimestamp
+                return [PSCustomObject]@{ data = $secondPage; hasNext = $false; performAsyncTotal = $true }
+            }
+
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = $from; ToDate = $to; Archived = $false; FileName = 'part.ndjson' }
+            $shared = @{
+                PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}
+                CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1
+                RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100
+            }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.EventCount | Should -Be 251
+            $result.ExpectedEventCount | Should -Be 251
+            $result.PageCount | Should -Be 2
+            $result.RewindCount | Should -Be 1
+            @(Get-Content -LiteralPath $result.FilePath) | Should -HaveCount 251
+            Should -Invoke Invoke-RestMethod -Times 3 -Exactly
+        }
+    }
+
+    It 'continues timestamp keyset pagination when a short page reports more data' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $from = [datetime]'2026-01-01T00:00:00Z'
+            $newer = [datetimeoffset]::new($from.AddMinutes(40)).ToUnixTimeMilliseconds()
+            $boundary = [datetimeoffset]::new($from.AddMinutes(30)).ToUnixTimeMilliseconds()
+            $older = [datetimeoffset]::new($from.AddMinutes(20)).ToUnixTimeMilliseconds()
+            $script:ActivityRequest = 0
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') {
+                    return [PSCustomObject]@{ total = 3; moreThanTotal = $false; searchedSince = 'test' }
+                }
+                $script:ActivityRequest++
+                if ($script:ActivityRequest -eq 1) {
+                    return [PSCustomObject]@{
+                        data = @(
+                            [PSCustomObject]@{ _id = 'newer'; timestamp = $newer },
+                            [PSCustomObject]@{ _id = 'boundary'; timestamp = $boundary }
+                        )
+                        hasNext = $true
+                    }
+                }
+                $request = $Body | ConvertFrom-Json
+                $request.filters.date.lte | Should -Be $boundary
+                return [PSCustomObject]@{
+                    data = @(
+                        [PSCustomObject]@{ _id = 'boundary'; timestamp = $boundary },
+                        [PSCustomObject]@{ _id = 'older'; timestamp = $older }
+                    )
+                    hasNext = $false
+                }
+            }
+
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = $from; ToDate = $from.AddHours(1); Archived = $false; FileName = 'short-page.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.EventCount | Should -Be 3
+            $result.PageCount | Should -Be 2
+            $result.RewindCount | Should -Be 1
+            @(Get-Content -LiteralPath $result.FilePath) | Should -HaveCount 3
+        }
+    }
+
+    It 'preserves response keys that differ only by case' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $from = [datetime]'2026-01-01T00:00:00Z'
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') {
+                    return [PSCustomObject]@{ total = 1; moreThanTotal = $false; searchedSince = 'test' }
+                }
+                return '{"data":[{"_id":"activity-1","timestamp":1767227400000,"level":"low","Level":"High"}],"hasNext":false,"performAsyncTotal":true}'
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = $from; ToDate = $from.AddHours(1); Archived = $false; FileName = 'case.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+            $line = Get-Content -LiteralPath $result.FilePath -Raw
+
+            $result.Success | Should -BeTrue
+            $line | Should -Match '"level":"low"'
+            $line | Should -Match '"Level":"High"'
+        }
+    }
+
+    It 'uses the archived range filter for archived chunks' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $from = [datetime]'2025-01-01T00:00:00Z'
+            Mock Invoke-RestMethod {
+                $request = $Body | ConvertFrom-Json
+                $request.filters.date.range | Should -Not -BeNullOrEmpty
+                $request.filters.date.PSObject.Properties.Name | Should -Not -Contain 'gte'
+                if ($Uri -like '*/count/') {
+                    $Uri | Should -BeLike '*/archived_activities/count/'
+                    return [PSCustomObject]@{ total = 0; moreThanTotal = $false; searchedSince = 'test' }
+                }
+                $Uri | Should -BeLike '*/archived_activities/'
+                return [PSCustomObject]@{ data = @(); hasNext = $false }
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = $from; ToDate = $from.AddHours(1); Archived = $true; FileName = 'archived.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.Archived | Should -BeTrue
+            $result.EventCount | Should -Be 0
+        }
+    }
+
+    It 'accepts an empty response only when the count is zero' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') { return [PSCustomObject]@{ total = 0; moreThanTotal = $false; searchedSince = 'test' } }
+                return [PSCustomObject]@{}
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; Archived = $false; FileName = 'empty.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.EventCount | Should -Be 0
+            (Get-Item -LiteralPath $result.FilePath).Length | Should -Be 0
+        }
+    }
+
+    It 'fails closed when the list does not match the count API' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $timestamp = [datetimeoffset]::new([datetime]'2026-01-01T00:30:00Z').ToUnixTimeMilliseconds()
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') { return [PSCustomObject]@{ total = 2; moreThanTotal = $false; searchedSince = 'test' } }
+                return [PSCustomObject]@{ data = @([PSCustomObject]@{ _id = 'one'; timestamp = $timestamp }); hasNext = $false }
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; Archived = $false; FileName = 'mismatch.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'PartialResponse'
+            Test-Path -LiteralPath $result.FilePath | Should -BeFalse
+        }
+    }
+
+    It 'records a persistent count overestimate after fresh-window retries are exhausted' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $timestamp = [datetimeoffset]::new([datetime]'2026-01-01T00:30:00Z').ToUnixTimeMilliseconds()
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') { return [PSCustomObject]@{ total = 2; moreThanTotal = $false; searchedSince = 'test' } }
+                return [PSCustomObject]@{ data = @([PSCustomObject]@{ _id = 'one'; timestamp = $timestamp }); hasNext = $false }
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; Archived = $false; FileName = 'stable-mismatch.ndjson'; Attempt = 2 }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100; MaxCountMismatchRestarts = 2 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.EventCount | Should -Be 1
+            $result.ExpectedEventCount | Should -Be 2
+            $result.CountDelta | Should -Be -1
+        }
+    }
+
+    It 'suppresses repeated stable activity representations before count validation' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $newer = [datetimeoffset]::new([datetime]'2026-01-01T00:40:00Z').ToUnixTimeMilliseconds()
+            $older = [datetimeoffset]::new([datetime]'2026-01-01T00:30:00Z').ToUnixTimeMilliseconds()
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') { return [PSCustomObject]@{ total = 2; moreThanTotal = $false; searchedSince = 'test' } }
+                return [PSCustomObject]@{
+                    data = @(
+                        [PSCustomObject]@{ _id = 'one'; timestamp = $newer },
+                        [PSCustomObject]@{ _id = 'one'; timestamp = $newer },
+                        [PSCustomObject]@{ _id = 'two'; timestamp = $older }
+                    )
+                    hasNext = $false
+                }
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; Archived = $false; FileName = 'duplicates.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.EventCount | Should -Be 2
+            $result.DuplicateRepresentationCount | Should -Be 1
+            @(Get-Content -LiteralPath $result.FilePath) | Should -HaveCount 2
+        }
+    }
+
+    It 'preserves unique activities returned beyond the count API snapshot' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $timestamp = [datetimeoffset]::new([datetime]'2026-01-01T00:30:00Z').ToUnixTimeMilliseconds()
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') { return [PSCustomObject]@{ total = 2; moreThanTotal = $false; searchedSince = 'test' } }
+                return [PSCustomObject]@{
+                    data = @(
+                        [PSCustomObject]@{ _id = 'one'; timestamp = $timestamp + 2 },
+                        [PSCustomObject]@{ _id = 'two'; timestamp = $timestamp + 1 },
+                        [PSCustomObject]@{ _id = 'three'; timestamp = $timestamp }
+                    )
+                    hasNext = $false
+                }
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; Archived = $false; FileName = 'count-delta.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.EventCount | Should -Be 3
+            $result.ExpectedEventCount | Should -Be 2
+            $result.CountDelta | Should -Be 1
+        }
+    }
+
+    It 'preserves identifier reuse at different timestamps' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $timestamp = [datetimeoffset]::new([datetime]'2026-01-01T00:30:00Z').ToUnixTimeMilliseconds()
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') { return [PSCustomObject]@{ total = 2; moreThanTotal = $false; searchedSince = 'test' } }
+                return [PSCustomObject]@{
+                    data = @(
+                        [PSCustomObject]@{ _id = 'reused'; timestamp = $timestamp + 1 },
+                        [PSCustomObject]@{ _id = 'reused'; timestamp = $timestamp }
+                    )
+                    hasNext = $false
+                }
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; Archived = $false; FileName = 'reused.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.EventCount | Should -Be 2
+            $result.DuplicateRepresentationCount | Should -Be 0
+        }
+    }
+
+    It 'preserves distinct payloads that share an identifier and timestamp' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $timestamp = [datetimeoffset]::new([datetime]'2026-01-01T00:30:00Z').ToUnixTimeMilliseconds()
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') { return [PSCustomObject]@{ total = 2; moreThanTotal = $false; searchedSince = 'test' } }
+                return [PSCustomObject]@{
+                    data = @(
+                        [PSCustomObject]@{ _id = 'shared'; timestamp = $timestamp; detail = 'first' },
+                        [PSCustomObject]@{ _id = 'shared'; timestamp = $timestamp; detail = 'second' }
+                    )
+                    hasNext = $false
+                }
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; Archived = $false; FileName = 'shared.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.EventCount | Should -Be 2
+            $result.DuplicateRepresentationCount | Should -Be 0
+        }
+    }
+
+    It 'fails closed on a missing activity timestamp' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') { return [PSCustomObject]@{ total = 1; moreThanTotal = $false; searchedSince = 'test' } }
+                return [PSCustomObject]@{ data = @([PSCustomObject]@{ _id = 'missing' }); hasNext = $false }
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; Archived = $false; FileName = 'missing.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.MissingTimestampCount | Should -Be 1
+        }
+    }
+
+    It 'classifies authentication failures without retrying them' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            Mock Invoke-RestMethod {
+                $response = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::Forbidden)
+                throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('Forbidden', $response)
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; Archived = $false; FileName = 'denied.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 3; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'Authentication'
+            $result.RetryCount | Should -Be 0
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly
+        }
+    }
+
+    It 'honors Retry-After when retrying a throttled request' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $script:RequestCount = 0
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $script:RequestCount++
+                if ($script:RequestCount -eq 1) {
+                    $response = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::TooManyRequests)
+                    $response.Headers.RetryAfter = [System.Net.Http.Headers.RetryConditionHeaderValue]::new([timespan]::FromSeconds(7))
+                    throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('Throttled', $response)
+                }
+                if ($Uri -like '*/count/') {
+                    return [PSCustomObject]@{ total = 0; moreThanTotal = $false; searchedSince = 'test' }
+                }
+                return [PSCustomObject]@{ data = @(); hasNext = $false }
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; Archived = $false; FileName = 'throttled.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 2; RetryDelaySeconds = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.RetryCount | Should -Be 1
+            Should -Invoke Start-Sleep -Times 1 -Exactly -ParameterFilter { $Seconds -ge 7 }
+        }
+    }
+
+    It 'retries transport and server failures before succeeding' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $script:RequestCount = 0
+            Mock Start-Sleep {}
+            Mock Invoke-RestMethod {
+                $script:RequestCount++
+                if ($script:RequestCount -eq 1) { throw [System.TimeoutException]::new('simulated timeout') }
+                if ($script:RequestCount -eq 2) {
+                    $response = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::InternalServerError)
+                    throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('server failure', $response)
+                }
+                if ($Uri -like '*/count/') {
+                    return [PSCustomObject]@{ total = 0; moreThanTotal = $false; searchedSince = 'test' }
+                }
+                return [PSCustomObject]@{ data = @(); hasNext = $false }
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; Archived = $false; FileName = 'transient.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 3; RetryDelaySeconds = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeTrue
+            $result.RetryCount | Should -Be 2
+            Should -Invoke Start-Sleep -Times 2 -Exactly
+            Should -Invoke Invoke-RestMethod -Times 4 -Exactly
+        }
+    }
+
+    It 'uses created keyset pagination when one activity timestamp fills a complete page' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $from = [datetime]'2026-01-01T00:00:00Z'
+            $expectedTimestampMilliseconds = [datetimeoffset]::new($from).ToUnixTimeMilliseconds()
+            $firstCreated = $expectedTimestampMilliseconds + 1000
+            $firstPage = @(
+                for ($i = 0; $i -lt 250; $i++) {
+                    [PSCustomObject]@{ _id = "dense-$i"; timestamp = $expectedTimestampMilliseconds; created = $firstCreated - $i }
+                }
+            )
+            $oldestCreated = [long]$firstPage[-1].created
+            $secondPage = @(
+                $firstPage[-1],
+                [PSCustomObject]@{ _id = 'dense-250'; timestamp = $expectedTimestampMilliseconds; created = $oldestCreated - 1 }
+            )
+            $script:ActivityRequest = 0
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') {
+                    return [PSCustomObject]@{ total = 251; moreThanTotal = $false; searchedSince = 'test' }
+                }
+                $script:ActivityRequest++
+                $request = $Body | ConvertFrom-Json
+                if ($script:ActivityRequest -eq 1) {
+                    $request.sortField | Should -Be 'date'
+                    return [PSCustomObject]@{ data = $firstPage; hasNext = $true }
+                }
+                $request.sortField | Should -Be 'created'
+                $request.filters.date.gte | Should -Be $expectedTimestampMilliseconds
+                $request.filters.date.lte | Should -Be $expectedTimestampMilliseconds
+                if ($script:ActivityRequest -eq 2) {
+                    $request.filters.PSObject.Properties.Name | Should -Not -Contain 'created'
+                    return [PSCustomObject]@{ data = $firstPage; hasNext = $true }
+                }
+                $request.filters.created.lte | Should -Be $oldestCreated
+                return [PSCustomObject]@{ data = $secondPage; hasNext = $false }
+            }
+
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = $from; ToDate = $from.AddHours(1); Archived = $false; FileName = 'dense.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Error | Should -BeNullOrEmpty
+            $result.Success | Should -BeTrue
+            $result.EventCount | Should -Be 251
+            $result.PageCount | Should -Be 3
+            $result.RewindCount | Should -Be 2
+            @(Get-Content -LiteralPath $result.FilePath) | Should -HaveCount 251
+            Should -Invoke Invoke-RestMethod -Times 4 -Exactly
+        }
+    }
+
+    It 'uses stable activity IDs to complete an archived dense timestamp' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $from = [datetime]'2025-01-01T00:00:00Z'
+            $expectedTimestampMilliseconds = [datetimeoffset]::new($from).ToUnixTimeMilliseconds()
+            $firstCreated = $expectedTimestampMilliseconds + 1000
+            $firstPage = @(
+                for ($i = 0; $i -lt 250; $i++) {
+                    [PSCustomObject]@{ _id = "archived-$i"; timestamp = $expectedTimestampMilliseconds; created = $firstCreated - $i }
+                }
+            )
+            $lastPage = @(
+                [PSCustomObject]@{ _id = 'archived-250'; timestamp = $expectedTimestampMilliseconds; created = $firstCreated - 250 }
+            )
+            $ascendingFirstPage = @($firstPage[249..0])
+            $script:ActivityRequest = 0
+            $script:CountRequest = 0
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') {
+                    $script:CountRequest++
+                    $count = if ($script:CountRequest -eq 1) { 251 } else { 252 }
+                    return [PSCustomObject]@{ total = $count; moreThanTotal = $false; searchedSince = 'test' }
+                }
+                $script:ActivityRequest++
+                $request = $Body | ConvertFrom-Json
+                if ($script:ActivityRequest -eq 1) {
+                    $request.sortField | Should -Be 'date'
+                    return [PSCustomObject]@{ data = $firstPage; hasNext = $true }
+                }
+                $request.sortField | Should -Be 'created'
+                $request.filters.date.range[0].start | Should -Be $expectedTimestampMilliseconds
+                $request.filters.date.range[0].end | Should -Be $expectedTimestampMilliseconds
+                if ($request.skip -eq 0) {
+                    $request.skip | Should -Be 0
+                    $page = if ($request.sortDirection -eq 'asc') { $ascendingFirstPage } else { $firstPage }
+                    return [PSCustomObject]@{ data = $page; hasNext = $true }
+                }
+                $request.skip | Should -Be 250
+                return [PSCustomObject]@{ data = $lastPage; hasNext = $false }
+            }
+
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = $from; ToDate = $from.AddHours(1); Archived = $true; FileName = 'archived-dense.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Error | Should -BeNullOrEmpty
+            $result.Success | Should -BeTrue
+            $result.EventCount | Should -Be 251
+            $result.PageCount | Should -Be 7
+            $result.RewindCount | Should -Be 1
+            @(Get-Content -LiteralPath $result.FilePath) | Should -HaveCount 251
+            Should -Invoke Invoke-RestMethod -Times 9 -Exactly
+        }
+    }
+
+    It 'fails closed when a recent created timestamp also fills a complete page' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $timestamp = [datetimeoffset]::new([datetime]'2026-01-01T00:30:00Z').ToUnixTimeMilliseconds()
+            $created = $timestamp + 1000
+            $events = @(for ($i = 0; $i -lt 250; $i++) { [PSCustomObject]@{ _id = "created-$i"; timestamp = $timestamp; created = $created } })
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') { return [PSCustomObject]@{ total = 251; moreThanTotal = $false; searchedSince = 'test' } }
+                return [PSCustomObject]@{ data = $events; hasNext = $true }
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; Archived = $false; FileName = 'dense-created.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'UnpageableBoundary'
+            $result.Error | Should -BeLike '*one created timestamp millisecond filled*'
+        }
+    }
+
+    It 'fails closed when an archived stable identifier maps to different dense payloads' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $expectedTimestampMilliseconds = [datetimeoffset]::new([datetime]'2025-01-01T00:30:00Z').ToUnixTimeMilliseconds()
+            $primaryEvents = @(for ($i = 0; $i -lt 250; $i++) { [PSCustomObject]@{ _id = "primary-$i"; timestamp = $expectedTimestampMilliseconds; created = ($expectedTimestampMilliseconds + 1000 - $i) } })
+            $script:CountRequest = 0
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') {
+                    $script:CountRequest++
+                    return [PSCustomObject]@{ total = $(if ($script:CountRequest -eq 1) { 250 } else { 2 }); moreThanTotal = $false; searchedSince = 'test' }
+                }
+                $request = $Body | ConvertFrom-Json
+                if ($request.sortField -eq 'date') {
+                    return [PSCustomObject]@{ data = $primaryEvents; hasNext = $true }
+                }
+                return [PSCustomObject]@{
+                    data = @(
+                        [PSCustomObject]@{ _id = 'reused'; timestamp = $expectedTimestampMilliseconds; created = ($expectedTimestampMilliseconds + 2); detail = 'first' },
+                        [PSCustomObject]@{ _id = 'reused'; timestamp = $expectedTimestampMilliseconds; created = ($expectedTimestampMilliseconds + 1); detail = 'second' }
+                    )
+                    hasNext = $false
+                }
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2025-01-01Z'; ToDate = [datetime]'2025-01-01T01:00:00Z'; Archived = $true; FileName = 'dense-id-collision.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.Error | Should -BeLike '*different archived dense-timestamp payloads*'
+            $result.FailureClass | Should -Be 'UnpageableBoundary'
+        }
+    }
+
+    It 'fails when created cannot disambiguate a full activity timestamp page' {
+        InModuleScope XDRInternals -Parameters @{ TestRoot = $TestDrive } {
+            $timestamp = [datetimeoffset]::new([datetime]'2026-01-01T00:30:00Z').ToUnixTimeMilliseconds()
+            $events = @(for ($i = 0; $i -lt 250; $i++) { [PSCustomObject]@{ _id = "same-$i"; timestamp = $timestamp } })
+            Mock Invoke-RestMethod {
+                if ($Uri -like '*/count/') { return [PSCustomObject]@{ total = 250; moreThanTotal = $false; searchedSince = 'test' } }
+                return [PSCustomObject]@{ data = $events; hasNext = $false }
+            }
+            $worker = New-XdrCloudAppsActivityTimelineExportWorker
+            $chunk = [PSCustomObject]@{ Index = 0; FromDate = [datetime]'2026-01-01Z'; ToDate = [datetime]'2026-01-01T01:00:00Z'; Archived = $false; FileName = 'unpageable.ndjson' }
+            $shared = @{ PartsPath = $TestRoot; BaseUrl = 'https://security.microsoft.com'; Filters = @{}; CookieData = @(); HeadersData = @{}; PageSize = 250; MaxRetries = 1; RequestTimeoutSeconds = 30; MaxPagesPerChunk = 100 }
+            $status = [System.Collections.Concurrent.ConcurrentDictionary[int, object]]::new()
+
+            $result = & $worker $chunk $shared $status
+
+            $result.Success | Should -BeFalse
+            $result.FailureClass | Should -Be 'UnpageableBoundary'
+        }
+    }
+}
+
+Describe 'Export-XdrCloudAppsActivityTimeline orchestration' {
+    BeforeEach {
+        Mock Update-XdrConnectionSettings {} -ModuleName XDRInternals
+        InModuleScope XDRInternals {
+            $script:session = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            $script:headers = @{}
+        }
+        Mock New-XdrCloudAppsActivityTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                [void]$statusMap
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                [System.IO.File]::WriteAllText($filePath, "{`"chunk`":$([int]$chunk.Index)}`n", [System.Text.UTF8Encoding]::new($false))
+                [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; ExpectedEventCount = 1L
+                    CountIsLowerBound = $false; PageCount = 1; RetryCount = 0; RewindCount = 0
+                    FileBytes = (Get-Item $filePath).Length; FileSha256 = (Get-FileHash $filePath).Hash.ToLowerInvariant()
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; ElapsedSeconds = 0.01
+                    Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+    }
+
+    It 'exports newest windows first and publishes a validated manifest' {
+        $from = [datetime]'2026-01-01T00:00:00Z'
+        $outputPath = Join-Path $TestDrive 'cloud-apps.ndjson'
+
+        $result = Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $from.AddHours(7) -Path $outputPath
+        $manifest = Get-Content -LiteralPath "$outputPath.manifest.json" -Raw | ConvertFrom-Json
+
+        $result.TotalEvents | Should -Be 2
+        $result.TotalChunks | Should -Be 2
+        $manifest.State | Should -Be 'Complete'
+        @(Get-Content -LiteralPath $outputPath) | Should -Be @('{"chunk":0}', '{"chunk":1}')
+        (Get-FileHash -LiteralPath $outputPath).Hash.ToLowerInvariant() | Should -Be $result.FileSha256
+        Test-Path -LiteralPath "$outputPath.parts" | Should -BeFalse
+    }
+
+    It 'splits a range crossing the archive boundary into both API routes' {
+        $to = [datetime]::UtcNow.AddDays(-29)
+        $from = [datetime]::UtcNow.AddDays(-31)
+        $outputPath = Join-Path $TestDrive 'mixed.ndjson'
+
+        $null = Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $to -Path $outputPath
+        $manifest = Get-Content -LiteralPath "$outputPath.manifest.json" -Raw | ConvertFrom-Json
+
+        @($manifest.Chunks | Where-Object Archived).Count | Should -BeGreaterThan 0
+        @($manifest.Chunks | Where-Object { -not $_.Archived }).Count | Should -BeGreaterThan 0
+    }
+
+    It 'rejects a caller-supplied date filter' {
+        $from = [datetime]'2026-01-01T00:00:00Z'
+        { Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $from.AddHours(1) -Path (Join-Path $TestDrive 'date.ndjson') -Filters @{ date = @{ gte = 1 } } } |
+            Should -Throw -ExpectedMessage '*cannot contain date*'
+    }
+
+    It 'rejects a created filter when the range includes archived activity' {
+        $from = [datetime]::UtcNow.AddDays(-31)
+        $to = [datetime]::UtcNow.AddDays(-30).AddHours(-1)
+
+        { Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $to -Path (Join-Path $TestDrive 'archived-created.ndjson') -Filters @{ created = @{ gte = 1 } } } |
+            Should -Throw -ExpectedMessage '*archived API does not support that filter*'
+    }
+
+    It 'rejects incompatible filter state on resume' {
+        Mock New-XdrCloudAppsActivityTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                [void]$sharedParameters
+                [void]$statusMap
+                [PSCustomObject]@{
+                    Success = $false; ChunkIndex = [int]$chunk.Index; EventCount = 0L; ExpectedEventCount = 0L
+                    CountIsLowerBound = $false; PageCount = 0; RetryCount = 0; RewindCount = 0
+                    FileBytes = 0L; FileSha256 = $null; MissingTimestampCount = 0L; BoundaryTimestampCount = 0L
+                    ElapsedSeconds = 0.01; Error = 'stop after manifest creation'; FailureClass = 'PermanentHttp'
+                }
+            }
+        } -ModuleName XDRInternals
+        $from = [datetime]'2026-01-01T00:00:00Z'
+        $outputPath = Join-Path $TestDrive 'incompatible.ndjson'
+        { Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $from.AddHours(1) -Path $outputPath -Filters @{ app = @{ eq = @('One') } } } | Should -Throw
+
+        { Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $from.AddHours(1) -Path $outputPath -Filters @{ app = @{ eq = @('Two') } } } |
+            Should -Throw -ExpectedMessage '*does not match this request*'
+    }
+
+    It 'resumes validated completed parts after an interrupted export' {
+        $script:ResumePhase = 1
+        Mock New-XdrCloudAppsActivityTimelineExportWorker {
+            if ($script:ResumePhase -eq 1) {
+                return {
+                    param($chunk, $sharedParameters, $statusMap)
+                    [void]$statusMap
+                    if ([int]$chunk.Index -eq 1) {
+                        return [PSCustomObject]@{
+                            Success = $false; ChunkIndex = 1; EventCount = 0L; ExpectedEventCount = 0L
+                            CountIsLowerBound = $false; CountDelta = 0L; PageCount = 0; RetryCount = 0
+                            RewindCount = 0; FileBytes = 0L; FileSha256 = $null; MissingTimestampCount = 0L
+                            BoundaryTimestampCount = 0L; DuplicateRepresentationCount = 0L; ElapsedSeconds = 0.01
+                            Error = 'simulated interruption'; FailureClass = 'PermanentHttp'
+                        }
+                    }
+                    $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                    [System.IO.File]::WriteAllText($filePath, "{`"chunk`":$([int]$chunk.Index)}`n", [System.Text.UTF8Encoding]::new($false))
+                    return [PSCustomObject]@{
+                        Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; ExpectedEventCount = 1L
+                        CountIsLowerBound = $false; CountDelta = 0L; PageCount = 1; RetryCount = 0
+                        RewindCount = 0; FileBytes = (Get-Item $filePath).Length
+                        FileSha256 = (Get-FileHash $filePath).Hash.ToLowerInvariant(); MissingTimestampCount = 0L
+                        BoundaryTimestampCount = 0L; DuplicateRepresentationCount = 0L; ElapsedSeconds = 0.01
+                        Error = $null; FailureClass = $null
+                    }
+                }
+            }
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                [void]$statusMap
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                [System.IO.File]::WriteAllText($filePath, "{`"chunk`":$([int]$chunk.Index)}`n", [System.Text.UTF8Encoding]::new($false))
+                [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; ExpectedEventCount = 1L
+                    CountIsLowerBound = $false; CountDelta = 0L; PageCount = 1; RetryCount = 0
+                    RewindCount = 0; FileBytes = (Get-Item $filePath).Length
+                    FileSha256 = (Get-FileHash $filePath).Hash.ToLowerInvariant(); MissingTimestampCount = 0L
+                    BoundaryTimestampCount = 0L; DuplicateRepresentationCount = 0L; ElapsedSeconds = 0.01
+                    Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+        $from = [datetime]'2026-01-01T00:00:00Z'
+        $outputPath = Join-Path $TestDrive 'resume.ndjson'
+
+        { Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $from.AddHours(13) -Path $outputPath } | Should -Throw
+        $script:ResumePhase = 2
+        $result = Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $from.AddHours(13) -Path $outputPath
+
+        $result.TotalEvents | Should -Be 3
+        $result.ResumedChunks | Should -Be 2
+        @(Get-Content -LiteralPath $outputPath) | Should -Be @('{"chunk":0}', '{"chunk":1}', '{"chunk":2}')
+    }
+
+    It 'replans pending windows when resume crosses the moving archive boundary' {
+        $script:ArchiveResumePhase = 1
+        Mock New-XdrCloudAppsActivityTimelineExportWorker {
+            if ($script:ArchiveResumePhase -eq 1) {
+                return {
+                    param($chunk, $sharedParameters, $statusMap)
+                    [void]$sharedParameters
+                    [void]$statusMap
+                    [PSCustomObject]@{
+                        Success = $false; ChunkIndex = [int]$chunk.Index; EventCount = 0L; ExpectedEventCount = 0L
+                        CountIsLowerBound = $false; CountDelta = 0L; PageCount = 0; RetryCount = 0; RewindCount = 0
+                        FileBytes = 0L; FileSha256 = $null; MissingTimestampCount = 0L; BoundaryTimestampCount = 0L
+                        DuplicateRepresentationCount = 0L; ElapsedSeconds = 0.01
+                        Error = 'simulated interruption'; FailureClass = 'PermanentHttp'
+                    }
+                }
+            }
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                [void]$statusMap
+                $filePath = Join-Path $sharedParameters.PartsPath ([string]$chunk.FileName)
+                [System.IO.File]::WriteAllText($filePath, "{`"archived`":$(([bool]$chunk.Archived).ToString().ToLowerInvariant())}`n", [System.Text.UTF8Encoding]::new($false))
+                [PSCustomObject]@{
+                    Success = $true; ChunkIndex = [int]$chunk.Index; EventCount = 1L; ExpectedEventCount = 1L
+                    CountIsLowerBound = $false; CountDelta = 0L; PageCount = 1; RetryCount = 0; RewindCount = 0
+                    FileBytes = (Get-Item $filePath).Length; FileSha256 = (Get-FileHash $filePath).Hash.ToLowerInvariant()
+                    MissingTimestampCount = 0L; BoundaryTimestampCount = 0L; DuplicateRepresentationCount = 0L
+                    ElapsedSeconds = 0.01; Error = $null; FailureClass = $null
+                }
+            }
+        } -ModuleName XDRInternals
+
+        $boundary = [datetime]::UtcNow.AddDays(-30)
+        $from = $boundary.AddHours(-1)
+        $to = $boundary.AddHours(1)
+        $outputPath = Join-Path $TestDrive 'archive-boundary-resume.ndjson'
+        { Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $to -Path $outputPath } | Should -Throw
+
+        $manifestPath = "$outputPath.manifest.json"
+        $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -AsHashtable
+        $pending = $manifest.Chunks[0]
+        $pending.FromDateUtc = $from.ToString('o')
+        $pending.ToDateUtc = $to.ToString('o')
+        $pending.DurationTicks = ($to - $from).Ticks
+        $pending.Archived = $false
+        $pending.Status = 'Pending'
+        $manifest.Chunks = @($pending)
+        $manifest.ArchiveBoundaryUtc = $boundary.AddDays(-1).ToString('o')
+        [System.IO.File]::WriteAllText($manifestPath, ($manifest | ConvertTo-Json -Depth 30), [System.Text.UTF8Encoding]::new($false))
+
+        $script:ArchiveResumePhase = 2
+        $result = Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $to -Path $outputPath
+        $resumedManifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+
+        $result.TotalChunks | Should -Be 2
+        $result.ArchivedChunks | Should -Be 1
+        @($resumedManifest.Chunks | Where-Object Archived).Count | Should -Be 1
+        @($resumedManifest.Chunks | Where-Object { -not $_.Archived }).Count | Should -Be 1
+        @(Get-Content -LiteralPath $outputPath) | Should -Be @('{"archived":false}', '{"archived":true}')
+    }
+
+    It 'preserves an existing final file when a forced replacement fails' {
+        Mock New-XdrCloudAppsActivityTimelineExportWorker {
+            return {
+                param($chunk, $sharedParameters, $statusMap)
+                [void]$sharedParameters
+                [void]$statusMap
+                [PSCustomObject]@{
+                    Success = $false; ChunkIndex = [int]$chunk.Index; EventCount = 0L; ExpectedEventCount = 0L
+                    CountIsLowerBound = $false; PageCount = 0; RetryCount = 0; RewindCount = 0
+                    FileBytes = 0L; FileSha256 = $null; MissingTimestampCount = 0L; BoundaryTimestampCount = 0L
+                    ElapsedSeconds = 0.01; Error = 'simulated failure'; FailureClass = 'PermanentHttp'
+                }
+            }
+        } -ModuleName XDRInternals
+        $from = [datetime]'2026-01-01T00:00:00Z'
+        $outputPath = Join-Path $TestDrive 'existing.ndjson'
+        Set-Content -LiteralPath $outputPath -Value 'original' -NoNewline
+
+        { Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $from.AddHours(1) -Path $outputPath -Force } | Should -Throw
+
+        Get-Content -LiteralPath $outputPath -Raw | Should -Be 'original'
+    }
+
+    It 'recovers a publishing manifest from a validated partial output' {
+        $from = [datetime]'2026-01-01T00:00:00Z'
+        $outputPath = Join-Path $TestDrive 'publishing.ndjson'
+        $null = Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $from.AddHours(1) -Path $outputPath
+        $manifestPath = "$outputPath.manifest.json"
+        $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -AsHashtable
+        $manifest.State = 'Publishing'
+        $manifest.Summary.PartsRetained = $true
+        [System.IO.File]::WriteAllText($manifestPath, ($manifest | ConvertTo-Json -Depth 30), [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::Move($outputPath, "$outputPath.partial")
+
+        $result = Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $from.AddHours(1) -Path $outputPath
+
+        $result.TotalEvents | Should -Be 1
+        (Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json).State | Should -Be 'Complete'
+        (Get-FileHash -LiteralPath $outputPath).Hash.ToLowerInvariant() | Should -Be $result.FileSha256
+    }
+
+    It 'refuses a completed final file whose hash no longer matches its manifest' {
+        $from = [datetime]'2026-01-01T00:00:00Z'
+        $outputPath = Join-Path $TestDrive 'invalid-final.ndjson'
+        $null = Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $from.AddHours(1) -Path $outputPath
+        [System.IO.File]::WriteAllText($outputPath, "changed`n", [System.Text.UTF8Encoding]::new($false))
+
+        { Export-XdrCloudAppsActivityTimeline -FromDate $from -ToDate $from.AddHours(1) -Path $outputPath } |
+            Should -Throw -ExpectedMessage '*failed validation*'
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Export-XdrCloudAppsActivityTimeline` for high-fidelity, resumable NDJSON export.
- Use separate recent and archived API strategies while preserving one bounded-memory export workflow.
- Reuse the proven pagination worker for bounded `Get-XdrCloudAppsActivityTimeline` requests.
- Add focused reliability tests, validation evidence, and follow-up plans for the device and identity exporters.

## Why

The Cloud Apps timeline APIs have different recent and archived behaviors. The prior bounded retrieval path used independent offset pagination, which could skip activity when the service returned short pages with more data, changed ordering, or concentrated many records at the same timestamp.

The exporter now uses timestamp keyset pagination, a creation-time fallback for dense recent timestamps, and stable-ID convergence for dense archived timestamps. It fails closed when a boundary cannot be paged safely instead of silently publishing an incomplete export.

## User impact

Large timeline exports can now:

- stream to NDJSON with bounded worker memory;
- resume from validated part files after interruption;
- cross the moving recent/archive boundary safely;
- validate ordering, range, part hashes, and the final SHA-256;
- preserve an existing destination during a failed forced replacement;
- distinguish authentication failures from retryable throttling, transport, and server failures.

Bounded `Get-XdrCloudAppsActivityTimeline` requests use the same pagination correctness rules without duplicating the export coordinator.

## Validation

- Focused Cloud Apps suites: **60 passed**
- Full repository harness: **19,992 passed, 0 failed, 3 expected skips**
- Recent 24-hour live export: 3,942 rows; zero missing timestamps, out-of-range rows, ordering reversals, duplicate payloads, or hash mismatch
- Live interruption/resume: resumed 18 validated parts and completed 11,485 rows with a matching final hash
- Archived live export: 212 rows with exact count parity and matching hash
- Prior 60-day bulk exercise: approximately 205,000 rows and 1 GiB across both API routes

Sanitized details and remaining opportunistic probes are recorded in `docs/cloud-apps-timeline-export-validation.md`. No activity payloads, tenant identifiers, cookies, or tokens are retained in the repository.
